### PR TITLE
Add --ignore-regex

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -278,7 +278,7 @@ def parse_options(args):
                         help='regular expression which is used to find '
                              'patterns to ignore by treating as whitespace. '
                              'When writing regexes, consider ensuring there '
-                             'is boundary non-word chars, e.g., '
+                             'are boundary non-word chars, e.g., '
                              '"\\Wmatch\\W". Defaults to empty/disabled.')
     parser.add_argument('-I', '--ignore-words',
                         action='append', metavar='FILE',

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -671,7 +671,7 @@ def main(*args):
     try:
         word_regex = re.compile(word_regex)
     except re.error as err:
-        print("ERROR: invalid regular expression \"%s\" (%s)" %
+        print("ERROR: invalid --regex \"%s\" (%s)" %
               (word_regex, err), file=sys.stderr)
         parser.print_help()
         return EX_USAGE
@@ -680,7 +680,7 @@ def main(*args):
         try:
             ignore_word_regex = re.compile(options.ignore_regex)
         except re.error as err:
-            print("ERROR: invalid regular expression \"%s\" (%s)" %
+            print("ERROR: invalid --ignore-regex \"%s\" (%s)" %
                   (options.ignore_regex, err), file=sys.stderr)
             parser.print_help()
             return EX_USAGE

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -478,6 +478,15 @@ def test_ignore_regex_flag(tmpdir, capsys):
     # Ignoring part of the word can result in odd behavior.
     assert cs.main(f.name, '--ignore-regex=nn') == 0
 
+    with open(op.join(d, 'flag.txt'), 'w') as f:
+        f.write('abandonned donn\n')
+    # Test file has 2 invalid entries.
+    assert cs.main(f.name) == 2
+    # Ignoring donn breaks them both.
+    assert cs.main(f.name, '--ignore-regex=donn') == 0
+    # Adding word breaks causes only one to be ignored.
+    assert cs.main(f.name, r'--ignore-regex=\Wdonn\W') == 1
+
 
 @contextlib.contextmanager
 def FakeStdin(text):

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -468,6 +468,9 @@ def test_ignore_regex_flag(tmpdir, capsys):
         f.write('# Please see http://example.com/abandonned for info\n')
     # Test file has 1 invalid entry, and it's not ignored by default.
     assert cs.main(f.name) == 1
+    # An empty regex is the default value, and nothing is ignored.
+    assert cs.main(f.name, '--ignore-regex=') == 1
+    assert cs.main(f.name, '--ignore-regex=""') == 1
     # Non-matching regex results in nothing being ignored.
     assert cs.main(f.name, '--ignore-regex=^$') == 1
     # A word can be ignored.

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import argparse
 import contextlib
 import inspect
 import os
@@ -466,6 +467,8 @@ def test_ignore_regex_flag(tmpdir, capsys):
 
     with open(op.join(d, 'flag.txt'), 'w') as f:
         f.write('# Please see http://example.com/abandonned for info\n')
+    # Test file has 1 invalid entry, and it's not ignored by default.
+    assert cs.main(f.name) == 1
     # Non-matching regex results in nothing being ignored.
     assert cs.main(f.name, '--ignore-regex=^$') == 1
     # A word can be ignored.

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-import argparse
 import contextlib
 import inspect
 import os

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -464,75 +464,14 @@ def test_ignore_regex_flag(tmpdir, capsys):
     assert code == EX_USAGE
     assert 'usage:' in stdout
 
-    # Empty regex matches everything.
     with open(op.join(d, 'flag.txt'), 'w') as f:
         f.write('# Please see http://example.com/abandonned for info\n')
+    # Non-matching regex results in nothing being ignored.
     assert cs.main(f.name, '--ignore-regex=^$') == 1
-
-    # Custom ignore.
-    with open(op.join(d, 'flag.txt'), 'w') as f:
-        f.write('abandonned\n')
+    # A word can be ignored.
     assert cs.main(f.name, '--ignore-regex=abandonned') == 0
-
-
-def test_uri(tmpdir, capsys):
-    """Test ignore regex functionality for URIs."""
-    d = str(tmpdir)
-
-    # Ignoring text in path.
-    with open(op.join(d, 'uri.txt'), 'w') as f:
-        f.write('# Please see http://example.com/abandonned for info\n')
-    assert cs.main(f.name) == 0
-
-    # Test a different protocol.
-    with open(op.join(d, 'uri.txt'), 'w') as f:
-        f.write('# Please see https://example.com/abandonned for info\n')
-    assert cs.main(f.name) == 0
-
-    # Ignoring text in path ending with /.
-    with open(op.join(d, 'uri.txt'), 'w') as f:
-        f.write('# Please see http://example.com/abandonned/ for info\n')
-    assert cs.main(f.name) == 0
-
-    # Ignoring text in domain.
-    with open(op.join(d, 'uri.txt'), 'w') as f:
-        f.write('# Please see http://abandonned.com/example for info\n')
-    assert cs.main(f.name) == 0
-
-    # Ignoring text in anchor.
-    with open(op.join(d, 'uri.txt'), 'w') as f:
-        f.write('# Please see http://example.com/ex#abandonned for info\n')
-    assert cs.main(f.name) == 0
-
-    # Typo because there's no protocol.
-    with open(op.join(d, 'uri.txt'), 'w') as f:
-        f.write('# Please see example.com/abandonned for info\n')
-    assert cs.main(f.name) == 1
-
-    # Typo because there aren't enough domain parts.
-    with open(op.join(d, 'uri.txt'), 'w') as f:
-        f.write('# Please see http://abandonned for info\n')
-    assert cs.main(f.name) == 1
-
-
-def test_email(tmpdir, capsys):
-    """Test ignore regex functionality for emails."""
-    d = str(tmpdir)
-
-    # Ignoring text in username.
-    with open(op.join(d, 'email.txt'), 'w') as f:
-        f.write('# Please contact abandonned@example.com for info\n')
-    assert cs.main(f.name) == 0
-
-    # Ignoring text in domain.
-    with open(op.join(d, 'email.txt'), 'w') as f:
-        f.write('# Please contact example@abandonned.com for info\n')
-    assert cs.main(f.name) == 0
-
-    # Typo because there's no TLD for an email.
-    with open(op.join(d, 'email.txt'), 'w') as f:
-        f.write('# Please contact abandonned@example for info\n')
-    assert cs.main(f.name) == 1
+    # Ignoring part of the word can result in odd behavior.
+    assert cs.main(f.name, '--ignore-regex=nn') == 0
 
 
 @contextlib.contextmanager

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -455,6 +455,26 @@ def test_context(tmpdir, capsys):
     assert 'ERROR' in lines[0]
 
 
+def test_ignore_regex_flag(tmpdir, capsys):
+    """Test ignore regex flag functionality."""
+    d = str(tmpdir)
+
+    # Invalid regex.
+    code, stdout, _ = cs.main('--ignore-regex=(', std=True)
+    assert code == EX_USAGE
+    assert 'usage:' in stdout
+
+    # Empty regex matches everything.
+    with open(op.join(d, 'flag.txt'), 'w') as f:
+        f.write('# Please see http://example.com/abandonned for info\n')
+    assert cs.main(f.name, '--ignore-regex=^$') == 1
+
+    # Custom ignore.
+    with open(op.join(d, 'flag.txt'), 'w') as f:
+        f.write('abandonned\n')
+    assert cs.main(f.name, '--ignore-regex=abandonned') == 0
+
+
 def test_uri(tmpdir, capsys):
     """Test ignore regex functionality for URIs."""
     d = str(tmpdir)
@@ -463,8 +483,6 @@ def test_uri(tmpdir, capsys):
     with open(op.join(d, 'uri.txt'), 'w') as f:
         f.write('# Please see http://example.com/abandonned for info\n')
     assert cs.main(f.name) == 0
-    # Same is a typo with ignores disabled.
-    assert cs.main(f.name, '--ignore-regex=^$') == 1
 
     # Test a different protocol.
     with open(op.join(d, 'uri.txt'), 'w') as f:
@@ -505,8 +523,6 @@ def test_email(tmpdir, capsys):
     with open(op.join(d, 'email.txt'), 'w') as f:
         f.write('# Please contact abandonned@example.com for info\n')
     assert cs.main(f.name) == 0
-    # Same is a typo with ignores disabled.
-    assert cs.main(f.name, '--ignore-regex=^$') == 1
 
     # Ignoring text in domain.
     with open(op.join(d, 'email.txt'), 'w') as f:


### PR DESCRIPTION
This was originally for issue #676, but the preference there is for a different approach. We're keeping it because it may still prove useful, e.g., a regex like (?:[a-fA-F0-9]{0,4}:){2,7}[a-fA-F0-9]{0,4})\\]? could be used to ignore spelling mistakes in ipv6 addresses.

Mechanically, this erases the matching text before the word regex is applied.