### PR TITLE
Add stuido->studio (and similar)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -24516,6 +24516,7 @@ situatution->situation
 situatutions->situations
 situbbornness->stubbornness
 situdio->studio
+situdios->studios
 siturations->situations
 situtation->situation
 situtations->situations
@@ -25468,9 +25469,12 @@ stucture->structure
 stuctured->structured
 stuctures->structures
 studdy->study
-studi->study
+studi->study, studio,
+studis->studies, studios,
 studing->studying
 stuggling->struggling
+stuido->studio
+stuidos->studios
 stuill->still
 stummac->stomach
 sturcture->structure

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25472,6 +25472,8 @@ studdy->study
 studi->study, studio,
 studing->studying
 studis->studies, studios,
+studoi->studio
+studois->studios
 stuggling->struggling
 stuido->studio
 stuidos->studios

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25470,8 +25470,8 @@ stuctured->structured
 stuctures->structures
 studdy->study
 studi->study, studio,
-studis->studies, studios,
 studing->studying
+studis->studies, studios,
 stuggling->struggling
 stuido->studio
 stuidos->studios

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -26,6 +26,7 @@ secants->seconds
 seeked->sought
 sinc->sync, sink, since,
 sincs->syncs, sinks, since,
+stdio->studio
 stoll->still
 storaged->storage, stored,
 storaget->storage

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -27,6 +27,7 @@ seeked->sought
 sinc->sync, sink, since,
 sincs->syncs, sinks, since,
 stdio->studio
+stdios->studios
 stoll->still
 storaged->storage, stored,
 storaget->storage


### PR DESCRIPTION
EDIT: Just to clarify... I found `stuido` as a genuine typo in an internal project (in the context of "Visual Stuido Code"), so I thought whilst adding that typo I might as well add a bunch of similar typos for the same word too :slightly_smiling_face: 