### PR TITLE
Import from misspelling Wikipedia list

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11790,6 +11790,7 @@ inpacting->impacting
 inpacts->impacts
 inpeach->impeach
 inpending->impending
+inpenetrable->impenetrable
 inplementation->implementation
 inplementations->implementations
 inplemented->implemented

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14973,6 +14973,7 @@ otherwhise->otherwise
 otherwice->otherwise
 otherwis->otherwise
 otherwize->otherwise
+otherwordly->otherworldly
 otherwse->otherwise
 otherwsie->otherwise
 othewice->otherwise

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10725,6 +10725,7 @@ hygeine->hygiene
 hygene->hygiene
 hygenic->hygienic
 hygine->hygiene
+hyjack->hijack
 hypen->hyphen
 hypenate->hyphenate
 hypenated->hyphenated

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21873,6 +21873,7 @@ trianglular->triangular
 trianglutaion->triangulation
 triangulataion->triangulation
 triangultaion->triangulation
+trigered->triggered
 trigerred->triggered
 trigerring->triggering
 trigers->triggers

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3431,6 +3431,7 @@ cauched->caught
 caugt->caught
 cauhgt->caught
 cauing->causing
+causalities->casualties
 causees->causes
 causion->caution
 causioned->cautioned

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -799,6 +799,7 @@ aiport->airport
 airator->aerator
 airbourne->airborne
 aircaft->aircraft
+aircrafts'->aircraft's
 aircrafts->aircraft
 airial->aerial, arial,
 airloom->heirloom

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3363,6 +3363,7 @@ Carribean->Caribbean
 carridge->carriage, cartridge,
 carrige->carriage
 carryintg->carrying
+carryng->carrying
 cartdridge->cartridge
 Carthagian->Carthaginian
 carthographer->cartographer

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14663,6 +14663,7 @@ oldes->oldest
 oll->all, ole, old, Olly, oil,
 olny->only
 olt->old
+olther->other
 oly->only
 omision->omission
 omited->omitted

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20366,6 +20366,7 @@ subcribing->subscribing
 subdirectoires->subdirectories
 subdirectorys->subdirectories
 subdirecty->subdirectory
+subdivisio->subdivision
 subdivisiond->subdivisioned
 subelemet->subelement
 subelemets->subelements

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -15428,6 +15428,7 @@ peacefuland->peaceful and
 peacify->pacify
 peageant->pageant
 peaple->people
+peaples->peoples
 pecentage->percentage
 pecified->specified, pacified,
 pecularities->peculiarities

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -15427,6 +15427,7 @@ peacd->peace
 peacefuland->peaceful and
 peacify->pacify
 peageant->pageant
+peaple->people
 pecentage->percentage
 pecified->specified, pacified,
 pecularities->peculiarities

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -15484,6 +15484,7 @@ percieved->perceived
 percision->precision
 perenially->perennially
 peresent->present, presents, presence, percent,
+peretrator->perpetrator
 perfec->perfect
 perfecct->perfect
 perfecctly->perfectly

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11789,6 +11789,7 @@ inpacted->impacted
 inpacting->impacting
 inpacts->impacts
 inpeach->impeach
+inpending->impending
 inplementation->implementation
 inplementations->implementations
 inplemented->implemented

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21111,6 +21111,7 @@ tasbar->taskbar
 taskelt->tasklet
 tast->taste
 tath->that
+tatoo->tattoo
 tatoos->tattoos
 tattooes->tattoos
 tavelling->travelling

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32,6 +32,7 @@ abbriviations->abbreviations
 aberation->aberration
 abigious->ambiguous
 abiguity->ambiguity
+abilityes->abilities
 abilties->abilities
 abilty->ability
 abiss->abyss

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -15468,6 +15468,7 @@ pensle->pencil
 peom->poem
 peoms->poems
 peopel->people
+peopels->peoples
 peopl->people
 peotry->poetry
 pepare->prepare

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2878,6 +2878,7 @@ booleen->boolean
 boolen->boolean
 boomark->bookmark
 boomarks->bookmarks
+boook->book
 booolean->boolean
 boostrap->bootstrap
 boostrapping->bootstrapping

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -781,6 +781,7 @@ agresssive->aggressive
 agrgument->argument
 agrguments->arguments
 agricultue->agriculture
+agriculure->agriculture
 agricuture->agriculture
 agrieved->aggrieved
 agrresive->aggressive

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1467,6 +1467,7 @@ anthropolgist->anthropologist
 anthropolgy->anthropology
 antialialised->antialiased
 antialising->antialiasing
+antiapartheid->anti-apartheid
 anticpate->anticipate
 anual->annual
 anually->annually

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13468,6 +13468,7 @@ millioniare->millionaire
 millisencond->millisecond
 millisenconds->milliseconds
 milliseonds->milliseconds
+millitant->militant
 millitary->military
 millon->million
 millsencond->millisecond

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20609,6 +20609,7 @@ sucide->suicide
 sucidial->suicidal
 sucome->succumb
 sucsede->succeed
+sudent->student
 sudents->students
 sudmobule->submodule
 sudmobules->submodules

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2809,6 +2809,7 @@ bimontly->bimonthly
 binairy->binary
 binanary->binary
 binay->binary
+binominal->binomial
 biridectionality->bidirectionality
 bistream->bitstream
 bitamps->bitmaps

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21956,6 +21956,7 @@ turtorial->tutorial
 turtorials->tutorials
 Tuscon->Tucson
 tust->trust
+tution->tuition
 tutoriel->tutorial
 tutoriels->tutorials
 twelth->twelfth

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10057,6 +10057,7 @@ gitars->guitars
 gitatributes->gitattributes
 gived->given
 givem->given, give them, give 'em,
+glamourous->glamorous
 glight->flight
 gloab->globe
 gloabal->global

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10726,6 +10726,7 @@ hygene->hygiene
 hygenic->hygienic
 hygine->hygiene
 hyjack->hijack
+hyjacking->hijacking
 hypen->hyphen
 hypenate->hyphenate
 hypenated->hyphenated

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -780,6 +780,7 @@ agressor->aggressor
 agresssive->aggressive
 agrgument->argument
 agrguments->arguments
+agricultue->agriculture
 agricuture->agriculture
 agrieved->aggrieved
 agrresive->aggressive

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3706,6 +3706,7 @@ chnage->change
 chnages->changes
 chnge->change
 chnnel->channel
+choclate->chocolate
 choicing->choosing
 choise->choice
 choises->choices

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20726,6 +20726,7 @@ suppressingd->suppressing
 supprt->support
 suppy->supply
 suppying->supplying
+suprassing->surpassing
 supres->suppress
 supresed->suppressed
 supreses->suppresses

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -821,6 +821,7 @@ ajurnment->adjournment
 ajust->adjust
 ajusted->adjusted
 ajustment->adjustment
+aka->a.k.a.
 ake->ache
 aks->ask
 aktivate->activate

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -15602,6 +15602,7 @@ perperty->property
 perphas->perhaps
 perpindicular->perpendicular
 perrror->perror
+persan->person
 persepctive->perspective
 persepective->perspective
 persepectives->perspectives

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8451,6 +8451,7 @@ eqaulity->equality
 eqaulizer->equalizer
 eqivalent->equivalent
 eqivalents->equivalents
+equalibrium->equilibrium
 equallity->equality
 equaly->equally
 equel->equal

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20609,6 +20609,7 @@ sucide->suicide
 sucidial->suicidal
 sucome->succumb
 sucsede->succeed
+sudents->students
 sudmobule->submodule
 sudmobules->submodules
 sueful->useful

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21506,6 +21506,7 @@ tim->time, Tim, disabled due to being a person's name
 timedlta->timedelta
 timeing->timing
 timere->timer
+timeschedule->time schedule
 timestan->timespan
 timestemp->timestamp
 timestemps->timestamps

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8455,6 +8455,7 @@ equalibrium->equilibrium
 equallity->equality
 equaly->equally
 equel->equal
+equelibrium->equilibrium
 equialent->equivalent
 equilavalent->equivalent
 equilibium->equilibrium


### PR DESCRIPTION
Imported missing words from: https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines