### PR TITLE
Restore resizeable (british spelling)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20344,7 +20344,6 @@ resistable->resistible
 resistence->resistance
 resistent->resistant
 resivwar->reservoir
-resizeable->resizable
 resizeble->resizable
 reslection->reselection
 reslove->resolve


### PR DESCRIPTION
Undoing a change in 902baa47

This was also removed in 2018 in
https://github.com/codespell-project/codespell/pull/707