### PR TITLE
Add -L/--ignore-words-list to whitelist words directly

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -228,6 +228,12 @@ def parse_options(args):
                            'by codespell. File must contain 1 word per line. '
                            'Words are case sensitive based on how they are '
                            'written in codespell_lib/data/dictionary.txt')
+    parser.add_option('-L', '--ignore-words-list',
+                      action='append', metavar='WORDS',
+                      help='Comma separated list of words to be ignored '
+                           'by codespell. Words are case sensitive based on '
+                           'how they are written in '
+                           'codespell_lib/data/dictionary.txt')
     parser.add_option('-r', '--regex',
                       action='store', type='string',
                       help='Regular expression which is used to find words. '
@@ -594,6 +600,11 @@ def main(*args):
             parser.print_help()
             return 1
         build_ignore_words(ignore_words_file)
+
+    ignore_words_list = options.ignore_words_list or []
+    for comma_separated_words in ignore_words_list:
+        for word in comma_separated_words.split(','):
+            ignore_words.add(word.strip())
 
     dictionaries = options.dictionary or [default_dictionary]
     for dictionary in dictionaries:

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -198,6 +198,14 @@ def test_ignore_dictionary(reload_codespell_lib):
         assert cs.main('-I', f.name, d) == 1
 
 
+def test_ignore_word_list(reload_codespell_lib):
+    """Test ignore word list functionality"""
+    with TemporaryDirectory() as d:
+        with open(op.join(d, 'bad.txt'), 'w') as f:
+            f.write('abandonned\nabondon\nabilty\n')
+        assert cs.main('-Labandonned,someword', '-Labilty', d) == 1
+
+
 def test_custom_regex(reload_codespell_lib):
     """Test custom word regex"""
     with TemporaryDirectory() as d:


### PR DESCRIPTION
This PR adds a new command line option `-L WORDS` / `--ignore-words-list WORDS` (where `WORDS` is a comma-separated list of words) to whitelist words directly from the command line without the need for a separate "ignore file".

Other than proposed in #185, I've chosen to use a new command line option (`-L`) instead of extending the existing command line option `-I` in order to avoid ambiguities (is the parameter a filename or a word to whitelist?).