### PR TITLE
Delete msg after loop

### DIFF
--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -41,6 +41,7 @@ def test_dictionary_formatting():
                  '%s has a single entry but contains a trailing comma'),
             ]:
                 assert not re.search(r, rep), (msg % (prefix,))
+            del msg
             rep_count = rep.count(',')
             if rep_count and not rep.endswith(','):
                 assert 'disabled' in rep.split(',')[-1], \


### PR DESCRIPTION
The last value of `msg` will not be carried to the next line and a
misleading value of `msg` for a different assert can be avoided.
