### PR TITLE
Add a few new misspellings seen in the wild

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3272,7 +3272,7 @@ avriant->variant
 avriants->variants
 avtive->active
 awared->awarded
-aways->always
+aways->always, away,
 aweful->awful
 awefully->awfully
 awnser->answer
@@ -26115,6 +26115,7 @@ swalloed->swallowed
 swaped->swapped
 swapiness->swappiness
 swaping->swapping
+swarmin->swarming
 swcloumns->swcolumns
 swepth->swept
 swich->switch
@@ -29120,6 +29121,8 @@ windoes->windows
 windos->windows
 windwo->window
 winn->win
+winndow->window
+winndows->windows
 winodw->window
 wipoing->wiping
 wirded->wired, weird,


### PR DESCRIPTION
Specifically:
aways -> away
swarmin -> swarming
winndows -> windows