### PR TITLE
Unify acknowledgment

### DIFF
--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -1,3 +1,4 @@
+acknowledgement->acknowledgment
 amortised->amortized
 analyse->analyze
 analysed->analyzed


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Spelling 
acknowledgment is the preferred us-american spelling. 