### PR TITLE
Add spelling corrections for securiy and securiyt

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -23866,6 +23866,8 @@ secue->secure
 secuely->securely
 secuity->security
 secund->second
+securiy->security
+securiyt->security
 securly->securely
 securre->secure
 securrely->securely


### PR DESCRIPTION
Many projects forget the T or swap T and Y in "Security": https://grep.app/search?q=securiy and https://grep.app/search?q=securiyt