### PR TITLE
Add the other terms from https://tools.ietf.org/id/draft-knodel-terminology-00.html

### DIFF
--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -1,8 +1,9 @@
 blacklist->blocklist
 blacklists->blocklists
+man-in-the-middle->on-path attacker
 master->primary, leader, active, writer, coordinator, parent,
 masters->primaries, leaders, actives, writers, coordinators, parents,
 slave->secondary, follower, standby, replica, reader, worker, helper,
 slaves->secondaries, followers, standbys, replicas, readers, workers, helpers,
-whitelist->allowlist
-whitelists->allowlists
+whitelist->allowlist, permitlist,
+whitelists->allowlists, permitlists,


### PR DESCRIPTION
I was tempted to add `he->they` too, but I suspect that would have far too many false positives as the former is still acceptable depending on context.