### PR TITLE
Dict: Add plural of comma

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5467,6 +5467,7 @@ commansd->commands
 commant->command, comment,
 commanted->commanded, commented,
 commants->commands, comments,
+commata->commas
 commect->connect
 commected->connected
 commecting->connecting

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5467,7 +5467,7 @@ commansd->commands
 commant->command, comment,
 commanted->commanded, commented,
 commants->commands, comments,
-commata->commas
+commatas->commas, commata,
 commect->connect
 commected->connected
 commecting->connecting

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -18,6 +18,7 @@ chack->check, chalk, cheque,
 chancel->cancel
 chancels->cancels
 circularly->circular
+commata->commas
 commend->comment, command,
 commends->comments, commands,
 confectionary->confectionery


### PR DESCRIPTION
Hey, 
I'm not sure about this one. Wiktionary proposes commata as plural of comma[1]. cambridge[2] and aspell[3] don't know commata. 

What is the opinion of our natives? @peternewman @lurch 

[1] https://en.wiktionary.org/wiki/commata
[2] https://dictionary.cambridge.org/us/spellcheck/english/?q=commata
[3] http://app.aspell.net/lookup?dict=en_US;words=commata