### PR TITLE
Add additional spelling corrections for advisor(y|ies).

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2432,6 +2432,10 @@ aviod->avoid
 avioded->avoided
 avioding->avoiding
 aviods->avoids
+avisories->advisories
+avisoriy->advisory, advisories,
+avisoriyes->advisories
+avisory->advisory
 avod->avoid
 avoded->avoided
 avoding->avoiding


### PR DESCRIPTION
Additional variants for https://github.com/codespell-project/codespell/pull/1300, see e.g.:

https://github.com/search?q=avisory&type=Code