### PR TITLE
FIX: Update Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,13 @@ matrix:
         - os: linux
           python: 2.7
         - os: linux
-          python: 3.3
-        - os: linux
           python: 3.4
         - os: linux
           python: 3.5
         - os: linux
           python: 3.6
-        # OSX commented out for now because it's slow and a bit buggy as of
-        # 2017/11/15
-        # - os: osx
-        #   python: 2.7
-        # - os: osx
-        #   python: 3.6
+        - os: osx
+          python: 3.6
 
 before_install:
     - source tools/travis_tools.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
           python: 3.5
         - os: linux
           python: 3.6
-        - os: osx
-          python: 3.6
 
 before_install:
     - source tools/travis_tools.sh


### PR DESCRIPTION
The 3.3 archive is gone, I assume that means Travis can't use it. We probably don't need it anyway, so I'm removing it and adding an OSX one for completeness (it has been more stable recently).