### PR TITLE
Allow a 1% drop in coverage to not be a failure

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,8 @@
 comment: off
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
We could make it purely informational:
https://docs.codecov.io/docs/commit-status#informational

Given it's not required to pass for merging. Although then we might possibly miss huge drops in coverage.

Triggered by:
LOL, I've got no idea why **codecov/project** isn't happy with this!

_Originally posted by @lurch in https://github.com/codespell-project/codespell/pull/1659#issuecomment-683435451_