### PR TITLE
Removing stand-alone->standalone as it's a valid spelling

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12976,8 +12976,7 @@ staically->statically
 stainlees->stainless
 staion->station
 stamement's->statement's, statements, statement,
-stand-alone->standalone
-standalown->standalone
+standalown->standalone, stand-alone
 standar->standard
 standarad->standard
 standardss->standards

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12976,7 +12976,7 @@ staically->statically
 stainlees->stainless
 staion->station
 stamement's->statement's, statements, statement,
-standalown->standalone, stand-alone
+standalown->standalone, stand-alone,
 standar->standard
 standarad->standard
 standardss->standards


### PR DESCRIPTION
https://dictionary.cambridge.org/dictionary/english/stand-alone

Also adding it as a suggestion of standalown for the same reason.

CC @Fourchaux .