### PR TITLE
Check if corrections are errors themselves

### DIFF
--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -39,11 +39,17 @@ def test_dictionary_formatting():
                         ('currently corrections must end with trailing "," (if'
                          ' multiple corrections are available) or '
                          'have "disabled" in the comment')
-            err_dict[err] = rep
             reps = [r.strip() for r in rep.lower().split(',')]
             reps = [r for r in reps if len(r)]
+            err_dict[err] = reps
             unique = list()
             for r in reps:
                 if r not in unique:
                     unique.append(r)
             assert reps == unique, 'entries are not (lower-case) unique'
+    # check for corrections that are errors (but nit self replacements)
+    for err in err_dict:
+        for r in err_dict[err]:
+            assert (r not in err_dict) or (r in err_dict[r]), \
+                ('error %s: correction %s is an error itself' % (err, r))
+

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -47,7 +47,7 @@ def test_dictionary_formatting():
                 if r not in unique:
                     unique.append(r)
             assert reps == unique, 'entries are not (lower-case) unique'
-    # check for corrections that are errors (but nit self replacements)
+    # check for corrections that are errors (but not self replacements)
     for err in err_dict:
         for r in err_dict[err]:
             assert (r not in err_dict) or (r in err_dict[r]), \

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -52,4 +52,3 @@ def test_dictionary_formatting():
         for r in err_dict[err]:
             assert (r not in err_dict) or (r in err_dict[r]), \
                 ('error %s: correction %s is an error itself' % (err, r))
-


### PR DESCRIPTION
This adds a pytest based test to ensure that corrections are not errors themselves - as requested in #435 and with a similar solution as suggested by @EdwardBetts 

Fortunately, the current dictionary is clean ;)