### PR TITLE
Add intput->input and translation(s) corrections.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -17984,6 +17984,7 @@ rquested->requested
 rquesting->requesting
 rquests->requests
 rranslation->translation
+rranslations->translations
 rrase->erase
 rsizing->resizing
 rsource->resource
@@ -20719,6 +20720,7 @@ transalte->translate
 transalted->translated
 transaltes->translates
 transaltion->translation
+transaltions->translations
 transation->transaction, translation,
 transations->transactions, translations,
 transcendance->transcendence
@@ -20869,12 +20871,15 @@ traslate->translate
 traslated->translated
 traslates->translates
 traslating->translating
+traslation->translation
+traslations->translations
 traslucency->translucency
 trasmission->transmission
 trasnaction->transaction
 trasnlate->translate
 trasnlated->translated
 trasnlation->translation
+trasnlations->translations
 trasnport->transport
 trasnports->transports
 trasparency->transparency

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11685,6 +11685,7 @@ intitials->initials
 intity->entity
 intot->into
 intpreter->interpreter
+intput->input
 intputs->inputs
 intrduced->introduced
 intreeg->intrigue


### PR DESCRIPTION
See e.g.
https://github.com/search?q=%22intput%22
https://github.com/php/php-src/pull/3049
https://github.com/php/php-src/pull/3049#discussion_r164489495

While most of these "intput" are typos it *might* be possible that this is a function name like seen in e.g. https://github.com/JochenBe/intput.