### PR TITLE
Add spelling corrections for prepent->prepend

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10807,6 +10807,7 @@ prepaired->prepared
 prepartion->preparation
 prepartions->preparations
 prepatory->preparatory
+prepent->prepend, disabled due being a programming term
 preperation->preparation
 preperations->preparations
 prepresent->represent


### PR DESCRIPTION
See e.g.

https://github.com/search?q=%22prependet%22&type=Code
https://github.com/search?q=%22prepented%22&type=Code

For https://github.com/search?q=%22prepent%22&type=Code there is e.g.:

https://www.urbandictionary.com/define.php?term=prepent

so not sure if this should be dropped?