### PR TITLE
Disable 'BINARY file' warning by default

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -260,7 +260,7 @@ def parse_options(args):
                            'available; 3 applies both 1 and 2')
 
     parser.add_option('-q', '--quiet-level',
-                      action='store', type='int', default=0,
+                      action='store', type='int', default=2,
                       help='Bitmask that allows codespell to run quietly. '
                            '0: the default, in which all messages are '
                            'printed. 1: disable warnings about wrong '

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -248,7 +248,7 @@ def test_encoding():
         with open(f.name, 'wb') as f:
             f.write(b'\x00\x00naiive\x00\x00')
         with CaptureStdout() as sio:
-            assert_equal(cs.main(f.name), 0)
+            assert_equal(cs.main('-q', '0', f.name), 0)
         assert_true('WARNING: Binary file' in sio[1])
         with CaptureStdout() as sio:
             assert_equal(cs.main('-q', '2', f.name), 0)


### PR DESCRIPTION
Currently codespell prints warning if it finds a binary file in the
tree. It is annoying as many projects contain .git/.svn/images/object/etc files.
Disable the warning by default and let users enable it if needed.