### PR TITLE
Remove binominal->binomial from dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2590,7 +2590,6 @@ bimontly->bimonthly
 binairy->binary
 binanary->binary
 binay->binary
-binominal->binomial
 bistream->bitstream
 bitamps->bitmaps
 bitwise-orring->bitwise-oring


### PR DESCRIPTION
`binominal` is a [legit word](https://www.collinsdictionary.com/us/dictionary/english/binominal)