### PR TITLE
Add renaming advice based on IETF draft-knodel-terminology-00

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,11 +41,11 @@ The ``-w`` flag will actually implement the changes recommended by codespell. No
 
     codespell -I FILE, --ignore-words=FILE
 
-The ``-I`` flag can be used to whitelist certain words that are in the ``codespell_lib/data/dictionary.txt``. The format of the whitelist file is one word per line. Invoke using: ``codespell -I path/to/file.txt`` to execute codespell referencing said whitelist. **Important note:** The whitelist passed to ``-I`` is case-sensitive based on how it is listed in ``dictionary.txt``. ::
+The ``-I`` flag can be used for a list of certain words to allow that are in the codespell dictionaries. The format of the file is one word per line. Invoke using: ``codespell -I path/to/file.txt`` to execute codespell referencing said list of allowed words. **Important note:** The list passed to ``-I`` is case-sensitive based on how it is listed in the codespell dictionaries. ::
 
     codespell -L word1,word2,word3,word4
 
-The ``-L`` flag can be used to whitelist certain words that are comma-separated placed immediately after it. ::
+The ``-L`` flag can be used to allow certain words that are comma-separated placed immediately after it. ::
 
     codespell -S, --skip=
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -43,7 +43,7 @@ _builtin_dictionaries = (
     ('clear', 'for unambiguous errors', '', False, None),
     ('rare', 'for rare but valid words', '_rare', None, None),
     ('informal', 'for informal words', '_informal', True, True),
-    ('usage', 'for recommended terms', '_usage', True, None),
+    ('usage', 'for recommended terms', '_usage', None, None),
     ('code', 'for words common to code and/or mathematics', '_code', None, None),  # noqa: E501
     ('names', 'for valid proper names that might be typos', '_names', None, None),  # noqa: E501
     ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US', True, True),  # noqa: E501

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -43,6 +43,7 @@ _builtin_dictionaries = (
     ('clear', 'for unambiguous errors', '', False, None),
     ('rare', 'for rare but valid words', '_rare', None, None),
     ('informal', 'for informal words', '_informal', True, True),
+    ('usage', 'for recommended terms', '_usage', True, None),
     ('code', 'for words common to code and/or mathematics', '_code', None, None),  # noqa: E501
     ('names', 'for valid proper names that might be typos', '_names', None, None),  # noqa: E501
     ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US', True, True),  # noqa: E501

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3556,7 +3556,7 @@ bizzare->bizarre
 bject->object
 bjects->objects
 blackslashes->backslashes
-blaclist->blocklist
+blaclist->blacklist
 blaim->blame
 blaimed->blamed
 blak->black, blank,
@@ -28039,10 +28039,10 @@ whicht->which
 whihc->which
 whihch->which
 whilest->whilst
-whiltelist->allowlist
-whiltelisted->allowlisted
-whiltelisting->allowlisting
-whiltelists->allowlists
+whiltelist->whitelist
+whiltelisted->whitelisted
+whiltelisting->whitelisting
+whiltelists->whitelists
 whilw->while
 whioch->which
 whiped->wiped

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -6,7 +6,6 @@ automatized->automated
 automatizes->automates
 backword->backward
 backwords->backwards
-blacklist->blocklist
 bloc->block
 blocs->blocks
 bodgy->body
@@ -135,7 +134,6 @@ wee->we
 whats->what's
 whet->when, what, wet,
 whiling->while
-whitelist->allowlist
 wight->weight, white, right, write,
 wights->weights, whites, rights, writes,
 wit->with

--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -1,4 +1,8 @@
+blacklist->blocklist
+blacklists->blocklists
 master->primary, leader, active, writer, coordinator, parent,
 masters->primaries, leaders, actives, writers, coordinators, parents,
 slave->secondary, follower, standby, replica, reader, worker, helper,
 slaves->secondaries, followers, standbys, replicas, readers, workers, helpers,
+whitelist->allowlist
+whitelists->allowlists

--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -1,0 +1,4 @@
+master->primary, leader, active, writer, coordinator, parent,
+masters->primaries, leaders, actives, writers, coordinators, parents,
+slave->secondary, follower, standby, replica, reader, worker, helper,
+slaves->secondaries, followers, standbys, replicas, readers, workers, helpers,

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -175,6 +175,8 @@ def test_error_checking_in_aspell(err, rep, err_aspell, rep_aspell, match):
 allowed_dups = {
     ('dictionary.txt', 'dictionary_en-GB_to_en-US.txt'),
     ('dictionary.txt', 'dictionary_rare.txt'),
+    ('dictionary.txt', 'dictionary_usage.txt'),
+    ('dictionary_rare.txt', 'dictionary_usage.txt'),
 }
 
 


### PR DESCRIPTION
Based on:
https://tools.ietf.org/id/draft-knodel-terminology-00.html#rfc.section.1.1.1

Offer to replace master/slave with:
- Primary-secondary
- Leader-follower
- Active-standby
- Primary-replica
- Writer-reader
- Coordinator-worker
- Parent-helper