### PR TITLE
C escapes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SORT_ARGS := -f
 
-PHONY := all check check-dictionary sort-dictionary clean
+PHONY := all check check-dictionary sort-dictionary test clean
 
 all: check-dictionary codespell.1
 
@@ -19,6 +19,9 @@ sort-dictionary:
 
 pypi:
 	python setup.py sdist register upload
+
+test:
+	PYTHONPATH=`pwd` PATH=`pwd`/bin:$$PATH nosetests --with-coverage --cover-erase
 
 clean:
 	rm -rf codespell.1

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -40,6 +40,7 @@ file_opener = None
 quiet_level = 0
 encodings = ['utf-8', 'iso-8859-1']
 word_regex = re.compile(r"[\w\-']+")
+c_escape_regex = re.compile(r'\\\w')
 # Users might want to link this file into /usr/local/bin, so we resolve the
 # symbolic link path to the real path if necessary.
 default_dictionary = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -281,6 +282,12 @@ def parse_options(args):
                       action='store_true', default=False,
                       help='Check file names as well.')
 
+    parser.add_option('--c-escapes',
+                      action='store_true', default=False,
+                      help='Treats files as if they contain C-style character '
+                           'escapes. So for example "\\nHello" is parsed as '
+                           '"hello" instead of "nhallo".')
+
     (o, args) = parser.parse_args(list(args))
 
     if not args:
@@ -472,6 +479,9 @@ def parse_file(filename, colors, summary):
 
         fixed_words = set()
         asked_for = set()
+
+        if options.c_escapes:
+            line = c_escape_regex.sub(' ', line)
 
         for word in word_regex.findall(line):
             lword = word.lower()

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -256,6 +256,15 @@ def test_check_filename():
         assert_equal(cs.main('-f', d), 1)
 
 
+def test_c_escapes():
+    """Test c-esacpes option"""
+    with TemporaryDirectory() as d:
+        with open(op.join(d, 'test.txt'), 'w') as f:
+            f.write('\\nabandonned')
+        assert_equal(cs.main(d), 0)
+        assert_equal(cs.main('--c-escapes', d), 1)
+
+
 class TemporaryDirectory(object):
     """Backport for 2.7"""
 


### PR DESCRIPTION
A new command line option `--c-esacpes` is implemented which treats files as if they contain C-style character escapes. So for example "\nHello" is parsed as "hello" instead of "nhello".

What do you think?