### PR TITLE
FIX: Packaging and 1.17.1 bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_install:
     - virtualenv --python=python venv
     - source venv/bin/activate
     - python --version  # just to check
-    - pip install -U pip wheel  # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
-    - retry pip install pytest pytest-cov pytest-dependency flake8 coverage codecov chardet setuptools docutils
+    - pip install -U pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
+    - retry pip install pytest pytest-cov pytest-dependency flake8 coverage codecov chardet setuptools docutils check-manifest
     - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then retry pip install aspell-python-py2; fi
     - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then retry pip install aspell-python-py3; fi
     - cd $SRC_DIR
@@ -49,6 +49,7 @@ script:
         python setup.py check --restructuredtext --strict;
       fi;
     - pytest codespell_lib
+    - make check-manifest
 
 after_success:
     - codecov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,11 @@
 include codespell_lib/__init__.py
 recursive-include codespell_lib *.py
-include codespell_lib/data/dictionary.txt
+include codespell_lib/data/dictionary*.txt
 include codespell_lib/data/linux-kernel.exclude
 include COPYING
+include bin/codespell
+exclude *.yml *.yaml
+exclude .coveragerc
+exclude example example/* snap snap/* tools tools/*
+exclude Makefile
+exclude codespell.1.include

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ trim-dictionaries:
 		sed -E -i.bak -e 's/^[[:space:]]+//; s/[[:space:]]+$$//; /^$$/d' $$dictionary && rm $$dictionary.bak; \
 	done
 
+check-manifest:
+	check-manifest
+
 pypi:
 	python setup.py sdist register upload
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -31,7 +31,7 @@ encodings = ('utf-8', 'iso-8859-1')
 USAGE = """
 \t%prog [OPTIONS] [file1 file2 ... fileN]
 """
-VERSION = '1.17.0'
+VERSION = '1.17.1'
 
 # Users might want to link this file into /usr/local/bin, so we resolve the
 # symbolic link path to the real path if necessary.


### PR DESCRIPTION
Closes #1516.

I already pushed 1.17.1 to PyPI after checking that the sdist actually had the dictionaries in it from the `MANIFEST.in` changes. But `check-manifest` should prevent us from having this problem in the future.