### PR TITLE
Remove 'parameterset->parameter set' ; too many false positives

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13149,7 +13149,6 @@ parameteras->parameters
 parametere->parameter, parameters,
 parameterical->parametrical
 parameterizes->parametrizes
-parameterset->parameter set
 parameterts->parameters
 parametes->parameters
 parametic->parametric, paramedic,


### PR DESCRIPTION
Because of codespell's lack of differentiating camelcase functions names in conjunction with this being a common programming term - I'm proposing to delete this entry from the dictionary. 