### PR TITLE
Remove comma from simple entries w/o given reason

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11742,7 +11742,7 @@ intelegence->intelligence
 intelegent->intelligent
 intelegently->intelligently
 inteligability->intelligibility
-inteligable->intelligible,
+inteligable->intelligible
 inteligance->intelligence
 inteligantly->intelligently
 inteligence->intelligence
@@ -12057,7 +12057,7 @@ intruments->instruments
 intrusted->entrusted
 intstead->instead
 intuative->intuitive
-inturpratasion->interpretation,
+inturpratasion->interpretation
 inturpratation->interpretation
 inturprett->interpret
 intutive->intuitive
@@ -12099,7 +12099,7 @@ invlove->involve
 invloved->involved
 invloves->involves
 invocaition->invocation
-invokable->invocable,
+invokable->invocable
 invokation->invocation
 invokations->invocations
 invokee->invoked, invoke,
@@ -12518,7 +12518,7 @@ ligh->light, lie, lye,
 ligher->lighter, liar, liger,
 lighers->lighters, liars, ligers,
 lightening->lightening, lightning, lighting,
-lightsensor->light sensor,
+lightsensor->light sensor
 lightweigh->lightweight
 lightwight->lightweight
 lightyear->light year
@@ -22855,7 +22855,7 @@ wolrdly->worldly
 wolrdwide->worldwide
 wolwide->worldwide
 womens->women's, women,
-won;t->won't,
+won;t->won't
 wonderfull->wonderful
 wonderig->wondering
 wont't->won't

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -41,6 +41,8 @@ def test_dictionary_formatting():
                         ('currently corrections must end with trailing "," (if'
                          ' multiple corrections are available) or '
                          'have "disabled" in the comment')
+            if rep.count(',') == 1 and rep.split(',')[-1].strip() == '':
+                raise AssertionError('simple entry contains trailing comma')
             reps = [r.strip() for r in rep.lower().split(',')]
             reps = [r for r in reps if len(r)]
             err_dict[err] = reps

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -24,25 +24,29 @@ def test_dictionary_formatting():
             assert not re.match(r'^\s.*', rep), ('error %s: correction %r '
                                                  'cannot start with whitespace'
                                                  % (err, rep))
+            prefix = 'error %s: correction %r' % (err, rep)
             for (r, msg) in [
-                (r'^,', 'error %s: correction %r starts with a comma'),
-                (r'\s,', 'error %s: correction %r contains a whitespace '
-                         'character followed by a comma'),
-                (r',\s\s', 'error %s: correction %r contains a comma followed '
-                           'by multiple whitespace characters'),
-                (r',[^ ]', 'error %s: correction %r contains a comma *not* '
-                           'followed by a space'),
-                (r'\s+$', 'error %s: correction %r has a trailing space')
+                (r'^,',
+                 '%s starts with a comma'),
+                (r'\s,',
+                 '%s contains a whitespace character followed by a comma'),
+                (r',\s\s',
+                 '%s contains a comma followed by multiple whitespace '
+                 'characters'),
+                (r',[^ ]',
+                 '%s contains a comma *not* followed by a space'),
+                (r'\s+$',
+                 '%s has a trailing space'),
+                (r'^[^,]*,\s*$',
+                 '%s has a single entry but contains a trailing comma'),
             ]:
-                assert not re.search(r, rep), (msg % (err, rep))
-            if rep.count(','):
-                if not rep.endswith(','):
-                    assert 'disabled' in rep.split(',')[-1], \
-                        ('currently corrections must end with trailing "," (if'
-                         ' multiple corrections are available) or '
-                         'have "disabled" in the comment')
-            if rep.count(',') == 1 and rep.split(',')[-1].strip() == '':
-                raise AssertionError('simple entry contains trailing comma')
+                assert not re.search(r, rep), (msg % (prefix,))
+            rep_count = rep.count(',')
+            if rep_count and not rep.endswith(','):
+                assert 'disabled' in rep.split(',')[-1], \
+                    ('currently corrections must end with trailing "," (if '
+                     ' multiple corrections are available) or have "disabled" '
+                     'in the comment')
             reps = [r.strip() for r in rep.lower().split(',')]
             reps = [r for r in reps if len(r)]
             err_dict[err] = reps


### PR DESCRIPTION
- Remove the comma at the end of simple entries without given reason.
  Use the following command to find these entries:
```console
  awk -F , 'NF == 2' < ./codespell_lib/data/dictionary.txt | \
  grep --invert disabled
```
- Output was:
```console
  inteligable->intelligible,
  inturpratasion->interpretation,
  invokable->invocable,
  lightsensor->light sensor,
  won;t->won't,
```