### PR TITLE
Add descrption(s)->description(s)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8772,6 +8772,8 @@ descritptions->descriptions
 descritptive->descriptive
 descritptor->descriptor
 descritptors->descriptors
+descrption->description
+descrptions->descriptions
 descrptor->descriptor
 descrptors->descriptors
 descrutor->destructor


### PR DESCRIPTION
Encountered this spelling while maintaining someone's code.