### PR TITLE
Add notse->note(s)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9487,6 +9487,7 @@ notity->notify
 notmalize->normalize
 notmalized->normalized
 notning->nothing
+notse->notes, note,
 nott->not
 notwhithstanding->notwithstanding
 noveau->nouveau


### PR DESCRIPTION
See e.g. https://github.com/search?q=notse&type=Code

There seems some valid use like "NotSE" but in most cased this should be a spelling mistake.