### PR TITLE
Add several spelling corrections for Microsoft

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8272,10 +8272,16 @@ mial->mail
 mices->mice
 Michagan->Michigan
 micorcode->microcode
+Micorsoft->Microsoft
 micoscopy->microscopy
+Micosoft->Microsoft
 microprocesspr->microprocessor
+Microsft->Microsoft
 microship->microchip
-microsofot->microsoft
+Microsof->Microsoft
+Microsofot->Microsoft
+Micrsft->Microsoft
+Micrsoft->Microsoft
 midified->modified
 midwifes->midwives
 migth->might


### PR DESCRIPTION
I'm seeing those quite often. Not sure if those could cause some false positives for other similar names so any feedback is very welcome.

The PR is changing the existing microsoft spelling and capitalise it based on the suggestion in https://github.com/codespell-project/codespell/pull/734#issuecomment-434089546