### PR TITLE
Linux Kernel typos: 1st and 2nd block

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12656,6 +12656,7 @@ vulnerablility->vulnerability
 vyer->very
 vyre->very
 waht->what
+wakup->wakeup
 wan't->want, wasn't,
 wan->want
 wan;t->want, wasn't,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10874,6 +10874,7 @@ spaw->spawn
 spawed->spawned
 spawing->spawning
 spaws->spawns
+spcial->special
 spcifies->specifies
 speach->speech
 spearator->separator

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10716,6 +10716,7 @@ sincerley->sincerely
 sincs->sincs, syncs, sinks, since,
 singal->signal
 singal->signal, single,
+singals->signals
 singe->singe, single,
 singed->signed, singled, singed,
 singlton->singleton

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8036,7 +8036,7 @@ occurrances->occurrences
 occurrs->occurs
 oclock->o'clock
 ocntext->context
-octet->octect
+octect->octet
 octohedra->octahedra
 octohedral->octahedral
 octohedron->octahedron

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12858,6 +12858,7 @@ wresters->wrestlers
 wriet->write
 writeing->writing
 writen->written
+writet->writes
 writewr->writer
 writingm->writing
 writting->writing

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -275,7 +275,6 @@ activitis->activities
 activly->actively
 activties->activities
 activw->active
-actuall->actual
 actuall->actually, actual,
 actualy->actually
 actuell->actual

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12601,6 +12601,7 @@ villify->vilify
 villin->villi, villain, villein,
 vincinity->vicinity
 violentce->violence
+virtaul->virtual
 virtualy->virtually
 virtuell->virtual
 virture->virtue

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2795,8 +2795,7 @@ contan->contain
 contaned->contained
 contaning->containing
 contans->contains
-contant->constant, content,
-contant->contact
+contant->constant, content, contact
 contants->constants, contents,
 contast->contrast, contest,
 contatenated->concatenated

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11857,6 +11857,7 @@ torpeados->torpedoes
 torpedos->torpedoes
 totation->rotation
 tothe->to the
+totol->total
 touble->trouble
 toubles->troubles
 toubling->troubling

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12730,6 +12730,7 @@ whereever->wherever
 wherether->whether
 whery->where
 whet->when
+whetehr->whether
 wheter->whether
 whethe->whether
 whethter->whether

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9427,7 +9427,6 @@ queueud->queued
 queus->queues
 quicklyu->quickly
 quinessential->quintessential
-quite->quiet
 quitely->quite, quietly,
 quiting->quitting
 quitt->quit

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12369,6 +12369,7 @@ unusal->unusual
 unusally->unusually
 unuseable->unusable
 unuseful->useless
+unusre->unsure
 unusuable->unusable
 unvailable->unavailable
 unversionned->unversioned

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10706,7 +10706,6 @@ sinature->signature
 sinc->sinc, synch, sync, sink, since,
 sincerley->sincerely
 sincs->sincs, syncs, sinks, since,
-singal->signal
 singal->signal, single,
 singals->signals
 singe->singe, single,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11033,6 +11033,7 @@ staus->status
 stcokbrush->stockbrush
 steams->streams
 stength->strength
+steram->stream
 steriods->steroids
 sterotypes->stereotypes
 stil->still

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11386,6 +11386,7 @@ suspention->suspension
 suspicios->suspicious
 suspicous->suspicious
 suspicously->suspiciously
+sustem->system
 sustitution->substitution
 sustitutions->substitutions
 sutdown->shutdown

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2089,13 +2089,10 @@ chnge->change
 choise->choice
 choises->choices
 chooose->choose
-choosed->chose, chosen,
 choosed->chosen
-choosen->chosen
 chopipng->chopping
 chose->choose
 chosed->chose
-chosen->chose
 choser->chooser
 chosing->choosing
 chould->should, could,
@@ -8255,7 +8252,7 @@ orignal->original
 orignally->originally
 orignially->originally
 origninal->original
-orphan->orhpan
+orhpan->orphan
 orthagonal->orthogonal
 orthagonalize->orthogonalize
 osbscure->obscure

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10685,6 +10685,7 @@ signularity->singularity
 silentely->silently
 silenty->silently
 sill->still
+simiar->similar
 similarily->similarly
 similary->similarly
 similat->similar

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -4309,7 +4309,6 @@ egde->edge
 egdes->edges
 ege->edge
 ehough->enough
-eigth->eight
 eigth->eighth, eight,
 eihter->either
 einstance->instance

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10684,6 +10684,7 @@ signular->singular
 signularity->singularity
 silentely->silently
 silenty->silently
+sill->still
 similarily->similarly
 similary->similarly
 similat->similar

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10755,6 +10755,7 @@ slect->select
 slected->selected
 slecting->selecting
 slection->selection
+slient->silent
 slighly->slightly
 sligth->slight
 sligthly->slightly

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11381,6 +11381,7 @@ suscribed->subscribed
 suscribes->subscribes
 suseptable->susceptible
 suseptible->susceptible
+suspedn->suspend
 suspention->suspension
 suspicios->suspicious
 suspicous->suspicious

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3062,7 +3062,6 @@ coumpound->compound
 coumpounds->compounds
 councellor->councillor, counselor, councilor,
 councellors->councillors, counselors, councilors,
-cound->could
 cound->could, count,
 counding->counting
 coundition->condition

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12790,6 +12790,7 @@ wirh->with
 wirte->write
 wirtes->writes
 wirting->writing
+witdh->width
 witha->with a, with,
 withdrawl->withdrawal, withdraw,
 withe->with

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10651,6 +10651,7 @@ siezed->seized, sized,
 siezing->seizing, sizing,
 siezure->seizure
 siezures->seizures
+sift->shift
 sigen->sign
 sightly->slightly
 siginificant->significant

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12243,6 +12243,7 @@ unkowns->unknowns
 unles->unless
 unlikey->unlikely
 unlimitied->unlimited
+unline->unlike
 unmanouverable->unmaneuverable, unmanoeuvrable,
 unmistakeably->unmistakably
 unncessary->unnecessary

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11610,6 +11610,7 @@ temporarly->temporarily, temporary,
 tempory->temporary
 temprary->temporary, temporarily,
 temproary->temporary
+temr->term
 tenacle->tentacle
 tenacles->tentacles
 tenative->tentative

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11309,6 +11309,7 @@ supplamented->supplemented
 suppliementing->supplementing
 suppoed->supposed
 suppoert->support
+suppor->support
 suppored->supported
 supporession->suppression
 supportd->supported

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12735,6 +12735,7 @@ wheter->whether
 whethe->whether
 whethter->whether
 whic->which
+whicg->which
 which;s->which's
 whichs->which's
 whicht->which

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3408,7 +3408,6 @@ degnerates->degenerates
 degrate->degrade
 degreee->degree
 degreees->degrees
-degrees->degree
 deimiter->delimiter
 deined->denied, defined,
 deivce->device

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11532,6 +11532,7 @@ tagnets->tangents
 tahn->than
 taht->that
 taks->task
+takslet->tasklet
 talekd->talked
 tangeant->tangent
 tangeantial->tangential

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2089,7 +2089,7 @@ chnge->change
 choise->choice
 choises->choices
 chooose->choose
-choosed->chosen
+choosed->chose, chosen,
 chopipng->chopping
 chosed->chose
 choser->chooser

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12020,6 +12020,7 @@ truely->truly
 trully->truly
 trun->turn
 truncat->truncate
+truned->turned
 trustworthyness->trustworthiness
 tryed->tried
 tryes->tries

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11727,6 +11727,7 @@ thna->than
 thne->then
 thnig->thing
 thnigs->things
+thorugh->through
 thos->those, this,
 thoses->those
 thoughout->throughout

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11729,7 +11729,6 @@ thorugh->through
 thos->those, this,
 thoses->those
 thoughout->throughout
-thought->thougth
 thow->throw, tow,
 thown->thrown, town,
 thrad->thread

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10161,7 +10161,6 @@ resuling->resulting
 resulsets->resultsets
 resultion->resolution
 resultions->resolutions
-results->result
 resultung->resulting
 resulution->resolution
 resumt->resume

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11531,6 +11531,7 @@ tagnetial->tangential
 tagnets->tangents
 tahn->than
 taht->that
+taks->task
 talekd->talked
 tangeant->tangent
 tangeantial->tangential

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12030,6 +12030,7 @@ tthe->the
 tuhmbnail->thumbnail
 tupple->tuple
 tupples->tuples
+ture->true
 turly->truly
 turnk->turnkey, trunk,
 Tuscon->Tucson

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10640,6 +10640,7 @@ shpapes->shapes
 shreak->shriek
 shriks->shrinks
 shrinked->shrunk
+shure->sure
 shutdownm->shutdown
 shwo->show
 sicne->since

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2997,7 +2997,6 @@ correnspond->correspond
 corrensponded->corresponded
 corrensponding->corresponding
 corrensponds->corresponds
-corrent->correct
 corrent->correct, current,
 correponding->corresponding
 correponds->corresponds

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10714,6 +10714,7 @@ sinature->signature
 sinc->sinc, synch, sync, sink, since,
 sincerley->sincerely
 sincs->sincs, syncs, sinks, since,
+singal->signal
 singal->signal, single,
 singe->singe, single,
 singed->signed, singled, singed,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12461,6 +12461,7 @@ vaguaries->vagaries
 vaiable->variable
 vaiables->variables
 vaiants->variants
+vaid->valid
 vaieties->varieties
 vaild->valid
 vailidty->validity

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12898,6 +12898,7 @@ Yementite->Yemenite, Yemeni,
 yera->year
 yeras->years
 yersa->years
+yhe->the
 yieldin->yielding
 ymbols->symbols
 yotube->youtube

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11719,6 +11719,7 @@ thimngs->things
 thinn->thin
 this this->this, this is, is this,
 thise->these
+thist->this
 thiunk->think
 thjese->these
 thn->then

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12416,6 +12416,7 @@ usally->usually
 uscaled->unscaled
 useable->usable
 useage->usage
+usees->uses
 usefule->useful
 usefull->useful
 usefullness->usefulness

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8058,7 +8058,6 @@ ocurrance->occurrence
 ocurred->occurred
 ocurrence->occurrence
 ocurrences->occurrences
-oder->order
 oder->order, odor,
 oen->one
 of of->of

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -6978,7 +6978,6 @@ lating->latin
 latitide->latitude
 latitute->latitude
 latops->laptops
-latter->later
 lattitude->latitude
 lauch->launch
 lauched->launched

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11543,6 +11543,7 @@ tanget->tangent
 tangetial->tangential
 tangetially->tangentially
 tangets->tangents
+tanks->thanks
 tansfomed->transformed
 targer->target
 targetted->targeted

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11731,6 +11731,7 @@ thorugh->through
 thos->those, this,
 thoses->those
 thoughout->throughout
+thought->thougth
 thow->throw, tow,
 thown->thrown, town,
 thrad->thread

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10787,6 +10787,7 @@ snyc->sync
 socail->social
 socalism->socialism
 socities->societies
+socked->socket
 soecialize->specialized
 soem->some
 softwares->software

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9323,7 +9323,6 @@ provate->provide
 provded->provided
 provder->provider
 provdided->provided
-proved->proven
 provicial->provincial
 providfers->providers
 providse->provide

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10840,6 +10840,7 @@ sortnr->sorter
 soruce->source
 soruces->sources
 sotred->sorted
+sotring->storing
 sotry->story
 sotyr->satyr, story,
 souce->source

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11807,6 +11807,7 @@ timmestamp->timestamp
 timming->timing
 timne->time
 timout->timeout
+timtout->timeout
 tiome->time, tome,
 tipe->type, tip,
 tipically->typically

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11034,6 +11034,7 @@ stcokbrush->stockbrush
 steams->streams
 stength->strength
 steram->stream
+sterio->stereo
 steriods->steroids
 sterotypes->stereotypes
 stil->still

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10487,6 +10487,7 @@ sempahore->semaphore
 sempahores->semaphores
 senario->scenario
 senarios->scenarios
+sence->sense
 sence->sense, since,
 senquence->sequence
 sensistive->sensitive

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2091,7 +2091,6 @@ choises->choices
 chooose->choose
 choosed->chosen
 chopipng->chopping
-chose->choose
 chosed->chose
 choser->chooser
 chosing->choosing

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12447,6 +12447,7 @@ ususally->usually
 utilis->utilise
 utilites->utilities
 utiliz->utilize
+utiliza->utilize
 utillities->utilities
 utilties->utilities
 utiltity->utility

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12382,6 +12382,7 @@ unwraped->unwrapped
 unwrritten->unwritten
 unxpected->unexpected
 unziped->unzipped
+upadted->updated
 upate->update
 upated->updated
 upates->updates

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10660,6 +10660,7 @@ sigit->digit
 sigle->single
 sigleton->singleton
 signales->signals
+signall->signal
 signatue->signature
 signatur->signature
 signficant->significant

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12018,6 +12018,7 @@ trucating->truncating
 truelly->truly
 truely->truly
 trully->truly
+trun->turn
 truncat->truncate
 trustworthyness->trustworthiness
 tryed->tried

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10739,6 +10739,7 @@ Sixtin->Sistine, Sixteen,
 Skagerak->Skagerrak
 skalar->scalar
 skateing->skating
+skeep->skip
 skelton->skeleton
 skept->skipped
 skipd->skipped

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10479,7 +10479,6 @@ sempahore->semaphore
 sempahores->semaphores
 senario->scenario
 senarios->scenarios
-sence->sense
 sence->sense, since,
 senquence->sequence
 sensistive->sensitive

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12868,6 +12868,7 @@ wroked->worked
 wroking->working
 wroks->works
 wronf->wrong
+wrtie->write
 wth->with
 wtih->with
 wuold->would

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11139,6 +11139,7 @@ studing->studying
 stuggling->struggling
 sturcture->structure
 sturctures->structures
+stutus->status
 styhe->style
 subcatagories->subcategories
 subcatagory->subcategory

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11414,6 +11414,7 @@ swown->shown
 swtich->switch
 swtichs->switches
 syas->says
+syatem->sypport
 sychronisly->synchronously
 sychronmode->synchronmode
 sycronise->synchronise

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3799,7 +3799,6 @@ didnt't->didn't
 didnt->didn't
 didnt;->didn't
 diea->idea, die,
-dieing->dying
 dieing->dying, dyeing,
 diemsion->dimension
 dieties->deities


### PR DESCRIPTION
Well, the game is...
Extracted from the kernel all "typo" fixes commits.
Playing with Python to extract differences.
Check by hand the result.

It's a looong game, let's see if there's something good...