### PR TITLE
Add litaral(s)->literal(s)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -16956,6 +16956,7 @@ listernes->listeners
 listner->listener
 listners->listeners
 litaral->literal
+litarally->literally
 litarals->literals
 litature->literature
 liteautrue->literature

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -16955,6 +16955,8 @@ listenters->listeners
 listernes->listeners
 listner->listener
 listners->listeners
+litaral->literal
+litarals->literals
 litature->literature
 liteautrue->literature
 literaly->literally


### PR DESCRIPTION
I misspelled this when I wanted to write `numeric literal`.