### PR TITLE
Remove "tim" from dictionary.txt

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11440,7 +11440,6 @@ tigthens->tightens
 tigthly->tightly
 tihkn->think
 tihs->this
-tim->time
 timeing->timing
 timestan->timespan
 timestemp->timestamp


### PR DESCRIPTION
"Tim" is a valid first name.
This commit fixes #535.