### PR TITLE
Typos from VisualSharp Microsoft

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8136,6 +8136,7 @@ limitiation->limitation
 limitiations->limitations
 limitied->limited
 limitted->limited
+limted->limited
 lincese->license
 lincesed->licensed
 linceses->licenses
@@ -13974,6 +13975,7 @@ unbeleivable->unbelievable
 unbeliefable->unbelievable
 unbelivable->unbelievable
 unce->once
+uncehck->uncheck
 uncehcked->unchecked
 uncertainities->uncertainties
 uncertainity->uncertainty

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13457,9 +13457,9 @@ tetss->tests
 tetxture->texture
 texline->textline
 textfrme->textframe
-texxt->text
 texual->textual
 texually->textually
+texxt->text
 tey->they
 tghe->the
 tha->than, that, the,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1221,7 +1221,10 @@ assasins->assassins
 assassintation->assassination
 asscciated->associated
 asscoitaed->associated
+assebly->assembly
 assember->assembler
+assemby->assembly
+assemnly->assembly
 assemple->assemble
 assersion->assertion
 assertation->assertion
@@ -1557,6 +1560,7 @@ avod->avoid
 avoded->avoided
 avoding->avoiding
 avods->avoids
+avoinding->avoiding
 avtive->active
 awared->awarded
 aways->always
@@ -2054,6 +2058,7 @@ can;t->can't
 canadan->canadian
 canbe->can be
 cancelability->cancellability
+cancelaltion->cancellation
 cancelles->cancels
 cancled->canceled
 candadate->candidate
@@ -2543,6 +2548,7 @@ coeficent->coefficient
 coeficents->coefficients
 coeficient->coefficient
 coelesce->coalesce
+coersion->coercion
 coexsiting->coexisting
 cofidence->confidence
 cofiguration->configuration
@@ -3148,6 +3154,8 @@ constraing->constraining, constraint,
 constraintes->constraints
 constrait->constraint
 constraits->constraints
+constrant->constraint
+constrants->constraints
 constrast->contrast
 constrasts->contrasts
 constrcuct->construct
@@ -4070,6 +4078,7 @@ deregistartion->deregistration
 deregisted->deregistered
 deregisteres->deregisters
 deregistrated->deregistered
+deregistred->deregistered
 derevative->derivative
 derevatives->derivatives
 dergeistered->deregistered
@@ -4357,6 +4366,7 @@ dicovers->discovers
 dicovery->discovery
 dicrectory->directory
 dicretionary->discretionary
+dicsriminated->discriminated
 dictaionaries->dictionaries
 dictaionary->dictionary
 dictinary->dictionary
@@ -4409,6 +4419,8 @@ differnce->difference
 differnces->differences
 differnet->different
 differnt->different
+differntiates->differentiates
+differntly->differently
 differrence->difference
 differrent->different
 diffferent->different
@@ -4473,6 +4485,7 @@ diplaying->displaying
 diplays->displays
 diplomancy->diplomacy
 dipose->dispose, depose,
+diposed->disposed, deposed,
 diposing->disposing, deposing,
 dipthong->diphthong
 dipthongs->diphthongs
@@ -4684,6 +4697,7 @@ distrubutions->distributions
 distruction->destruction
 distructive->destructive
 distuingish->distinguish
+disuade->dissuade
 ditance->distance
 ditinguishes->distinguishes
 ditributed->distributed
@@ -4864,6 +4878,7 @@ dumplicates->duplicates
 dumplicating->duplicating
 duoblequote->doublequote
 dupicate->duplicate
+duplciate->duplicate
 dupliate->duplicate
 dupliates->duplicates
 duplicat->duplicate
@@ -6120,6 +6135,7 @@ frambuffer->framebuffer
 framebufer->framebuffer
 framei->frame
 frametyp->frametype
+frameworkk->framework
 framlayout->framelayout
 framwork->framework
 frane->frame
@@ -7401,6 +7417,7 @@ inivisible->invisible
 inizialize->initialize
 inizialized->initialized
 inizializes->initializes
+inlalid->invalid
 inlcude->include
 inlcuded->included
 inlcudes->includes
@@ -7550,6 +7567,7 @@ intelegent->intelligent
 intelegently->intelligently
 inteligence->intelligence
 inteligent->intelligent
+intelisense->intellisense
 intenational->international
 intendet->intended
 inteneded->intended
@@ -8012,6 +8030,7 @@ lavae->larvae
 layed->laid
 lazer->laser
 lazyness->laziness
+lcoation->location
 leaast->least
 leace->leave
 leack->leak
@@ -8116,7 +8135,7 @@ limite->limit
 limitiation->limitation
 limitiations->limitations
 limitied->limited
-limted->limited
+limitted->limited
 lincese->license
 lincesed->licensed
 linceses->licenses
@@ -8552,6 +8571,7 @@ micorcode->microcode
 Micorsoft->Microsoft
 micoscopy->microscopy
 Micosoft->Microsoft
+Microfost->Microsoft
 microprocesspr->microprocessor
 Microsft->Microsoft
 microship->microchip
@@ -8785,10 +8805,11 @@ moslty->mostly
 mostlky->mostly
 mosture->moisture
 motiviated->motivated
+motiviation->motivation
 motoroloa->motorola
 moudle->module
 mould->mold, mould, module,
-mounth->month
+mounth->month, mouth,
 mountian->mountain
 mountpiont->mountpoint
 mountpionts->mountpoints
@@ -9199,6 +9220,7 @@ occassioned->occasioned
 occassions->occasions
 occational->occasional
 occationally->occasionally
+occcur->occur
 occour->occur
 occoured->occurred
 occouring->occurring
@@ -9383,6 +9405,7 @@ oppsofite->opposite
 oppurtunity->opportunity
 opration->operation
 opreation->operation
+opreations->operations
 opression->oppression
 opressive->oppressive
 opten->often, open,
@@ -10812,6 +10835,7 @@ que->queue
 Queenland->Queensland
 queing->queueing
 queiried->queried
+queisce->quiesce
 queriable->queryable
 quering->querying
 querries->queries
@@ -11456,6 +11480,8 @@ repostiories->repositories
 repostiory->repository
 repport->report
 repraesentation->representation
+repreesnt->represent
+repreesnts->represents
 reprensent->represent
 reprensentation->representation
 represantative->representative
@@ -11475,7 +11501,7 @@ represnets->represents
 represnt->represent
 represntative->representative
 represnted->represented
-represnts->representative
+represnts->represents
 reprociblbe->reproducible
 reproducabely->reproducibly
 reproducable->reproducible
@@ -11572,6 +11598,7 @@ resembes->resembles
 resemblence->resemblance
 reseration->reservation
 reserverd->reserved
+reservered->reserved
 resest->reset, recessed,
 resetable->resettable
 reseted->reset
@@ -12091,6 +12118,7 @@ sentinal->sentinel
 sentinals->sentinels
 sentive->sensitive
 sentively->sensitively, sensitivity,
+sepaate->separate
 separat->separate
 separater->separator
 separatly->separately
@@ -13428,6 +13456,7 @@ tetss->tests
 tetxture->texture
 texline->textline
 textfrme->textframe
+texxt->text
 texual->textual
 texually->textually
 tey->they
@@ -13945,6 +13974,7 @@ unbeleivable->unbelievable
 unbeliefable->unbelievable
 unbelivable->unbelievable
 unce->once
+uncehcked->unchecked
 uncertainities->uncertainties
 uncertainity->uncertainty
 unchache->uncache
@@ -14758,6 +14788,7 @@ wither->wither, either, whether, weather,
 withh->with
 withih->within
 withing->within
+withinn->within
 withion->within
 witho->with
 withold->withhold
@@ -14789,6 +14820,7 @@ wont't->won't
 wont->won't, wont,
 worarounds->workarounds
 wordlwide->worldwide
+worfklow->workflow
 workaorund->workaround
 workaraound->workaround
 workarbound->workaround

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -94,7 +94,8 @@ acccess->access
 acccessed->accessed
 acccesses->accesses
 acccessible->accessible
-acccessor->accessors
+acccessor->accessor
+acccessors->accessors
 acccused->accused
 accecpted->accepted
 accees->access
@@ -8815,12 +8816,12 @@ mountian->mountain
 mountpiont->mountpoint
 mountpionts->mountpoints
 mouspointer->mousepointer
-moutn->moutn
+moutn->mount
 moutned->mounted
 moutning->mounting
 moutnpoint->mountpoint
 moutnpoints->mountpoints
-moutns->moutns
+moutns->mounts
 movebackwrd->movebackward
 moveble->movable
 movei->movie, disabled due to assembly code


### PR DESCRIPTION
(Part 1)
cf. https://github.com/Microsoft/visualfsharp/pull/2789/files

**Note 1:** 
Line represnts->representative.
_representative_ is rather far from _represnts_, right?
Put _represents_ instead.

**Note 2:**
Line moutn->moutn
Line moutns->moutns
Are not these 2 (non)-corrections wrong?