### PR TITLE
Add suggestion for acronym-compatible "master/slave" replacements

### DIFF
--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -1,9 +1,9 @@
 blacklist->blocklist
 blacklists->blocklists
 man-in-the-middle->on-path attacker
-master->primary, leader, active, writer, coordinator, parent,
-masters->primaries, leaders, actives, writers, coordinators, parents,
-slave->secondary, follower, standby, replica, reader, worker, helper,
-slaves->secondaries, followers, standbys, replicas, readers, workers, helpers,
+master->primary, leader, active, writer, coordinator, parent, manager, main,
+masters->primaries, leaders, actives, writers, coordinators, parents, managers,
+slave->secondary, follower, standby, replica, reader, worker, helper, subordinate, subsystem,
+slaves->secondaries, followers, standbys, replicas, readers, workers, helpers, subordinates,
 whitelist->allowlist, permitlist,
 whitelists->allowlists, permitlists,


### PR DESCRIPTION
Offer replacement terms for "master/slave" that share the same initials,
so that, eg. SPI buses can reuse MISO/MOSI.

Suggestions are "manager/subordinate" and "main/subsystem", with the
latter only suggested in singular form ("mains" is something else as a
noun).

From https://twitter.com/ktemkin/status/1271605835303489537 and
https://twitter.com/profhummel/status/1271899937647652870