### PR TITLE
rare: Add 'trough->through'

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -134,6 +134,7 @@ tittle->title
 tittles->title
 toke->took
 tread->thread, treat,
+trough->through
 unknow->unknown
 unknows->unknowns
 untypically->atypically


### PR DESCRIPTION
This is a common misspelling but also a valid word