### PR TITLE
don't bomb out on non-regular files

### DIFF
--- a/codespell.py
+++ b/codespell.py
@@ -509,11 +509,14 @@ def main(*args):
                         i += 1
 
                 for file in files:
-                    if os.path.islink(file):
+                    fname = os.path.join(root, file)
+                    if not os.path.isfile(fname):
+                        continue
+                    if not os.path.getsize(fname):
                         continue
                     if glob_match.match(file):
                         continue
-                    parse_file(os.path.join(root, file), colors, summary)
+                    parse_file(fname, colors, summary)
 
             continue
 


### PR DESCRIPTION
I have unix sockets sitting in my source dir:

```
$ ls -al /home/vagrant/pdns/pdns/pdns.controlsocket
srwxr-xr-x 1 root root 0 Jul 23 14:58 /home/vagrant/pdns/pdns/pdns.controlsocket
```

This makes codespell abort:

```
$ ./codespell.py -s ~/pdns
[...]
Traceback (most recent call last):
  File "./codespell.py", line 527, in <module>
    sys.exit(main(*sys.argv))
  File "./codespell.py", line 516, in main
    parse_file(os.path.join(root, file), colors, summary)
  File "./codespell.py", line 378, in parse_file
    if not istextfile(filename):
  File "./codespell.py", line 298, in istextfile
    with open(filename, mode='rb') as f:
IOError: [Errno 6] No such device or address: '/home/vagrant/pdns/pdns/pdns.controlsocket'
```

This pull requests simply skips non-files. Feel free to comment on style, I'm happy to edit. I had def isfile(..): before but I realised it would just say 'return os.path.isfile(..)'
