### PR TITLE
Fix Blank lines in dictionary aren't flagged by check-dictionary, cause crash #1088

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-SORT_ARGS := -f
+SORT_ARGS := -f -b
 
-PHONY := all check check-dictionary sort-dictionary clean
+DICTIONARY := codespell_lib/data/dictionary.txt
+
+PHONY := all check check-dictionary sort-dictionary trim-dictionary clean
 
 all: check-dictionary codespell.1
 
@@ -9,13 +11,20 @@ codespell.1: codespell.1.include bin/codespell
 	sed -i '/\.SS \"Usage/,+2d' codespell.1
 
 check-dictionary:
-	@if ! LC_ALL=C sort ${SORT_ARGS} -c codespell_lib/data/dictionary.txt; then \
+	@if ! LC_ALL=C sort ${SORT_ARGS} -c ${DICTIONARY}; then \
 		echo "Dictionary not sorted. Sort with 'make sort-dictionary'"; \
+		exit 1; \
+	fi
+	@if egrep -n "^\s*$$|\s$$|^\s" ${DICTIONARY}; then \
+		echo "Dictionary contains leading/trailing whitespace and/or blank lines.  Trim with 'make trim-dictionary'"; \
 		exit 1; \
 	fi
 
 sort-dictionary:
-	LC_ALL=C sort ${SORT_ARGS} -u -o codespell_lib/data/dictionary.txt codespell_lib/data/dictionary.txt
+	LC_ALL=C sort ${SORT_ARGS} -u -o ${DICTIONARY} ${DICTIONARY}
+
+trim-dictionary:
+	sed -E -i.bak -e 's/^[[:space:]]+//; s/[[:space:]]+$$//; /^$$/d' ${DICTIONARY} && rm ${DICTIONARY}.bak
 
 pypi:
 	python setup.py sdist register upload


### PR DESCRIPTION
The -b argument added to sort ignores leading whitespace, so sort and trim can be done in either order.  Without it, if sorting is done first, all lines with leading whitespace are bunched together, so after the whitespace is removed sort needs to be done a second time. 

-b sorts everything into the proper order regardless of leading whitespace, so it is still in the correct order after trimming.