### PR TITLE
Add spelling corrections for vulnerab(le|ilit(y|ies)).

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -28674,6 +28674,9 @@ vulnerabuilties->vulnerabilities
 vulnerabuilty->vulnerability
 vulnerabule->vulnerable
 vulnerabulility->vulnerability
+vulnerarbilities->vulnerabilities
+vulnerarbility->vulnerability
+vulnerarble->vulnerable
 vulnerbilities->vulnerabilities
 vulnerbility->vulnerability
 vulnerbuilities->vulnerabilities


### PR DESCRIPTION
While https://grep.app/search?q=vulnerarbility doesn't show any hits github itself and google has a few:

https://github.com/search?q=vulnerarbility&type=Code
https://www.google.com/search?q=%22vulnerarbility%22