### PR TITLE
FIX: --check-hidden respects directories

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -715,7 +715,7 @@ def main(*args):
                 if glob_match.match(root):  # skip (absolute) directories
                     del dirs[:]
                     continue
-                if is_hidden(root, options.check_hidden):
+                if is_hidden(root, options.check_hidden):  # dir itself hidden
                     continue
                 for file_ in files:
                     # ignore hidden files in directories

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -323,14 +323,15 @@ def test_check_hidden(tmpdir):
                    op.join(d, '.abandonned.txt')) == 2
     assert cs.main('--check-hidden', '--check-filenames', d) == 2
     # hidden directory
+    assert cs.main(d) == 0
     assert cs.main('--check-hidden', d) == 1
     assert cs.main('--check-hidden', '--check-filenames', d) == 2
-    os.mkdir(op.join(d, '.test'))
+    os.mkdir(op.join(d, '.abandonned'))
     copyfile(op.join(d, '.abandonned.txt'),
-             op.join(d, '.test', 'abandonned.txt'))
+             op.join(d, '.abandonned', 'abandonned.txt'))
     assert cs.main(d) == 0
     assert cs.main('--check-hidden', d) == 2
-    assert cs.main('--check-hidden', '--check-filenames', d) == 4
+    assert cs.main('--check-hidden', '--check-filenames', d) == 5
 
 
 def test_case_handling(tmpdir, capsys):


### PR DESCRIPTION
Closes #783
Closes #1549

I decided not to add `--check-hidden-files` / `--check-hidden-directories` options, assume YAGNI and add later if someone needs it. (`--check-hidden files` will not work because then there's ambiguity about whether the last thing is a value for `--check-hidden` or a file/dir to check e.g. in `codespell --check-hidden files whatever`, it's unclear if "files" should be checked or if it's a value for `--check-hidden`.)