### PR TITLE
Ignore the .git folder

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           check_filenames: true
           # When using this Action in other repos, the --skip option below can be removed
-          skip: ./codespell_lib/data,./example/code.c,test_basic.py,*.pyc
+          skip: ./.git,./codespell_lib/data,./example/code.c,test_basic.py,*.pyc


### PR DESCRIPTION
See also #1549 I don't know if this is a Codespell bug or a config error on our part. Thoughts?