### PR TITLE
ans is a common abbreviation for answer

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -757,7 +757,6 @@ anormaly->abnormally
 anounced->announced
 anouncement->announcement
 anroid->android
-ans->and
 ansalisation->nasalisation
 ansalization->nasalization
 ansestors->ancestors


### PR DESCRIPTION
Hello!

I'm trying to use codespell to create unit tests for [scapy](https://github.com/secdev/scapy). We handle packets and networking stuff, and we handle answers of packets.

We use `ans` a LOT, as an abbreviation for `answer`.

I have two options:
- create a custom dictionary, that I will have to update myself lots of time, and that will take place in our repo
- kindly suggest an update 😄 

Hope this could be merged