### PR TITLE
Add theorical->theoretical

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27685,6 +27685,8 @@ thenn->then
 theorectical->theoretical
 theoreticall->theoretically
 theoreticaly->theoretically
+theorical->theoretical
+theorically->theoretically
 theoritical->theoretical
 ther->there, their, the, other,
 therafter->thereafter


### PR DESCRIPTION
According to https://www.oxfordlearnersdictionaries.com/spellcheck/english/?q=theorical "theorical" does not exist, even though it is used in many projects (https://grep.app/search?q=theorical).

Add spelling corrections for `theorical` and `theorically`