### PR TITLE
Remove partway (valid word)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9997,7 +9997,6 @@ partitioing->partitioning
 partitiones->partitions
 partiton->partition
 partitoning->partitioning
-partway->part-way
 pary->party, parry,
 pase->pass, pace, parse,
 pased->passed


### PR DESCRIPTION
Parway is a valid word https://www.merriam-webster.com/dictionary/partway