### PR TITLE
Add "researved" spelling correction

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20069,7 +20069,13 @@ prersistent->persistent
 presance->presence
 prescrition->prescription
 prescritions->prescriptions
+presearvation->preservation
+presearvations->preservations
 presearve->preserve
+presearved->preserved
+presearver->preserver
+presearves->preserves
+presearving->preserving
 presedential->presidential
 presenece->presence
 presener->presenter
@@ -22474,6 +22480,7 @@ researvations->reservations
 researve->reserve
 researved->reserved
 researves->reserves
+researving->reserving
 reselction->reselection
 resembelance->resemblance
 resembes->resembles

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22468,6 +22468,7 @@ rescrition->restriction
 rescritions->restrictions
 reseach->research
 reseached->researched
+researved->reserved
 reselction->reselection
 resembelance->resemblance
 resembes->resembles

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22468,7 +22468,10 @@ rescrition->restriction
 rescritions->restrictions
 reseach->research
 reseached->researched
+researvation->reservation
+researvations->reservations
 researved->reserved
+researves->reserves
 reselction->reselection
 resembelance->resemblance
 resembes->resembles

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20069,6 +20069,7 @@ prersistent->persistent
 presance->presence
 prescrition->prescription
 prescritions->prescriptions
+presearve->preserve
 presedential->presidential
 presenece->presence
 presener->presenter

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22470,6 +22470,7 @@ reseach->research
 reseached->researched
 researvation->reservation
 researvations->reservations
+researve->reserve
 researved->reserved
 researves->reserves
 reselction->reselection


### PR DESCRIPTION
This mispelling occurs in several projects: https://grep.app/search?q=researved