### PR TITLE
Add spelling correction for fixe->fixed, fixes, fix

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8928,6 +8928,7 @@ fitering->filtering
 fitler->filter
 fitlers->filters
 fivety->fifty
+fixe->fixed, fixes, fix,
 fixeme->fixme
 fizeek->physique
 flage->flags

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8928,7 +8928,7 @@ fitering->filtering
 fitler->filter
 fitlers->filters
 fivety->fifty
-fixe->fixed, fixes, fix,
+fixe->fixed, fixes, fix, fixme, fixer,
 fixeme->fixme
 fizeek->physique
 flage->flags


### PR DESCRIPTION
Have seen this "live" from time to time but i'm not sure if this is too generic as it might be e.g. a variable or an abbreviation:

https://github.com/search?q=%22fixe%22