### PR TITLE
Add tests for aspell dictionaries different from 'en'

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -60,7 +60,7 @@ _builtin_dictionaries = (
     ('names', 'for valid proper names that might be typos', '_names',
         None, None, None, None,),
     ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US',  # noqa: E501
-        True, True, ('en_GB',), ('en_US',)),  # noqa: E501
+        True, True, ('en_GB',), ('en_US',)),
 )
 _builtin_default = 'clear,rare'
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -35,6 +35,8 @@ USAGE = """
 """
 VERSION = '2.0.dev0'
 
+supported_languages = ('en', 'en_GB-ise', 'en_US', 'en_CA', 'en_AU')
+
 # Users might want to link this file into /usr/local/bin, so we resolve the
 # symbolic link path to the real path if necessary.
 _data_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -48,7 +50,7 @@ _builtin_dictionaries = (
     ('usage', 'for recommended terms', '_usage', None, None),
     ('code', 'for words common to code and/or mathematics', '_code', None, None),  # noqa: E501
     ('names', 'for valid proper names that might be typos', '_names', None, None),  # noqa: E501
-    ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US', True, True),  # noqa: E501
+    ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US', ('en_GB-ise',), ('en_US',)),  # noqa: E501
 )
 _builtin_default = 'clear,rare'
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -42,7 +42,9 @@ supported_languages = supported_languages_en
 # symbolic link path to the real path if necessary.
 _data_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 _builtin_dictionaries = (
-    # name, desc, name, err in aspell, correction in aspell
+    # name, desc, name, err in aspell, correction in aspell, \
+    # err dictionary array, rep dictionary array
+    # The arrays must contain the names of aspell dictionaries
     # The aspell tests here aren't the ideal state, but the None's are
     # realistic for obscure words
     ('clear', 'for unambiguous errors', '',
@@ -54,9 +56,9 @@ _builtin_dictionaries = (
     ('usage', 'for recommended terms', '_usage',
         None, None, None, None),
     ('code', 'for words common to code and/or mathematics', '_code',
-        None, None, None, None,),  # noqa: E501
+        None, None, None, None,),
     ('names', 'for valid proper names that might be typos', '_names',
-        None, None, None, None,),  # noqa: E501
+        None, None, None, None,),
     ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US',  # noqa: E501
         True, True, ('en_GB',), ('en_US',)),  # noqa: E501
 )

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -35,7 +35,7 @@ USAGE = """
 """
 VERSION = '2.0.dev0'
 
-supported_languages = ('en', 'en_GB-ise', 'en_US', 'en_CA', 'en_AU')
+supported_languages = ('en', 'en_GB-ise', 'en_US')
 
 # Users might want to link this file into /usr/local/bin, so we resolve the
 # symbolic link path to the real path if necessary.

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -35,7 +35,7 @@ USAGE = """
 """
 VERSION = '2.0.dev0'
 
-supported_languages = ('en', 'en_GB-ise', 'en_US')
+supported_languages = ('en', 'en_GB-ise', 'en_US', 'en_CA', 'en_AU')
 
 # Users might want to link this file into /usr/local/bin, so we resolve the
 # symbolic link path to the real path if necessary.

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -35,7 +35,7 @@ USAGE = """
 """
 VERSION = '2.0.dev0'
 
-supported_languages = ('en', 'en_GB-ise', 'en_US', 'en_CA', 'en_AU')
+supported_languages = ('en', 'en_GB', 'en_US', 'en_CA', 'en_AU')
 
 # Users might want to link this file into /usr/local/bin, so we resolve the
 # symbolic link path to the real path if necessary.
@@ -50,7 +50,7 @@ _builtin_dictionaries = (
     ('usage', 'for recommended terms', '_usage', None, None),
     ('code', 'for words common to code and/or mathematics', '_code', None, None),  # noqa: E501
     ('names', 'for valid proper names that might be typos', '_names', None, None),  # noqa: E501
-    ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US', ('en_GB-ise',), ('en_US',)),  # noqa: E501
+    ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US', ('en_GB',), ('en_US',)),  # noqa: E501
 )
 _builtin_default = 'clear,rare'
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -35,7 +35,8 @@ USAGE = """
 """
 VERSION = '2.0.dev0'
 
-supported_languages = ('en', 'en_GB', 'en_US', 'en_CA', 'en_AU')
+supported_languages_en = ('en', 'en_GB', 'en_US', 'en_CA', 'en_AU')
+supported_languages = supported_languages_en
 
 # Users might want to link this file into /usr/local/bin, so we resolve the
 # symbolic link path to the real path if necessary.
@@ -44,13 +45,20 @@ _builtin_dictionaries = (
     # name, desc, name, err in aspell, correction in aspell
     # The aspell tests here aren't the ideal state, but the None's are
     # realistic for obscure words
-    ('clear', 'for unambiguous errors', '', False, None),
-    ('rare', 'for rare but valid words', '_rare', None, None),
-    ('informal', 'for informal words', '_informal', True, True),
-    ('usage', 'for recommended terms', '_usage', None, None),
-    ('code', 'for words common to code and/or mathematics', '_code', None, None),  # noqa: E501
-    ('names', 'for valid proper names that might be typos', '_names', None, None),  # noqa: E501
-    ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US', ('en_GB',), ('en_US',)),  # noqa: E501
+    ('clear', 'for unambiguous errors', '',
+        False, None, supported_languages_en, None),
+    ('rare', 'for rare but valid words', '_rare',
+        None, None, None, None),
+    ('informal', 'for informal words', '_informal',
+        True, True, supported_languages_en, supported_languages_en),
+    ('usage', 'for recommended terms', '_usage',
+        None, None, None, None),
+    ('code', 'for words common to code and/or mathematics', '_code',
+        None, None, None, None,),  # noqa: E501
+    ('names', 'for valid proper names that might be typos', '_names',
+        None, None, None, None,),  # noqa: E501
+    ('en-GB_to_en-US', 'for corrections from en-GB to en-US', '_en-GB_to_en-US',  # noqa: E501
+        True, True, ('en_GB',), ('en_US',)),  # noqa: E501
 )
 _builtin_default = 'clear,rare'
 

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -75,7 +75,7 @@ def _check_aspell(phrase, msg, in_aspell, fname):
     elif in_aspell is False:
         languages = supported_languages
     elif in_aspell is True:
-        languages = ('en',)
+        languages = supported_languages
     else:
         languages = in_aspell
     if ' ' in phrase:

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -73,19 +73,19 @@ def _check_aspell(phrase, msg, in_aspell, fname):
     if in_aspell is None:
         return  # don't check
     elif in_aspell is False:
-        language = supported_languages
+        languages = supported_languages
     elif in_aspell is True:
-        language = ('en',)
+        languages = ('en',)
     else:
-        language = in_aspell
+        languages = in_aspell
     if ' ' in phrase:
         for word in phrase.split():
             _check_aspell(word, msg, in_aspell, fname)
         return  # stop normal checking as we've done each word above
     this_in_aspell = any(spellers[lang].check(phrase.encode(
-        spellers[lang].ConfigKeys()['encoding'][1])) for lang in language)
+        spellers[lang].ConfigKeys()['encoding'][1])) for lang in languages)
     end = 'be in aspell dictionaries %s for dictionary %s' % (
-        ' '.join(map(str, language)), fname,)
+        ' '.join(languages), fname,)
     if in_aspell:  # should be an error in aspell
         assert this_in_aspell, '%s should %s' % (msg, end)
     else:  # shouldn't be

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -74,7 +74,7 @@ def _check_aspell(phrase, msg, in_aspell, fname):
         return  # don't check
     elif in_aspell is False or in_aspell is True:
         languages = supported_languages
-    else:  # in_aspell is a costum array of dictionary names
+    else:  # in_aspell is a custom array of dictionary names
         languages = in_aspell
     if ' ' in phrase:
         for word in phrase.split():

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -79,12 +79,11 @@ def _check_aspell(phrase, msg, in_aspell, fname, languages):
     this_in_aspell = any(spellers[lang].check(phrase.encode(
         spellers[lang].ConfigKeys()['encoding'][1])) for lang in languages)
     end = 'be in aspell dictionaries (%s) for dictionary %s' % (
-        ', '.join(languages), fname,)
+        ', '.join(languages), fname)
     if in_aspell:  # should be an error in aspell
         assert this_in_aspell, '%s should %s' % (msg, end)
     else:  # shouldn't be
         assert not this_in_aspell, '%s should not %s' % (msg, end)
-        return this_in_aspell
 
 
 def _check_err_rep(err, rep, in_aspell, fname, languages):

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -14,6 +14,7 @@ try:
     import aspell
     speller = aspell.Speller('lang', 'en')
     spellerGB = aspell.Speller('lang', 'en_GB-ise')
+    speller_array= (speller, spellerGB)
 except Exception as exp:  # probably ImportError, but maybe also language
     speller = None
     if os.getenv('REQUIRE_ASPELL', 'false').lower() == 'true':
@@ -74,11 +75,8 @@ def _check_aspell(phrase, msg, in_aspell, fname):
         for word in phrase.split():
             _check_aspell(word, msg, in_aspell, fname)
         return  # stop normal checking as we've done each word above
-    this_in_aspell = speller.check(
-        phrase.encode(speller.ConfigKeys()['encoding'][1]))
-    if not this_in_aspell:
-        this_in_aspell = spellerGB.check(
-            phrase.encode(spellerGB.ConfigKeys()['encoding'][1]))
+    this_in_aspell = any(sp.check(phrase.encode(
+        sp.ConfigKeys()['encoding'][1])) for sp in speller_array)
     end = 'be in aspell for dictionary %s' % (fname,)
     if in_aspell:  # should be an error in aspell
         assert this_in_aspell, '%s should %s' % (msg, end)

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -17,6 +17,7 @@ try:
     for lang in supported_languages:
         spellers[lang] = aspell.Speller('lang', lang)
 except Exception as exp:  # probably ImportError, but maybe also language
+    spellers = dict()
     if os.getenv('REQUIRE_ASPELL', 'false').lower() == 'true':
         raise RuntimeError(
             'Cannot run complete tests without aspell when '

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -13,7 +13,7 @@ from codespell_lib._codespell import _builtin_dictionaries
 try:
     import aspell
     speller = aspell.Speller('lang', 'en')
-    speller2 = aspell.Speller('lang', 'en_GB-ise')
+    spellerGB = aspell.Speller('lang', 'en_GB-ise')
 except Exception as exp:  # probably ImportError, but maybe also language
     speller = None
     if os.getenv('REQUIRE_ASPELL', 'false').lower() == 'true':
@@ -77,8 +77,8 @@ def _check_aspell(phrase, msg, in_aspell, fname):
     this_in_aspell = speller.check(
         phrase.encode(speller.ConfigKeys()['encoding'][1]))
     if not this_in_aspell:
-        this_in_aspell = speller2.check(
-            phrase.encode(speller2.ConfigKeys()['encoding'][1]))
+        this_in_aspell = spellerGB.check(
+            phrase.encode(spellerGB.ConfigKeys()['encoding'][1]))
     end = 'be in aspell for dictionary %s' % (fname,)
     if in_aspell:  # should be an error in aspell
         assert this_in_aspell, '%s should %s' % (msg, end)

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -180,7 +180,8 @@ def test_error_checking(err, rep, match):
 def test_error_checking_in_aspell(err, rep, err_aspell, rep_aspell, match):
     """Test that our error checking works with aspell."""
     with pytest.raises(AssertionError, match=match):
-        _check_err_rep(err, rep, (err_aspell, rep_aspell), 'dummy', supported_languages)
+        _check_err_rep(
+            err, rep, (err_aspell, rep_aspell), 'dummy', supported_languages)
 
 
 # allow some duplicates, like "m-i-n-i-m-i-s-e", or "c-a-l-c-u-l-a-t-a-b-l-e"

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -68,7 +68,7 @@ def test_dictionary_formatting(fname, in_aspell):
 
 
 def _check_aspell(phrase, msg, in_aspell, fname):
-    if not bool(spellers):  # if no spellcheckers exist
+    if not spellers:  # if no spellcheckers exist
         return  # cannot check
     if in_aspell is None:
         return  # don't check
@@ -86,10 +86,10 @@ def _check_aspell(phrase, msg, in_aspell, fname):
         spellers[lang].ConfigKeys()['encoding'][1])) for lang in language)
     end = 'be in aspell dictionaries %s for dictionary %s' % (
         ' '.join(map(str, language)), fname,)
-    if not in_aspell:  # should be an error in aspell
-        assert not this_in_aspell, '%s should not %s' % (msg, end)
-    else:  # shouldn't be
+    if in_aspell:  # should be an error in aspell
         assert this_in_aspell, '%s should %s' % (msg, end)
+    else:  # shouldn't be
+        assert not this_in_aspell, '%s should not %s' % (msg, end)
 
 
 def _check_err_rep(err, rep, in_aspell, fname):
@@ -156,7 +156,7 @@ def test_error_checking(err, rep, match):
         _check_err_rep(err, rep, (None, None), 'dummy')
 
 
-@pytest.mark.skipif(not bool(spellers), reason='requires aspell-en')
+@pytest.mark.skipif(not spellers, reason='requires aspell-en')
 @pytest.mark.parametrize('err, rep, err_aspell, rep_aspell, match', [
     # This doesn't raise any exceptions, so skip for now:
     # pytest.param('a', 'uvw, bar,', None, None, 'should be in aspell'),

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -13,6 +13,7 @@ from codespell_lib._codespell import _builtin_dictionaries
 try:
     import aspell
     speller = aspell.Speller('lang', 'en')
+    speller2 = aspell.Speller('lang', 'en_GB-ise')
 except Exception as exp:  # probably ImportError, but maybe also language
     speller = None
     if os.getenv('REQUIRE_ASPELL', 'false').lower() == 'true':
@@ -75,6 +76,9 @@ def _check_aspell(phrase, msg, in_aspell, fname):
         return  # stop normal checking as we've done each word above
     this_in_aspell = speller.check(
         phrase.encode(speller.ConfigKeys()['encoding'][1]))
+    if not this_in_aspell:
+        this_in_aspell = speller2.check(
+            phrase.encode(speller2.ConfigKeys()['encoding'][1]))
     end = 'be in aspell for dictionary %s' % (fname,)
     if in_aspell:  # should be an error in aspell
         assert this_in_aspell, '%s should %s' % (msg, end)

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -72,11 +72,9 @@ def _check_aspell(phrase, msg, in_aspell, fname):
         return  # cannot check
     if in_aspell is None:
         return  # don't check
-    elif in_aspell is False:
+    elif in_aspell is False or in_aspell is True:
         languages = supported_languages
-    elif in_aspell is True:
-        languages = supported_languages
-    else:
+    else:  # in_aspell is a costum array of dictionary names
         languages = in_aspell
     if ' ' in phrase:
         for word in phrase.split():

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -78,8 +78,8 @@ def _check_aspell(phrase, msg, in_aspell, fname, languages):
         return  # stop normal checking as we've done each word above
     this_in_aspell = any(spellers[lang].check(phrase.encode(
         spellers[lang].ConfigKeys()['encoding'][1])) for lang in languages)
-    end = 'be in aspell dictionaries %s for dictionary %s' % (
-        ' '.join(languages), fname,)
+    end = 'be in aspell dictionaries (%s) for dictionary %s' % (
+        ', '.join(languages), fname,)
     if in_aspell:  # should be an error in aspell
         assert this_in_aspell, '%s should %s' % (msg, end)
     else:  # shouldn't be

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -39,7 +39,7 @@ _data_dir = op.join(op.dirname(__file__), '..', 'data')
 _fnames_in_aspell = [
     (op.join(_data_dir, 'dictionary%s.txt' % d[2]), d[3:5], d[5:7])
     for d in _builtin_dictionaries]
-fname_params = pytest.mark.parametrize('fname, in_aspell, in_dictionary', _fnames_in_aspell)
+fname_params = pytest.mark.parametrize('fname, in_aspell, in_dictionary', _fnames_in_aspell)  # noqa: E501
 
 
 def test_dictionaries_exist():
@@ -149,7 +149,8 @@ def _check_err_rep(err, rep, in_aspell, fname, languages):
 def test_error_checking(err, rep, match):
     """Test that our error checking works."""
     with pytest.raises(AssertionError, match=match):
-        _check_err_rep(err, rep, (None, None), 'dummy', (supported_languages, supported_languages))
+        _check_err_rep(err, rep, (None, None), 'dummy',
+                       (supported_languages, supported_languages))
 
 
 @pytest.mark.skipif(not spellers, reason='requires aspell-en')
@@ -181,7 +182,8 @@ def test_error_checking_in_aspell(err, rep, err_aspell, rep_aspell, match):
     """Test that our error checking works with aspell."""
     with pytest.raises(AssertionError, match=match):
         _check_err_rep(
-            err, rep, (err_aspell, rep_aspell), 'dummy', (supported_languages, supported_languages))
+            err, rep, (err_aspell, rep_aspell), 'dummy',
+            (supported_languages, supported_languages))
 
 
 # allow some duplicates, like "m-i-n-i-m-i-s-e", or "c-a-l-c-u-l-a-t-a-b-l-e"

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -14,7 +14,7 @@ try:
     import aspell
     speller = aspell.Speller('lang', 'en')
     spellerGB = aspell.Speller('lang', 'en_GB-ise')
-    speller_array= (speller, spellerGB)
+    speller_array = (speller, spellerGB)
 except Exception as exp:  # probably ImportError, but maybe also language
     speller = None
     if os.getenv('REQUIRE_ASPELL', 'false').lower() == 'true':

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -11,13 +11,13 @@ import pytest
 from codespell_lib._codespell import _builtin_dictionaries
 from codespell_lib._codespell import supported_languages
 
+spellers = dict()
+
 try:
     import aspell
-    spellers = dict()
     for lang in supported_languages:
         spellers[lang] = aspell.Speller('lang', lang)
 except Exception as exp:  # probably ImportError, but maybe also language
-    spellers = dict()
     if os.getenv('REQUIRE_ASPELL', 'false').lower() == 'true':
         raise RuntimeError(
             'Cannot run complete tests without aspell when '

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -73,7 +73,7 @@ def _check_aspell(phrase, msg, in_aspell, fname, language=('en',)):
         return  # don't check
     if ' ' in phrase:
         for word in phrase.split():
-            _check_aspell(word, msg, in_aspell, fname)
+            _check_aspell(word, msg, in_aspell, fname, language)
         return  # stop normal checking as we've done each word above
     this_in_aspell = any(spellers[lang].check(phrase.encode(
         spellers[lang].ConfigKeys()['encoding'][1])) for lang in language)

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -84,6 +84,7 @@ def _check_aspell(phrase, msg, in_aspell, fname, languages):
         assert this_in_aspell, '%s should %s' % (msg, end)
     else:  # shouldn't be
         assert not this_in_aspell, '%s should not %s' % (msg, end)
+        return this_in_aspell
 
 
 def _check_err_rep(err, rep, in_aspell, fname, languages):

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -83,7 +83,8 @@ def _check_aspell(phrase, msg, in_aspell, fname):
         return  # stop normal checking as we've done each word above
     this_in_aspell = any(spellers[lang].check(phrase.encode(
         spellers[lang].ConfigKeys()['encoding'][1])) for lang in language)
-    end = 'be in aspell for dictionary %s' % (fname,)
+    end = 'be in aspell dictionaries %s for dictionary %s' % (
+        ' '.join(map(str, language)), fname,)
     if not in_aspell:  # should be an error in aspell
         assert not this_in_aspell, '%s should not %s' % (msg, end)
     else:  # shouldn't be


### PR DESCRIPTION
This adds additional tests in the en_GB-ise dictionary. 

I can add en_CA and en_AU too

Closes #1689 