### PR TITLE
Move 'commitish->committish' to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5566,7 +5566,6 @@ commiters->committers
 commiti->committee, committing, commit,
 commitin->committing
 commiting->committing
-commitish->committish
 committ->commit
 committe->committee
 committi->committee

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -6,6 +6,7 @@ cas->case, cast,
 clas->class
 cloneable->clonable
 cmo->com
+commitish->committish
 copyable->copiable
 define'd->defined
 dof->of, doff,


### PR DESCRIPTION
This is a programming term and therefore moved to the relevant code dictionary.