### PR TITLE
Allow to use --skip multiple times

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -58,7 +58,8 @@ class QuietLevels(object):
 class GlobMatch(object):
     def __init__(self, pattern):
         if pattern:
-            self.pattern_list = pattern.split(',')
+            # Pattern might be a list of comma-delimited strings
+            self.pattern_list = ','.join(pattern).split(',')
         else:
             self.pattern_list = None
 
@@ -243,6 +244,7 @@ def parse_options(args):
                         help='print summary of fixes')
 
     parser.add_argument('-S', '--skip',
+                        action='append',
                         help='Comma-separated list of files to skip. It '
                              'accepts globs as well. E.g.: if you want '
                              'codespell to skip .eps and .txt files, '


### PR DESCRIPTION
Make it possible to add custom system-wide ignored directories with an alias in shell rc script, e.g.:
```bash
alias codespell="codespell --skip=".git,node_modules"
```
and allow to extend this list by executing codespell alias with extra `--skip` argument.