### PR TITLE
Added spelling corrections for cross-site typo variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5292,8 +5292,12 @@ corrrupted->corrupted
 corrspond->correspond
 corrsponds->corresponds
 corruptiuon->corruption
+cors-site->cross-site
 corse->course
 corsor->cursor
+corss-site->cross-site
+corssite->cross-site
+corsssite->cross-site
 corus->chorus
 cosntrain->constrain
 cosntrains->constrains, constraints,
@@ -5462,6 +5466,7 @@ crockadile->crocodile
 crockodiles->crocodiles
 cronological->chronological
 cros->cross
+cros-site->cross-site
 croshet->crochet
 crosreference->cross-reference
 crosreferenced->cross-referenced
@@ -5469,9 +5474,11 @@ crosreferences->cross-references
 cross-commpilation->cross-compilation
 cross-orgin->cross-origin
 crossin->crossing
+crossite->cross-site
 crossreference->cross-reference
 crossreferenced->cross-referenced
 crossreferences->cross-references
+crosssite->cross-site
 crowdsigna->crowdsignal
 crowkay->croquet
 crowm->crown

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5293,11 +5293,15 @@ corrspond->correspond
 corrsponds->corresponds
 corruptiuon->corruption
 cors-site->cross-site
+cors-sute->cross-site
 corse->course
 corsor->cursor
 corss-site->cross-site
+corss-sute->cross-site
 corssite->cross-site
 corsssite->cross-site
+corsssute->cross-site
+corssute->cross-site
 corus->chorus
 cosntrain->constrain
 cosntrains->constrains, constraints,
@@ -5467,6 +5471,7 @@ crockodiles->crocodiles
 cronological->chronological
 cros->cross
 cros-site->cross-site
+cros-sute->cross-site
 croshet->crochet
 crosreference->cross-reference
 crosreferenced->cross-referenced
@@ -5479,6 +5484,8 @@ crossreference->cross-reference
 crossreferenced->cross-referenced
 crossreferences->cross-references
 crosssite->cross-site
+crosssute->cross-site
+crossute->cross-site
 crowdsigna->crowdsignal
 crowkay->croquet
 crowm->crown


### PR DESCRIPTION
Like in "cross-site scripting" or "cross-site request forgery":

https://github.com/search?q=%22coss-site%22&type=Code

``cross site scripting`` is also used from time to time but this probably can't be added to the left part of the corrections yet.

``coss`` might be a typo of ``cross`` as well but i haven't added this due to possible false positives on the reporting.

I'm also not sure about "cors-site" because this might refer to "CORS":

https://github.com/search?q=%22cors-site%22&type=Code