### PR TITLE
Travis CI: Add Python 3.8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,13 @@
 # can't be any leading "-"s - All newlines will be removed, so use ";"s
 
 language: python
-sudo: false
-dist: xenial
-
-cache:
-  directories:
-    - $HOME/.cache/pip
-
-matrix:
-    include:
-        - os: linux
-          python: 2.7
-        - os: linux
-          python: 3.5
-        - os: linux
-          python: 3.6
-        - os: linux
-          python: 3.7
+cache: pip
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 
 before_install:
     - source tools/travis_tools.sh

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -347,8 +347,8 @@ def build_dict(filename, misspellings, ignore_words):
 def is_hidden(filename, check_hidden):
     bfilename = os.path.basename(filename)
 
-    return (bfilename not in ('', '.', '..') and
-            (not check_hidden and bfilename[0] == '.'))
+    return bfilename not in ('', '.', '..') and \
+           (not check_hidden and bfilename[0] == '.')
 
 
 def is_text_file(filename):

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -347,19 +347,13 @@ def build_dict(filename, misspellings, ignore_words):
 def is_hidden(filename, check_hidden):
     bfilename = os.path.basename(filename)
 
-    if bfilename != '' and bfilename != '.' and bfilename != '..' \
-                    and (not check_hidden and bfilename[0] == '.'):
-        return True
-
-    return False
+    return (bfilename not in ('', '.', '..')
+            and (not check_hidden and bfilename[0] == '.'))
 
 
 def is_text_file(filename):
     with open(filename, mode='rb') as f:
-        s = f.read(1024)
-    if b'\x00' in s:
-        return False
-    return True
+        return b'\x00' not in f.read()
 
 
 def fix_case(word, fixword):

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -311,13 +311,13 @@ def build_exclude_hashes(filename, exclude_lines):
 
 
 def build_ignore_words(filename, ignore_words):
-    with codecs.open(filename, mode='r', buffering=1, encoding='utf-8') as f:
+    with codecs.open(filename, mode='r', encoding='utf-8') as f:
         for line in f:
             ignore_words.add(line.strip())
 
 
 def build_dict(filename, misspellings, ignore_words):
-    with codecs.open(filename, mode='r', buffering=1, encoding='utf-8') as f:
+    with codecs.open(filename, mode='r', encoding='utf-8') as f:
         for line in f:
             [key, data] = line.split('->')
             # TODO for now, convert both to lower. Someday we can maybe add
@@ -348,12 +348,15 @@ def is_hidden(filename, check_hidden):
     bfilename = os.path.basename(filename)
 
     return bfilename not in ('', '.', '..') and \
-           (not check_hidden and bfilename[0] == '.')
+        (not check_hidden and bfilename[0] == '.')
 
 
 def is_text_file(filename):
     with open(filename, mode='rb') as f:
-        return b'\x00' not in f.read()
+        s = f.read(1024)
+    if b'\x00' in s:
+        return False
+    return True
 
 
 def fix_case(word, fixword):

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -347,8 +347,8 @@ def build_dict(filename, misspellings, ignore_words):
 def is_hidden(filename, check_hidden):
     bfilename = os.path.basename(filename)
 
-    return (bfilename not in ('', '.', '..')
-            and (not check_hidden and bfilename[0] == '.'))
+    return (bfilename not in ('', '.', '..') and
+            (not check_hidden and bfilename[0] == '.'))
 
 
 def is_text_file(filename):


### PR DESCRIPTION
Running codespell on Python 3.8 generates RuntimeWarnings...

$ __codespell__
```
/home/travis/virtualenv/python3.8.0/lib/python3.8/codecs.py:905:
RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode,
    the default buffer size will be used
file = builtins.open(filename, mode, buffering)
```
See: https://travis-ci.org/codespell-project/codespell/jobs/629584864#L430-L431