### PR TITLE
Read options from config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,30 @@ Want to know if a word you're proposing exists in codespell already? It is possi
     echo "word" | codespell -
     echo "1stword,2ndword" | codespell -
 
+Using a config file
+-------------------
+
+Command line options can also be specific in a config file.
+
+When running ``codespell``, it will check in the current directory for a file
+named ``setup.cfg`` (or a file specified via ``--config``), containing an entry
+named ``[tool:codespell]``. Each command line argument can also be specified in
+this file, for example:
+
+.. code-block:: cfg
+
+    [tool:codespell]
+    skip = *.po,*.ts,./src/3rdParty,./src/Test
+    count =
+    quiet-level = 3
+
+This is equivalent to running::
+
+    codespell --quiet-level 3 --count --skip "*.po,*.ts,./src/3rdParty,./src/Test"
+
+Any options specified in the config file will *override* options from the
+command line.
+
 Dictionary format
 -----------------
 

--- a/README.rst
+++ b/README.rst
@@ -85,10 +85,10 @@ Command line options can also be specific in a config file.
 
 When running ``codespell``, it will check in the current directory for a file
 named ``setup.cfg`` or ``.codespellrc`` (or a file specified via ``--config``),
-containing an entry named ``[tool:codespell]``. Each command line argument can
+containing an entry named ``[codespell]``. Each command line argument can
 also be specified in this file, for example::
 
-    [tool:codespell]
+    [codespell]
     skip = *.po,*.ts,./src/3rdParty,./src/Test
     count =
     quiet-level = 3

--- a/README.rst
+++ b/README.rst
@@ -84,9 +84,9 @@ Using a config file
 Command line options can also be specific in a config file.
 
 When running ``codespell``, it will check in the current directory for a file
-named ``setup.cfg`` (or a file specified via ``--config``), containing an entry
-named ``[tool:codespell]``. Each command line argument can also be specified in
-this file, for example::
+named ``setup.cfg`` or ``.codespellrc`` (or a file specified via ``--config``),
+containing an entry named ``[tool:codespell]``. Each command line argument can
+also be specified in this file, for example::
 
     [tool:codespell]
     skip = *.po,*.ts,./src/3rdParty,./src/Test

--- a/README.rst
+++ b/README.rst
@@ -86,9 +86,7 @@ Command line options can also be specific in a config file.
 When running ``codespell``, it will check in the current directory for a file
 named ``setup.cfg`` (or a file specified via ``--config``), containing an entry
 named ``[tool:codespell]``. Each command line argument can also be specified in
-this file, for example:
-
-.. code-block:: cfg
+this file, for example::
 
     [tool:codespell]
     skip = *.po,*.ts,./src/3rdParty,./src/Test

--- a/README.rst
+++ b/README.rst
@@ -81,12 +81,12 @@ Want to know if a word you're proposing exists in codespell already? It is possi
 Using a config file
 -------------------
 
-Command line options can also be specific in a config file.
+Command line options can also be specified in a config file.
 
 When running ``codespell``, it will check in the current directory for a file
 named ``setup.cfg`` or ``.codespellrc`` (or a file specified via ``--config``),
 containing an entry named ``[codespell]``. Each command line argument can
-also be specified in this file, for example::
+be specified in this file (without the preceding dashes), for example::
 
     [codespell]
     skip = *.po,*.ts,./src/3rdParty,./src/Test

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,8 @@ This is equivalent to running::
 
     codespell --quiet-level 3 --count --skip "*.po,*.ts,./src/3rdParty,./src/Test"
 
-Any options specified in the config file will *override* options from the
-command line.
+Any options specified in the command line will *override* options from the
+config file.
 
 Dictionary format
 -----------------

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -372,8 +372,12 @@ def parse_options(args):
     options = parser.parse_args(list(args))
 
     # Load config files and look for ``tool:codespell`` options.
-    if os.path.exists('setup.cfg') or options.config:
-        cfg_files = ['setup.cfg']
+    if (
+        options.config or
+        os.path.exists('setup.cfg') or
+        os.path.exists('.codespellrc')
+    ):
+        cfg_files = ['setup.cfg', '.codespellrc']
         if options.config:
             cfg_files.append(options.config)
         config = configparser.ConfigParser()

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -371,7 +371,7 @@ def parse_options(args):
     # Parse command line options.
     options = parser.parse_args(list(args))
 
-    # Load config files and look for ``tool:codespell`` options.
+    # Load config files and look for ``codespell`` options.
     if (
         options.config
         or os.path.exists('setup.cfg')
@@ -383,14 +383,14 @@ def parse_options(args):
         config = configparser.ConfigParser()
         config.read(cfg_files)
 
-        if config.has_section('tool:codespell'):
+        if config.has_section('codespell'):
             # Build a "fake" argv list using option name and value.
             cfg_args = []
-            for key in config['tool:codespell']:
+            for key in config['codespell']:
                 # Add option as arg.
                 cfg_args.append("--%s" % key)
                 # If value is blank, skip.
-                val = config['tool:codespell'][key]
+                val = config['codespell'][key]
                 if val != "":
                     cfg_args.append(val)
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -372,33 +372,28 @@ def parse_options(args):
     options = parser.parse_args(list(args))
 
     # Load config files and look for ``codespell`` options.
-    if (
-        options.config
-        or os.path.exists('setup.cfg')
-        or os.path.exists('.codespellrc')
-    ):
-        cfg_files = ['setup.cfg', '.codespellrc']
-        if options.config:
-            cfg_files.append(options.config)
-        config = configparser.ConfigParser()
-        config.read(cfg_files)
+    cfg_files = ['setup.cfg', '.codespellrc']
+    if options.config:
+        cfg_files.append(options.config)
+    config = configparser.ConfigParser()
+    config.read(cfg_files)
 
-        if config.has_section('codespell'):
-            # Build a "fake" argv list using option name and value.
-            cfg_args = []
-            for key in config['codespell']:
-                # Add option as arg.
-                cfg_args.append("--%s" % key)
-                # If value is blank, skip.
-                val = config['codespell'][key]
-                if val != "":
-                    cfg_args.append(val)
+    if config.has_section('codespell'):
+        # Build a "fake" argv list using option name and value.
+        cfg_args = []
+        for key in config['codespell']:
+            # Add option as arg.
+            cfg_args.append("--%s" % key)
+            # If value is blank, skip.
+            val = config['codespell'][key]
+            if val != "":
+                cfg_args.append(val)
 
-            # Parse config file options.
-            options = parser.parse_args(cfg_args)
+        # Parse config file options.
+        options = parser.parse_args(cfg_args)
 
-            # Re-parse command line options to override config.
-            options = parser.parse_args(list(args), namespace=options)
+        # Re-parse command line options to override config.
+        options = parser.parse_args(list(args), namespace=options)
 
     if not options.files:
         options.files.append('.')

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -394,12 +394,11 @@ def parse_options(args):
                 if val != "":
                     cfg_args.append(val)
 
-            # Positional-only args cannot be specified in config file, so pass
-            # through original positional command line args.
-            cfg_args += options.files
+            # Parse config file options.
+            options = parser.parse_args(cfg_args)
 
-            # Parse config file options to override command line options.
-            options = parser.parse_args(cfg_args, namespace=options)
+            # Re-parse command line options to override config.
+            options = parser.parse_args(list(args), namespace=options)
 
     if not options.files:
         options.files.append('.')

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -390,6 +390,10 @@ def parse_options(args):
                 if val != "":
                     cfg_args.append(val)
 
+            # Positional-only args cannot be specified in config file, so pass
+            # through original positional command line args.
+            cfg_args += options.files
+
             # Parse config file options to override command line options.
             options = parser.parse_args(cfg_args, namespace=options)
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -373,9 +373,9 @@ def parse_options(args):
 
     # Load config files and look for ``tool:codespell`` options.
     if (
-        options.config or
-        os.path.exists('setup.cfg') or
-        os.path.exists('.codespellrc')
+        options.config
+        or os.path.exists('setup.cfg')
+        or os.path.exists('.codespellrc')
     ):
         cfg_files = ['setup.cfg', '.codespellrc']
         if options.config:

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -488,6 +488,37 @@ def test_ignore_regex_flag(tmpdir, capsys):
     assert cs.main(f.name, r'--ignore-regex=\Wdonn\W') == 1
 
 
+def test_config(tmpdir, capsys):
+    """
+    Tests loading options from a config file.
+    """
+    d = str(tmpdir)
+
+    # Create sample files.
+    with open(op.join(d, 'bad.c'), 'w') as f:
+        f.write('abandonned donn\n')
+    with open(op.join(d, 'good.c'), 'w') as f:
+        f.write("good")
+
+    # Create a config file.
+    with open(op.join(d, 'config.cfg'), 'w') as f:
+        f.write(
+            '[tool:codespell]\n'
+            'skip = *bad.c\n'
+            'count = \n'
+        )
+
+    # Should fail when checking both.
+    code, stdout, _ = cs.main(count=False, std=True)
+    assert code == EX_DATAERR
+    assert 'bad.c' in stdout
+
+    # Should pass when skipping bad.c
+    code, stdout, _ = cs.main('--config config.cfg', count=False, std=True)
+    assert code == EX_OK
+    assert 'bad.c' in stdout
+
+
 @contextlib.contextmanager
 def FakeStdin(text):
     if sys.version[0] == '2':

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -504,7 +504,7 @@ def test_config(tmpdir, capsys):
     conffile = op.join(d, 'config.cfg')
     with open(conffile, 'w') as f:
         f.write(
-            '[tool:codespell]\n'
+            '[codespell]\n'
             'skip = bad.txt\n'
             'count = \n'
         )

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -495,28 +495,30 @@ def test_config(tmpdir, capsys):
     d = str(tmpdir)
 
     # Create sample files.
-    with open(op.join(d, 'bad.c'), 'w') as f:
+    with open(op.join(d, 'bad.txt'), 'w') as f:
         f.write('abandonned donn\n')
-    with open(op.join(d, 'good.c'), 'w') as f:
+    with open(op.join(d, 'good.txt'), 'w') as f:
         f.write("good")
 
     # Create a config file.
-    with open(op.join(d, 'config.cfg'), 'w') as f:
+    conffile = op.join(d, 'config.cfg')
+    with open(conffile, 'w') as f:
         f.write(
             '[tool:codespell]\n'
-            'skip = *bad.c,*config.cfg\n'
+            'skip = bad.txt\n'
             'count = \n'
         )
 
     # Should fail when checking both.
-    code, stdout, _ = cs.main(count=False, std=True)
-    assert code == EX_DATAERR
-    assert 'bad.c' in stdout
+    code, stdout, _ = cs.main(d, count=True, std=True)
+    # Code in this case is not exit code, but count of misspellings.
+    assert code == 2
+    assert 'bad.txt' in stdout
 
-    # Should pass when skipping bad.c
-    code, stdout, _ = cs.main('--config config.cfg', count=False, std=True)
-    assert code == EX_OK
-    assert 'bad.c' not in stdout
+    # Should pass when skipping bad.txt
+    code, stdout, _ = cs.main('--config', conffile, d, count=True, std=True)
+    assert code == 0
+    assert 'bad.txt' not in stdout
 
 
 @contextlib.contextmanager

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -504,7 +504,7 @@ def test_config(tmpdir, capsys):
     with open(op.join(d, 'config.cfg'), 'w') as f:
         f.write(
             '[tool:codespell]\n'
-            'skip = *bad.c\n'
+            'skip = *bad.c,*config.cfg\n'
             'count = \n'
         )
 
@@ -516,7 +516,7 @@ def test_config(tmpdir, capsys):
     # Should pass when skipping bad.c
     code, stdout, _ = cs.main('--config config.cfg', count=False, std=True)
     assert code == EX_OK
-    assert 'bad.c' in stdout
+    assert 'bad.c' not in stdout
 
 
 @contextlib.contextmanager

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,5 @@ addopts = --cov=codespell_lib --showlocals -rs --cov-report=
 
 [flake8]
 exclude = build, ci-helpers
-ignore =
+# W503 and W504 are mutually exclusive, must choose one.
+ignore = W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,4 @@ addopts = --cov=codespell_lib --showlocals -rs --cov-report=
 
 [flake8]
 exclude = build, ci-helpers
-# W503 and W504 are mutually exclusive, must choose one.
-ignore = W503
+ignore =


### PR DESCRIPTION
This adds the ability to read options from a config file, such as setup.cfg, similar to how most other python tools work.

* Documented in README.
* Added basic unit test.