### PR TITLE
ENH: Multiline help

### DIFF
--- a/codespell_lib/__main__.py
+++ b/codespell_lib/__main__.py
@@ -1,0 +1,4 @@
+from ._codespell import _script_main
+
+if __name__ == '__main__':
+    _script_main()

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -255,16 +255,15 @@ def parse_options(args):
                              'corrections. If this flag is not specified or '
                              'equals "-" then the default dictionary is used. '
                              'This option can be specified multiple times.')
-    builtin_opts = '\n- '.join([] + [
+    builtin_opts = '\n- '.join([''] + [
         '%r %s' % (d[0], d[1]) for d in _builtin_dictionaries])
     parser.add_argument('--builtin',
                         dest='builtin', default=_builtin_default,
                         metavar='BUILTIN-LIST',
                         help='Comma-separated list of builtin dictionaries '
                         'to include (when "-D -" or no "-D" is passed). '
-                        'Current options are:%s\nThe default is '
-                        '"--builtin %s".'
-                        % (builtin_opts, _builtin_default))
+                        'Current options are:' + builtin_opts + '\n'
+                        'The default is %(default)r.')
     parser.add_argument('-I', '--ignore-words',
                         action='append', metavar='FILE',
                         help='File that contains words which will be ignored '

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -207,6 +207,9 @@ class FileOpener(object):
 # -.-:-.-:-.-:-.:-.-:-.-:-.-:-.-:-.:-.-:-.-:-.-:-.-:-.:-.-:-
 
 
+# If someday this breaks, we can just switch to using RawTextHelpFormatter,
+# but it has the disadvantage of not wrapping our long lines.
+
 class NewlineHelpFormatter(argparse.HelpFormatter):
     """Help formatter that preserves newlines and deals with lists."""
 


### PR DESCRIPTION
@waldyrious @peternewman can you try and see if it's what you had in mind? This is what I see now:
<details>
<summary>codespell --help</summary>

```
usage: codespell [-h] [--version] [-d] [-c] [-w] [-D DICTIONARY]
                 [--builtin BUILTIN-LIST] [-I FILE] [-L WORDS] [-r REGEX] [-s]
                 [-S SKIP] [-x FILE] [-i INTERACTIVE] [-q QUIET_LEVEL] [-e]
                 [-f] [-H] [-A LINES] [-B LINES] [-C LINES]
                 [files [files ...]]

positional arguments:
  files                 files or directories to check

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -d, --disable-colors  disable colors, even when printing to terminal (always
                        set for Windows)
  -c, --enable-colors   enable colors, even when not printing to terminal
  -w, --write-changes   write changes in place if possible
  -D DICTIONARY, --dictionary DICTIONARY
                        Custom dictionary file that contains spelling
                        corrections. If this flag is not specified or equals
                        "-" then the default dictionary is used. This option
                        can be specified multiple times.
  --builtin BUILTIN-LIST
                        Comma-separated list of builtin dictionaries to
                        include (when "-D -" or no "-D" is passed). Current
                        options are:'clear' for unambiguous errors
                        - 'rare' for rare but valid words
                        - 'informal' for informal words
                        - 'usage' for recommended terms
                        - 'code' for words common to code and/or mathematics
                        - 'names' for valid proper names that might be typos
                        - 'en-GB_to_en-US' for corrections from en-GB to en-US
                        The default is "--builtin clear,rare".
  -I FILE, --ignore-words FILE
                        File that contains words which will be ignored by
                        codespell. File must contain 1 word per line. Words
                        are case sensitive based on how they are written in
                        the dictionary file
  -L WORDS, --ignore-words-list WORDS
                        Comma separated list of words to be ignored by
                        codespell. Words are case sensitive based on how they
                        are written in the dictionary file
  -r REGEX, --regex REGEX
                        Regular expression which is used to find words. By
                        default any alphanumeric character, the underscore,
                        the hyphen, and the apostrophe is used to build words.
                        This option cannot be specified together with --write-
                        changes.
  -s, --summary         print summary of fixes
  -S SKIP, --skip SKIP  Comma-separated list of files to skip. It accepts
                        globs as well. E.g.: if you want codespell to skip
                        .eps and .txt files, you'd give "*.eps,*.txt" to this
                        option.
  -x FILE, --exclude-file FILE
                        FILE with lines that should not be checked for errors
                        or changed
  -i INTERACTIVE, --interactive INTERACTIVE
                        Set interactive mode when writing changes:
                        - 0: no interactivity.
                        - 1: ask for confirmation.
                        - 2: ask user to choose one fix when more than one is
                          available.
                        - 3: both 1 and 2
  -q QUIET_LEVEL, --quiet-level QUIET_LEVEL
                        Bitmask that allows suppressing messages:
                        - 0: print all messages.
                        - 1: disable warnings about wrong encoding.
                        - 2: disable warnings about binary files.
                        - 4: omit warnings about automatic fixes that were
                          disabled in the dictionary.
                        - 8: don't print anything for non-automatic fixes.
                        - 16: don't print the list of fixed files.
                        As usual with bitmasks, these levels can be combined;
                        e.g. use 3 for levels 1+2, 7 for 1+2+4, 23 for
                        1+2+4+16, etc. The default mask is 2.
  -e, --hard-encoding-detection
                        Use chardet to detect the encoding of each file. This
                        can slow down codespell, but is more reliable in
                        detecting encodings other than utf-8, iso8859-1, and
                        ascii.
  -f, --check-filenames
                        check file names as well
  -H, --check-hidden    Check hidden files and directories (those starting
                        with ".") as well.
  -A LINES, --after-context LINES
                        print LINES of trailing context
  -B LINES, --before-context LINES
                        print LINES of leading context
  -C LINES, --context LINES
                        print LINES of surrounding context

```

</details>

Also now allows doing `python -m codespell_lib ...`, which is nice for debugging things like this because you can do `python -im codespell_lib`, then `import pdb; pdb.pm()` on errors.