### PR TITLE
Add spelling corrections for drescription

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9796,6 +9796,8 @@ drawm->drawn
 drawng->drawing
 dreasm->dreams
 dreawn->drawn
+drescription->description
+drescriptions->descriptions
 driagram->diagram
 driagrammed->diagrammed
 driagramming->diagramming


### PR DESCRIPTION
The Linux kernel had this misspelling fixed in https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=82efeb161c090072ab493ab8c8f8a551727f586e

And other projects share this misspelling: https://grep.app/search?q=drescription