### PR TITLE
Add spelling corrections for script(s).

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25376,6 +25376,8 @@ srink->shrink
 srinkd->shrunk
 srinked->shrunk
 srinking->shrinking
+sript->script
+sripts->scripts
 srollbar->scrollbar
 srouce->source
 srting->string, sorting,


### PR DESCRIPTION
See e.g.:

https://grep.app/search?q=sripts&words=true \
https://grep.app/search?q=sript&words=true

There seems to be a urban dictionary existing here:

https://www.urbandictionary.com/define.php?term=Sript

but IMHO `script` is a too common term in coding to not check for `sript`.