### PR TITLE
Add US spellings of other word-forms for 'standard'

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25111,6 +25111,9 @@ stadnard->standard
 stadnardisation->standardisation
 stadnardised->standardised
 stadnardising->standardising
+stadnardization->standardization
+stadnardized->standardized
+stadnardizing->standardizing
 stadnards->standards
 stae->state
 staement->statement


### PR DESCRIPTION
As requested in #1633 