### PR TITLE
Avoid 'invalid escape sequence \s' warning in Python 3.6

### DIFF
--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -20,9 +20,9 @@ def test_dictionary_formatting():
             rep = rep.rstrip('\n')
             assert len(rep) > 0, ('error %s: correction %r must be non-empty'
                                   % (err, rep))
-            assert not re.match('^\s.*', rep), ('error %s: correction %r '
-                                                'cannot start with whitespace'
-                                                % (err, rep))
+            assert not re.match(r'^\s.*', rep), ('error %s: correction %r '
+                                                 'cannot start with whitespace'
+                                                 % (err, rep))
             if rep.count(','):
                 if not rep.endswith(','):
                     assert 'disabled' in rep.split(',')[-1], \


### PR DESCRIPTION
Pytest on Python 3.6 reports a warning (`DeprecationWarning: invalid escape sequence \s`) for the expression `re.match('^\s.*', rep)` in `test_dictionary.py`, as `\s` is not a valid escape sequence any more.

This PR changes the expression to `re.match(r'^\s.*', rep)`, which avoids the warning. Note that an `r`-prefixed string literal is used.