### PR TITLE
Remove aka->a.k.a.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -910,7 +910,6 @@ ajusted->adjusted
 ajustement->adjustment
 ajusting->adjusting
 ajustment->adjustment
-aka->a.k.a.
 ake->ache
 akkumulate->accumulate
 akkumulated->accumulated


### PR DESCRIPTION
Neither is specifically favoured on Wikipedia: https://en.wikipedia.org/wiki/Aka or elsewhere https://writingexplained.org/aka-or-aka