### PR TITLE
Remove isused->issued, is used; too many false positives

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9623,7 +9623,6 @@ istead->instead
 istener->listeners
 ists->its, lists,
 isue->issue
-isused->issued, is used,
 iteger->integer
 iten->item
 itens->items


### PR DESCRIPTION
the `isUsed` variable/function is very common in source code. I'm getting a lot of false positives.  
Any objections to removing this ?