### PR TITLE
Add spelling corrections for resoruce

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -23128,6 +23128,8 @@ resopnses->responses
 resorce->resource
 resorces->resources
 resore->restore
+resoruce->resource
+resoruces->resources
 resouce->resource
 resouces->resources
 resoultion->resolution

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22037,7 +22037,9 @@ recordproducer->record producer
 recored->recorded
 recoriding->recording
 recource->resource
+recourced->resourced
 recources->resources
+recourcing->resourcing
 recquired->required
 recrational->recreational
 recreateation->recreation
@@ -22786,7 +22788,10 @@ reorginised->reorganised
 reorginized->reorganized
 reosnable->reasonable
 reosne->reason
+reosurce->resource
+reosurced->resourced
 reosurces->resources
+reosurcing->resourcing
 reounded->rounded
 reouted->routed, rerouted,
 repace->replace
@@ -23059,7 +23064,9 @@ resaurant->restaurant
 resaurants->restaurants
 rescaned->rescanned
 rescource->resource
+rescourced->resourced
 rescources->resources
+rescourcing->resourcing
 rescrition->restriction
 rescritions->restrictions
 reseach->research
@@ -23113,6 +23120,9 @@ resluts->results
 resoect->respect
 resoective->respective
 resoiurce->resource
+resoiurced->resourced
+resoiurces->resources
+resoiurcing->resourcing
 resoltion->resolution
 resoluitons->resolutions
 resoluton->resolution
@@ -23122,20 +23132,29 @@ resons->reasons
 resonse->response
 resonses->responses
 resoource->resource
+resoourced->resourced
 resoources->resources
+resoourcing->resourcing
 resopnse->response
 resopnses->responses
 resorce->resource
+resorced->resourced
 resorces->resources
+resorcing->resourcing
 resore->restore
 resoruce->resource
+resoruced->resourced
 resoruces->resources
+resorucing->resourcing
 resouce->resource
+resouced->resourced
 resouces->resources
+resoucing->resourcing
 resoultion->resolution
 resoultions->resolutions
 resourceype->resourcetype
 resoure->resource
+resoured->resourced
 resoures->resources
 resoution->resolution
 resoves->resolves
@@ -23182,6 +23201,9 @@ resposne->response
 resposnes->responses
 resquest->request
 resrouce->resource
+resrouced->resourced
+resrouces->resources
+resroucing->resourcing
 resrved->reserved
 ressapee->recipe
 ressemblance->resemblance
@@ -23194,7 +23216,9 @@ ressetting->resetting
 ressize->resize
 ressizes->resizes
 ressource->resource
+ressourced->resourced
 ressources->resources
+ressourcing->resourcing
 resssurecting->resurrecting
 ressult->result
 ressurect->resurrect
@@ -23257,7 +23281,13 @@ resumbmitting->resubmitting
 resumitted->resubmitted
 resumt->resume
 resuorce->resource
+resuorced->resourced
+resuorces->resources
+resuorcing->resourcing
 resurce->resource
+resurced->resourced
+resurces->resources
+resurcing->resourcing
 resurecting->resurrecting
 resurse->recurse, resource,
 resursive->recursive, resourceful,
@@ -23542,6 +23572,9 @@ rranslations->translations
 rrase->erase
 rsizing->resizing
 rsource->resource
+rsourced->resourced
+rsources->resources
+rsourcing->resourcing
 rturns->returns
 rubarb->rhubarb
 rucuperate->recuperate


### PR DESCRIPTION
Many projects use "Resoruce" instead of "Resource": https://grep.app/search?q=resoruce