### PR TITLE
Disable "universal newlines" to avoid unwanted changes

### DIFF
--- a/codespell.py
+++ b/codespell.py
@@ -137,7 +137,7 @@ class FileOpener:
         encoding = self.encdetector.result['encoding']
 
         try:
-            f = open(filename, encoding=encoding)
+            f = open(filename, 'r', encoding=encoding, newline='')
             lines = f.readlines()
         except UnicodeDecodeError:
             print('ERROR: Could not detect encoding: %s' % filename,
@@ -159,7 +159,7 @@ class FileOpener:
 
         while True:
             try:
-                f = open(filename, 'r', encoding=encodings[curr])
+                f = open(filename, 'r', encoding=encodings[curr], newline='')
                 lines = f.readlines()
                 break
             except UnicodeDecodeError:


### PR DESCRIPTION
Python 3 is using "universal newlines" by default when reading text files, which means that foreign line terminators are silently discarded and are never seen by the program; to disable this behavior, newline='' (empty string) must be added to open(), see http://docs.python.org/3/library/functions.html#open

Test cases:

```
python -c "print('teh')," >test
python -c "print('teh\r')," >test-cr
python -c "print('teh\n')," >test-lf
python -c "print('teh\r\n')," >test-crlf
python -c "print('teh\n\r')," >test-lfcr
for f in test*; do echo === $f ===; hexdump -C $f; ~/Programmazione/codespell/codespell.py -w $f; hexdump -C $f; done
```

Output when running on Linux before this patch (note how 0d is changed to 0a except in test-crlf where it disappears):

```
=== test ===
00000000  74 65 68 0a                                       |teh.|
00000004
FIXED: test
00000000  74 68 65 0a                                       |the.|
00000004
=== test-cr ===
00000000  74 65 68 0d                                       |teh.|
00000004
FIXED: test-cr
00000000  74 68 65 0a                                       |the.|
00000004
=== test-crlf ===
00000000  74 65 68 0d 0a                                    |teh..|
00000005
FIXED: test-crlf
00000000  74 68 65 0a                                       |the.|
00000004
=== test-lf ===
00000000  74 65 68 0a                                       |teh.|
00000004
FIXED: test-lf
00000000  74 68 65 0a                                       |the.|
00000004
=== test-lfcr ===
00000000  74 65 68 0a 0d                                    |teh..|
00000005
FIXED: test-lfcr
00000000  74 68 65 0a 0a                                    |the..|
00000005
```

Output when running on Linux after this patch (0d is preserved):

```
=== test ===
00000000  74 65 68 0a                                       |teh.|
00000004
FIXED: test
00000000  74 68 65 0a                                       |the.|
00000004
=== test-cr ===
00000000  74 65 68 0d                                       |teh.|
00000004
FIXED: test-cr
00000000  74 68 65 0d                                       |the.|
00000004
=== test-crlf ===
00000000  74 65 68 0d 0a                                    |teh..|
00000005
FIXED: test-crlf
00000000  74 68 65 0d 0a                                    |the..|
00000005
=== test-lf ===
00000000  74 65 68 0a                                       |teh.|
00000004
FIXED: test-lf
00000000  74 68 65 0a                                       |the.|
00000004
=== test-lfcr ===
00000000  74 65 68 0a 0d                                    |teh..|
00000005
FIXED: test-lfcr
00000000  74 68 65 0a 0d                                    |the..|
00000005
```
