### PR TITLE
Remove cancelled->canceled as it's valid one side of the pond

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2163,7 +2163,6 @@ canadan->canadian
 canbe->can be
 cancelability->cancellability
 cancelaltion->cancellation
-cancelled->canceled
 cancelles->cancels
 cancled->canceled
 candadate->candidate


### PR DESCRIPTION
https://www.grammarly.com/blog/canceled-vs-cancelled/