### PR TITLE
Add checks for 'bad commas' in corrections.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -6533,7 +6533,7 @@ identifer->identifier
 identifers->identifiers
 identifictaion->identification
 identifyable->identifiable
-identiy->identify,identity,
+identiy->identify, identity,
 ideosyncratic->idiosyncratic
 idesa->ideas, ides,
 idicate->indicate

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -23,6 +23,16 @@ def test_dictionary_formatting():
             assert not re.match(r'^\s.*', rep), ('error %s: correction %r '
                                                  'cannot start with whitespace'
                                                  % (err, rep))
+            for (r, msg) in [
+                (r'^,', 'error %s: correction %r starts with a comma'),
+                (r'\s,', 'error %s: correction %r contains a whitespace '
+                         'character followed by a comma'),
+                (r',\s\s', 'error %s: correction %r contains a comma followed '
+                           'by multiple whitespace characters'),
+                (r',[^ ]', 'error %s: correction %r contains a comma *not* '
+                           'followed by a space')
+            ]:
+                assert not re.search(r, rep), (msg % (err, rep))
             if rep.count(','):
                 if not rep.endswith(','):
                     assert 'disabled' in rep.split(',')[-1], \


### PR DESCRIPTION
This PR adds checks for detecting 'bad commas' in correction:

- a correction must not start with a comma,
- a whitespace character must not be followed by a comma,
- a comma must not be followed by multiple whitespace characters,
- a comma must always be followed by a space (except the trailing comma)

The PR also fixes the comma error introduced by #700.