### PR TITLE
Add a --no-context option when parsing stdin

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -257,6 +257,11 @@ def parse_options(args):
                            'choose one fix when more than one is '
                            'available; 3 applies both 1 and 2')
 
+    parser.add_option('-n', '--no-context',
+                      action='store_true', default=False,
+                      help='(when reading stdin) Do not print the line '
+                           'above the correction')
+
     parser.add_option('-q', '--quiet-level',
                       action='store', type='int', default=0,
                       help='Bitmask that allows codespell to run quietly. '
@@ -532,6 +537,11 @@ def parse_file(filename, colors, summary, misspellings, exclude_lines,
                           " ==> %(RIGHTWORD)s%(REASON)s"
                           % {'FILENAME': cfilename, 'LINE': cline,
                              'WRONGWORD': cwrongword,
+                             'RIGHTWORD': crightword, 'REASON': creason})
+                elif options.no_context:
+                    print('%(LINE)s: %(WRONGWORD)s '
+                          '==> %(RIGHTWORD)s%(REASON)s'
+                          % {'LINE': cline, 'WRONGWORD': cwrongword,
                              'RIGHTWORD': crightword, 'REASON': creason})
                 else:
                     print('%(LINE)s: %(STRLINE)s\n\t%(WRONGWORD)s '


### PR DESCRIPTION
I am writing a linter plugin integrating codespell, and it helps a lot
if there is only one line per warning, with only the relevant message
(the line content is already known by the editor).