### PR TITLE
Gauss spellings and more

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22070,7 +22070,7 @@ therby->thereby
 thereads->threads
 therefor->therefore, therefor,
 therefrom->there from
-therem->there
+therem->there, theorem,
 thereom->theorem
 thererin->therein
 theres->there's

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10953,6 +10953,7 @@ guarunteing->guaranteeing
 guaruntes->guarantees
 guarunty->guaranty
 guas->Gauss
+guass->Gauss
 guassian->gaussian
 Guatamala->Guatemala
 Guatamalan->Guatemalan

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10568,7 +10568,11 @@ gaurd->guard, gourd,
 gaurentee->guarantee
 gaurenteed->guaranteed
 gaurentees->guarantees
+gaus'->Gauss'
+gaus->Gauss, Gauss'
 gausian->gaussian
+gauss'->Gauss'
+gauss->Gauss, Gauss',
 geenrate->generate
 geenrated->generated
 geenrates->generates

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1,4 +1,3 @@
-,easure->measure
 1nd->1st
 a-diaerers->a-diaereses
 aaccessibility->accessibility

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1,3 +1,4 @@
+,easure->measure
 1nd->1st
 a-diaerers->a-diaereses
 aaccessibility->accessibility
@@ -3851,6 +3852,7 @@ certiticate->certificate
 cervial->cervical, servile, serval,
 cetting->setting
 Cgywin->Cygwin
+chaarges->charges
 chacacter->character
 chacacters->characters
 chache->cache
@@ -5076,6 +5078,7 @@ condtition->condition
 condtitional->conditional
 condtitionals->conditionals
 condtitions->conditions
+conductuve->conductive, conducive,
 conecct->connect
 coneccted->connected
 coneccting->connecting
@@ -7942,6 +7945,7 @@ discontigious->discontiguous
 discontigous->discontiguous
 discontiguities->discontinuities
 discontinous->discontinuous
+discontinuos->discontinuous
 discontinus->discontinue, discontinuous,
 discouranged->discouraged
 discourarged->discouraged
@@ -8626,11 +8630,14 @@ elction->election
 elctromagnetic->electromagnetic
 eleate->relate
 electic->eclectic, electric,
+electirc->electric
+electircal->electrical
 electon->election, electron,
 electrial->electrical
 electricly->electrically
 electricty->electricity
 electrinics->electronics
+electriv->electric
 electrnoics->electronics
 eleent->element
 elegible->eligible
@@ -11071,6 +11078,7 @@ hardocde->hardcode
 hardward->hardware
 hardwdare->hardware
 hardwirted->hardwired
+harge->charge
 harras->harass
 harrased->harassed
 harrases->harasses
@@ -15383,6 +15391,7 @@ onoly->only
 onot->note, not,
 ons->owns
 onself->oneself
+onservation->conservation, observation,
 ontain->contain
 onthe->on the
 ontrolled->controlled
@@ -15901,6 +15910,7 @@ pannels->panels
 panting->panting, painting,
 pantomine->pantomime
 paoition->position
+paor->pair
 Papanicalou->Papanicolaou
 paradime->paradigm
 paradym->paradigm
@@ -19606,6 +19616,7 @@ rythim->rhythm
 rythm->rhythm
 rythmic->rhythmic
 rythyms->rhythms
+saame->same
 sabatage->sabotage
 sabatour->saboteur
 sacalar->scalar
@@ -20611,6 +20622,7 @@ spawed->spawned
 spawing->spawning
 spawnve->spawn
 spaws->spawns
+spcae->space
 spcecified->specified
 spcial->special
 spcifies->specifies
@@ -22036,6 +22048,7 @@ thefore->therefore
 theif->thief
 theifs->thieves
 theire->their, they're,
+theis->this
 theiv->thief, they've,
 theive->thief
 theives->thieves
@@ -22057,6 +22070,7 @@ thereads->threads
 therefor->therefore, therefor,
 therefrom->there from
 therem->there
+thereom->theorem
 thererin->therein
 theres->there's
 therfore->therefore

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7585,6 +7585,7 @@ didnt->didn't
 didnt;->didn't
 diea->idea, die,
 dieing->dying, dyeing,
+dielectircs->dielectrics
 diemsion->dimension
 dieties->deities
 diety->deity

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22049,7 +22049,7 @@ thefore->therefore
 theif->thief
 theifs->thieves
 theire->their, they're,
-theis->this
+theis->this, thesis,
 theiv->thief, they've,
 theive->thief
 theives->thieves

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10569,6 +10569,7 @@ gaurentee->guarantee
 gaurenteed->guaranteed
 gaurentees->guarantees
 gaus'->Gauss'
+gaus's->Gauss'
 gaus->Gauss
 gausian->gaussian
 geenrate->generate
@@ -10952,7 +10953,10 @@ guaruntees->guarantees
 guarunteing->guaranteeing
 guaruntes->guarantees
 guarunty->guaranty
+guas'->Gauss'
+guas's->Gauss'
 guas->Gauss
+guass'->Gauss'
 guass->Gauss
 guassian->gaussian
 Guatamala->Guatemala

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2893,6 +2893,7 @@ becaus->because
 becausee->because
 becauseq->because
 becauses->because
+becausw->because
 beccause->because
 bechmark->benchmark
 becoem->become

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10568,11 +10568,8 @@ gaurd->guard, gourd,
 gaurentee->guarantee
 gaurenteed->guaranteed
 gaurentees->guarantees
-gaus'->Gauss'
-gaus->Gauss, Gauss'
+gaus->Gauss
 gausian->gaussian
-gauss'->Gauss'
-gauss->Gauss, Gauss',
 geenrate->generate
 geenrated->generated
 geenrates->generates
@@ -10954,6 +10951,7 @@ guaruntees->guarantees
 guarunteing->guaranteeing
 guaruntes->guarantees
 guarunty->guaranty
+guas->Gauss
 guassian->gaussian
 Guatamala->Guatemala
 Guatamalan->Guatemalan

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -17673,6 +17673,7 @@ rasing->raising
 raspoberry->raspberry
 rathar->rather
 rathern->rather
+rcall->recall
 rceate->create
 rceating->creating
 rduce->reduce

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7585,6 +7585,7 @@ didnt->didn't
 didnt;->didn't
 diea->idea, die,
 dieing->dying, dyeing,
+dielectirc->dielectric
 dielectircs->dielectrics
 diemsion->dimension
 dieties->deities

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10568,6 +10568,7 @@ gaurd->guard, gourd,
 gaurentee->guarantee
 gaurenteed->guaranteed
 gaurentees->guarantees
+gaus'->Gauss'
 gaus->Gauss
 gausian->gaussian
 geenrate->generate


### PR DESCRIPTION
Gauss should be capitalized as it's referring to a human (proper noun).

Note: what I did doesn't seem to work. Is the dictionary case insensitive?

Output from a sample project:

```
./section5.tex:102: gauss'  ==> gauss'
./section1.tex:669: Gauss'  ==> Gauss'
./section3.tex:377: Gauss'  ==> Gauss'
./section3.tex:385: Gauss'  ==> Gauss'
```