### PR TITLE
Remove 'errorstring' from dictionary: too many false positives

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7057,7 +7057,6 @@ errorneus->erroneous
 errornous->erroneous
 errornously->erroneously
 errorprone->error-prone
-errorstring->error string
 erros->errors
 errro->error
 errror->error


### PR DESCRIPTION
This is a common variable or function name.