### PR TITLE
Add context options: -A/-B/-C; Fixes #287

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -423,9 +423,9 @@ def print_context(lines, index, context_before, context_after):
     for i in range(index - context_before, index + context_after + 1):
         if 0 <= i < len(lines):
             if i == index:
-                print('> %s' % lines[i], end='')
+                print('> %s' % lines[i].rstrip())
             else:
-                print(': %s' % lines[i], end='')
+                print(': %s' % lines[i].rstrip())
 
 
 def parse_file(filename, colors, summary, misspellings, exclude_lines,
@@ -648,11 +648,11 @@ def main(*args):
         context_before = context_after = max(0, options.context)
     elif (options.before_context is not None) or \
          (options.after_context is not None):
+        context_before = context_after = 0
         if options.before_context is not None:
             context_before = max(0, options.before_context)
         if options.after_context is not None:
             context_after = max(0, options.after_context)
-        context_before = max(0, context_before)
 
     exclude_lines = set()
     if options.exclude_file:

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -640,7 +640,7 @@ def main(*args):
     context_after = -1
     if options.context is not None:
         if (options.before_context is not None) or \
-            (options.after_context is not None):
+                (options.after_context is not None):
             print('ERROR: --context/-C cannot be used together with '
                   '--context-before/-B or --context-after/-A')
             parser.print_help()

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -642,7 +642,8 @@ def main(*args):
             return 1
         context_both = max(0, options.context)
         context = (context_both, context_both)
-    elif (options.before_context is not None):
+    elif (options.before_context is not None) or \
+            (options.after_context is not None):
         context_before = 0
         context_after = 0
         if options.before_context is not None:

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -283,6 +283,12 @@ def parse_options(args):
                       action='store_true', default=False,
                       help='Check hidden files (those starting with ".") as '
                            'well.')
+    parser.add_option('-A', '--after-context', metavar='LINES',
+                      help='print LINES of trailing context', type='int')
+    parser.add_option('-B', '--before-context', metavar='LINES',
+                      help='print LINES of leading context', type='int')
+    parser.add_option('-C', '--context', metavar='LINES',
+                      help='print LINES of surrounding context', type='int')
 
     (o, args) = parser.parse_args(list(args))
 
@@ -411,8 +417,20 @@ def ask_for_word_fix(line, wrongword, misspelling, interactivity):
     return misspelling.fix, fix_case(wrongword, misspelling.data)
 
 
+def print_context(lines, index, context_before, context_after):
+    if context_before < 0:
+        return
+    for i in range(index - context_before, index + context_after + 1):
+        if 0 <= i < len(lines):
+            if i == index:
+                print('> %s' % lines[i], end='')
+            else:
+                print(': %s' % lines[i], end='')
+
+
 def parse_file(filename, colors, summary, misspellings, exclude_lines,
-               file_opener, word_regex, options):
+               file_opener, word_regex, context_before, context_after,
+               options):
     bad_count = 0
     lines = None
     changed = False
@@ -479,10 +497,13 @@ def parse_file(filename, colors, summary, misspellings, exclude_lines,
         for word in word_regex.findall(line):
             lword = word.lower()
             if lword in misspellings:
+                context_shown = False
                 fix = misspellings[lword].fix
                 fixword = fix_case(word, misspellings[lword].data)
 
                 if options.interactive and lword not in asked_for:
+                    context_shown = True
+                    print_context(lines, i, context_before, context_after)
                     fix, fixword = ask_for_word_fix(
                         lines[i], word, misspellings[lword],
                         options.interactive)
@@ -527,6 +548,8 @@ def parse_file(filename, colors, summary, misspellings, exclude_lines,
                 # our bad_count and thus return value
                 bad_count += 1
 
+                if not context_shown:
+                    print_context(lines, i, context_before, context_after)
                 if filename != '-':
                     print("%(FILENAME)s:%(LINE)s: %(WRONGWORD)s "
                           " ==> %(RIGHTWORD)s%(REASON)s"
@@ -613,6 +636,24 @@ def main(*args):
     else:
         summary = None
 
+    context_before = -1
+    context_after = -1
+    if options.context is not None:
+        if (options.before_context is not None) or \
+            (options.after_context is not None):
+            print('ERROR: --context/-C cannot be used together with '
+                  '--context-before/-B or --context-after/-A')
+            parser.print_help()
+            return 1
+        context_before = context_after = max(0, options.context)
+    elif (options.before_context is not None) or \
+         (options.after_context is not None):
+        if options.before_context is not None:
+            context_before = max(0, options.before_context)
+        if options.after_context is not None:
+            context_after = max(0, options.after_context)
+        context_before = max(0, context_before)
+
     exclude_lines = set()
     if options.exclude_file:
         build_exclude_hashes(options.exclude_file, exclude_lines)
@@ -642,7 +683,8 @@ def main(*args):
                         continue
                     bad_count += parse_file(
                         fname, colors, summary, misspellings, exclude_lines,
-                        file_opener, word_regex, options)
+                        file_opener, word_regex, context_before, context_after,
+                        options)
 
                 # skip (relative) directories
                 dirs[:] = [dir_ for dir_ in dirs if not glob_match.match(dir_)]
@@ -650,7 +692,8 @@ def main(*args):
         else:
             bad_count += parse_file(
                 filename, colors, summary, misspellings, exclude_lines,
-                file_opener, word_regex, options)
+                file_opener, word_regex, context_before, context_after,
+                options)
 
     if summary:
         print("\n-------8<-------\nSUMMARY:")

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -308,60 +308,57 @@ def test_context(tmpdir, capsys):
     with open(op.join(d, 'context.txt'), 'w') as f:
         f.write('line 1\nline 2\nline 3 abandonned\nline 4\nline 5')
 
-    try:
-        # symmetric context, fully within file
-        cs.main('-C', '1', d)
-        lines = capsys.readouterr()[0].split('\n')
-        assert len(lines) == 5
-        assert lines[0] == ': line 2'
-        assert lines[1] == '> line 3 abandonned'
-        assert lines[2] == ': line 4'
+    # symmetric context, fully within file
+    cs.main('-C', '1', d)
+    lines = capsys.readouterr()[0].split('\n')
+    assert len(lines) == 5
+    assert lines[0] == ': line 2'
+    assert lines[1] == '> line 3 abandonned'
+    assert lines[2] == ': line 4'
 
-        # requested context is bigger than the file
-        cs.main('-C', '10', d)
-        lines = capsys.readouterr()[0].split('\n')
-        assert len(lines) == 7
-        assert lines[0] == ': line 1'
-        assert lines[1] == ': line 2'
-        assert lines[2] == '> line 3 abandonned'
-        assert lines[3] == ': line 4'
-        assert lines[4] == ': line 5'
+    # requested context is bigger than the file
+    cs.main('-C', '10', d)
+    lines = capsys.readouterr()[0].split('\n')
+    assert len(lines) == 7
+    assert lines[0] == ': line 1'
+    assert lines[1] == ': line 2'
+    assert lines[2] == '> line 3 abandonned'
+    assert lines[3] == ': line 4'
+    assert lines[4] == ': line 5'
 
-        # only before context
-        cs.main('-B', '2', d)
-        lines = capsys.readouterr()[0].split('\n')
-        assert len(lines) == 5
-        assert lines[0] == ': line 1'
-        assert lines[1] == ': line 2'
-        assert lines[2] == '> line 3 abandonned'
+    # only before context
+    cs.main('-B', '2', d)
+    lines = capsys.readouterr()[0].split('\n')
+    assert len(lines) == 5
+    assert lines[0] == ': line 1'
+    assert lines[1] == ': line 2'
+    assert lines[2] == '> line 3 abandonned'
 
-        # only after context
-        cs.main('-A', '1', d)
-        lines = capsys.readouterr()[0].split('\n')
-        assert len(lines) == 4
-        assert lines[0] == '> line 3 abandonned'
-        assert lines[1] == ': line 4'
+    # only after context
+    cs.main('-A', '1', d)
+    lines = capsys.readouterr()[0].split('\n')
+    assert len(lines) == 4
+    assert lines[0] == '> line 3 abandonned'
+    assert lines[1] == ': line 4'
 
-        # asymmetric context
-        cs.main('-B', '2', '-A', '1', d)
-        lines = capsys.readouterr()[0].split('\n')
-        assert len(lines) == 6
-        assert lines[0] == ': line 1'
-        assert lines[1] == ': line 2'
-        assert lines[2] == '> line 3 abandonned'
-        assert lines[3] == ': line 4'
+    # asymmetric context
+    cs.main('-B', '2', '-A', '1', d)
+    lines = capsys.readouterr()[0].split('\n')
+    assert len(lines) == 6
+    assert lines[0] == ': line 1'
+    assert lines[1] == ': line 2'
+    assert lines[2] == '> line 3 abandonned'
+    assert lines[3] == ': line 4'
 
-        # both '-C' and '-A' on the command line
-        cs.main('-C', '2', '-A', '1', d)
-        lines = capsys.readouterr()[0].split('\n')
-        assert 'ERROR' in lines[0]
+    # both '-C' and '-A' on the command line
+    cs.main('-C', '2', '-A', '1', d)
+    lines = capsys.readouterr()[0].split('\n')
+    assert 'ERROR' in lines[0]
 
-        # both '-C' and '-B' on the command line
-        cs.main('-C', '2', '-B', '1', d)
-        lines = capsys.readouterr()[0].split('\n')
-        assert 'ERROR' in lines[0]
-    finally:
-        os.remove(f.name)
+    # both '-C' and '-B' on the command line
+    cs.main('-C', '2', '-B', '1', d)
+    lines = capsys.readouterr()[0].split('\n')
+    assert 'ERROR' in lines[0]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This PR adds the options `-A/--after-context`, `-B/--before-context`, and `-C/--context` that enable the display of context lines surrounding a detected spelling error. Using `-C LINES` results in the display of LINES many context lines before and after the erroneous line, with `-B` and `-A` the before and after context can be configured separately. The default is to not show any context at all (so there's no change in behaviour if no context options are used).