### PR TITLE
🚧 Ignore escaped characters

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -234,7 +234,7 @@ def parse_options(args):
                              'how they are written in the dictionary file')
     parser.add_argument('-P', '--sub-pairs', type=str, metavar='FILE',
                         help='Custom substitution text file that contains '
-                             'substituions key value pairs.  Can be used to '
+                             'substitutions key value pairs.  Can be used to '
                              'substitute escaped characters.')
     parser.add_argument('-r', '--regex',
                         action='store', type=str,

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -396,11 +396,10 @@ def multiple_replace(find_dict, text):
     this was a cat meow meow Where don't
 
     """
-    # Create a regular expression from all of the dictionary keys
-    regex = re.compile("|".join(map(re.escape, find_dict.keys())))
-
-    # For each match, look up the corresponding value in the dictionary
-    return regex.sub(lambda match: find_dict[match.group(0)], text)
+    # replace for each match
+    for key, rep in find_dict.items():
+        text = text.replace(key, rep)
+    return text
 
 
 def ask_for_word_fix(line, wrongword, misspelling, interactivity):

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -33,6 +33,8 @@ USAGE = """
 """
 VERSION = '1.17.0.dev0'
 
+SUB_DICT = {'\\n': ' ', r"\'": "'"}
+
 # Users might want to link this file into /usr/local/bin, so we resolve the
 # symbolic link path to the real path if necessary.
 default_dictionary = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -369,6 +371,38 @@ def fix_case(word, fixword):
     return fixword
 
 
+def multiple_replace(find_dict, text):
+    """Multiple find and replace based on a dictionary
+
+    Parameters
+    ----------
+    find_dict : dict
+        Dictionary containing values to find and replace.  For example
+        ``{'\\n': ' ', r"\'": "'"}``
+
+    text : str
+        Text to perform substitution on.
+
+    Returns
+    -------
+    sub_text : str
+        Text with substitutions.
+
+    Examples
+    --------
+    >>> line = r'this was a cat meow meow\nWhere don\'t'
+    >>> find_dict = {'\\n': ' ', r"\'": "'"}
+    >>> multiple_replace(find_dict, text)
+    this was a cat meow meow Where don't
+
+    """
+    # Create a regular expression from all of the dictionary keys
+    regex = re.compile("|".join(map(re.escape, find_dict.keys())))
+
+    # For each match, look up the corresponding value in the dictionary
+    return regex.sub(lambda match: find_dict[match.group(0)], text)
+
+
 def ask_for_word_fix(line, wrongword, misspelling, interactivity):
     if interactivity <= 0:
         return misspelling.fix, fix_case(wrongword, misspelling.data)
@@ -491,6 +525,9 @@ def parse_file(filename, colors, summary, misspellings, exclude_lines,
 
         fixed_words = set()
         asked_for = set()
+
+        # escape valid characters
+        line = multiple_replace(SUB_DICT, line)
 
         for word in word_regex.findall(line):
             lword = word.lower()

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -84,7 +84,7 @@ def test_escaped(tmpdir, capsys):
 
 
 def test_escaped_sub_file(tmpdir, capsys):
-    """Test escaping characters using substituion file"""
+    """Test escaping characters using substitution file"""
     d = str(tmpdir)
     with open(op.join(d, 'escaped_text.txt'), 'w') as f:
         f.write(r"We can\'t")

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -73,6 +73,17 @@ def test_basic(tmpdir, capsys):
     assert cs.main(d) == 0
 
 
+def test_escaped(tmpdir, capsys):
+    """Test escaping characters"""
+    assert cs.main('_does_not_exist_') == 0
+    with open(op.join(str(tmpdir), 'tmp'), 'w') as f:
+        pass
+    d = str(tmpdir)
+    with open(op.join(d, 'escaped_char.txt'), 'w') as f:
+        f.write(r"\n\nWe can")
+    assert cs.main(d) == 0
+
+
 def test_interactivity(tmpdir, capsys):
     """Test interaction"""
     # Windows can't read a currently-opened file, so here we use

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -8,6 +8,8 @@ import os.path as op
 import subprocess
 import sys
 
+import pytest
+
 import codespell_lib as cs
 
 
@@ -75,13 +77,24 @@ def test_basic(tmpdir, capsys):
 
 def test_escaped(tmpdir, capsys):
     """Test escaping characters"""
-    assert cs.main('_does_not_exist_') == 0
-    with open(op.join(str(tmpdir), 'tmp'), 'w') as f:
-        pass
     d = str(tmpdir)
     with open(op.join(d, 'escaped_char.txt'), 'w') as f:
         f.write(r"\n\nWe can")
     assert cs.main(d) == 0
+
+
+def test_escaped_sub_file(tmpdir, capsys):
+    """Test escaping characters using substituion file"""
+    d = str(tmpdir)
+    with open(op.join(d, 'escaped_text.txt'), 'w') as f:
+        f.write(r"We can\'t")
+
+    sub_pair_filename = op.join(d, 'sub_pairs.txt')
+    with open(sub_pair_filename, 'w') as f:
+        f.write(r"\'->'")
+    with pytest.raises(Exception):
+        cs.main(d, '-P', 'notafile')
+    assert cs.main(d, '-P', sub_pair_filename) == 0
 
 
 def test_interactivity(tmpdir, capsys):


### PR DESCRIPTION
This take a stab at ignoring escaped characters.  It's a basic (and probably inefficient) implementation, so if there's a better way to get this done, please let me know.

Also, the escape dictionary should be modifiable by the user.