### PR TITLE
Add imapct->impact

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -6729,6 +6729,7 @@ imaghe->image
 imagin->imagine
 imaginery->imaginary, imagery,
 imanent->eminent, imminent,
+imapct->impact
 imapge->image
 imcoming->incoming
 imcomplete->incomplete


### PR DESCRIPTION
Common typo of "Impact":

https://github.com/search?q=%22imapct%22

Not sure if this could show false positives for something like an imap protocol variable?