### PR TITLE
Add spelling corrections for tamplate

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -26385,6 +26385,10 @@ takslet->tasklet
 talbe->table
 talekd->talked
 tallerable->tolerable
+tamplate->template
+tamplated->templated
+tamplates->templates
+tamplating->templating
 tangeant->tangent
 tangeantial->tangential
 tangeants->tangents


### PR DESCRIPTION
Many projects use "Tamplate" (and derivatives) instead of "Template": https://grep.app/search?q=tamplate