### PR TITLE
Remove floatation->flotation

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8760,7 +8760,6 @@ flexibilty->flexibility
 flie->file
 floading->floating, flooding,
 floading-add->floating-add
-floatation->flotation
 florescent->fluorescent
 floresent->fluorescent
 floride->fluoride


### PR DESCRIPTION
`flotation` is a less commonly used spelling for `floatation` per
https://www.merriam-webster.com/dictionary/flotation