### PR TITLE
Fix a bug with the correcting to itself test added in #1138

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2998,6 +2998,8 @@ Caesarian->Caesarean
 cahacter->character
 cahacters->characters
 cahange->change
+cahanged->changed
+cahanges->changes
 cahanging->changing
 cahannel->channel
 caharacter->character
@@ -3017,7 +3019,10 @@ cahdidate->candidate
 cahdidates->candidates
 cahe->cache
 cahes->caches
-cahgne->cahgne
+cahgne->change
+cahgned->changed
+cahgnes->changes
+cahgning->changing
 cahhel->channel
 cahhels->channels
 cahined->chained
@@ -3026,6 +3031,7 @@ cahining->chaining
 cahnge->change
 cahnged->changed
 cahnges->changes
+cahnging->changing
 cahnnel->channel
 cahnnels->channels
 cahr->char

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -14,11 +14,11 @@ def test_dictionary_formatting():
         for line in fid:
             err, rep = line.decode('utf-8').split('->')
             err = err.lower()
-            assert err != rep, 'error %r corrects to itself' % err
+            rep = rep.rstrip('\n')
+            assert err != rep.lower(), 'error %r corrects to itself' % err
             assert err not in err_dict, 'error %r already exists' % err
             assert ws.match(err) is None, 'error %r has whitespace' % err
             assert comma.match(err) is None, 'error %r has a comma' % err
-            rep = rep.rstrip('\n')
             assert len(rep) > 0, ('error %s: correction %r must be non-empty'
                                   % (err, rep))
             assert not re.match(r'^\s.*', rep), ('error %s: correction %r '
@@ -31,7 +31,8 @@ def test_dictionary_formatting():
                 (r',\s\s', 'error %s: correction %r contains a comma followed '
                            'by multiple whitespace characters'),
                 (r',[^ ]', 'error %s: correction %r contains a comma *not* '
-                           'followed by a space')
+                           'followed by a space'),
+                (r'\s+$', 'error %s: correction %r has a trailing space')
             ]:
                 assert not re.search(r, rep), (msg % (err, rep))
             if rep.count(','):


### PR DESCRIPTION
It wasn't removing the newline, so was never matching.

Also check for replacements with trailing whitespace