### PR TITLE
Remove two non-typos from the list

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14654,7 +14654,6 @@ memmory->memory
 memoery->memory
 memomry->memory
 memor->memory
-memorise->memorise, memorize,
 mempry->memory
 memroy->memory
 menally->mentally
@@ -14844,7 +14843,6 @@ minerial->mineral
 MingGW->MinGW
 minimam->minimum
 minimial->minimal
-minimise->minimise, minimize,
 minimium->minimum
 minimumm->minimum
 minimumn->minimum


### PR DESCRIPTION
"memorise" and "minimise" are note misspellings; they're just British spelling variants of the words.