### PR TITLE
'analyse' is a valid word in British English

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1239,7 +1239,11 @@ amung->among
 amunition->ammunition
 analagous->analogous
 analgous->analogous
+analise->analyse
+analised->analysed
+analiser->analyser
 analises->analysis, analyses,
+analising->analysing
 analitic->analytic
 analitical->analytical
 analitically->analytically
@@ -1253,14 +1257,15 @@ analogeous->analogous
 analoguous->analogous
 analoguously->analogously
 analyis->analysis
-analysator->analyzer
-analysers->analyzers
-analysies->analyzes
+analysator->analyser
+analysies->analyses, analysis,
 analysus->analysis
 analysy->analysis
 analyticall->analytical, analytically,
 analyticaly->analytically
 analyticly->analytically
+analyzator->analyzer
+analyzies->analysis, analyses, analyzes,
 ananlog->analog
 anarchim->anarchism
 anarchistm->anarchism


### PR DESCRIPTION
British English tends to use analyse in stead of analyze.

See https://writingexplained.org/analyse-or-analyze-difference