### PR TITLE
Removing backed->backend

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1481,7 +1481,6 @@ bacause->because
 baceause->because
 bacic->basic
 backbround->background
-backed->backend
 backgorund->background
 backgroud->background
 backrounds->backgrounds


### PR DESCRIPTION
`backed` is a valid word