### PR TITLE
Add "protcool" spelling correction

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20041,6 +20041,8 @@ protable->portable
 protaganist->protagonist
 protaganists->protagonists
 protcol->protocol
+protcool->protocol
+protcools->protocols
 protcted->protected
 protecion->protection
 protedcted->protected


### PR DESCRIPTION
This mispelling occurs in several projects: https://grep.app/search?q=protcool