### PR TITLE
Use proper escaping in 'word_regex_def'.

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -26,7 +26,7 @@ from optparse import OptionParser
 import os
 import fnmatch
 
-word_regex_def = u"[\w\-'’`]+"
+word_regex_def = u"[\\w\\-'’`]+"
 encodings = ('utf-8', 'iso-8859-1')
 USAGE = """
 \t%prog [OPTIONS] [file1 file2 ... fileN]


### PR DESCRIPTION
This PR changes

```
word_regex_def = u"[\w\-'’`]+"
```

to the properly escaped

```
word_regex_def = u"[\\w\\-'’`]+"
```

Which makes `flake8` happy ;)