### PR TITLE
Add typos of align, allocate, block, docker, given

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1303,7 +1303,7 @@ alignrigh->alignright
 alikes->alike, likes,
 aline->align, a line, line, saline,
 alined->aligned
-aling->align, along, a line, ailing, sling, 
+aling->align, along, a line, ailing, sling,
 alinged->aligned
 alinging->aligning
 alingment->alignment

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1314,8 +1314,9 @@ alising->aliasing
 aliver->alive, liver, a liver, sliver,
 allcate->allocate
 allcation->allocation
-allcator->allocator
+allcoate->allocate
 allcoated->allocated
+allcoating->allocating
 allcommnads->allcommands
 alle->all, alley,
 alled->called, allied,
@@ -1345,9 +1346,6 @@ alllocation->allocation
 alllow->allow
 alllows->allows
 allmost->almost
-allcoate->allocate
-allcoated->allocated
-allcoating->allocating
 alloacate->allocate
 alloate->allocate, allotted, allot,
 alloated->allocated, allotted,
@@ -3824,13 +3822,13 @@ blockin->blocking
 bloddy->bloody
 blodk->block
 blohted->bloated
-blokcer->blocker
-blokcs->blocks
 blokc->block
-blokcing->blocking
-blokcss->blocks
+blokcer->blocker
 blokchain->blockchain
 blokchains->blockchains
+blokcing->blocking
+blokcs->blocks
+blokcss->blocks
 bloking->blocking
 blong->belong
 blonged->belonged
@@ -7896,17 +7894,6 @@ dcoker->docker
 dcokerd->dockerd
 dcoking->docking
 dcoks->docks
-dockre->docker
-dockred->dockerd
-dokc->dock
-dokced->docked
-dokcer->docker
-dokcerd->dockerd
-dokcing->docking
-dokcre->docker
-dokcred->dockerd
-dokcs->docks
-dcument->document
 dcumented->documented
 dcumenting->documenting
 dcuments->documents
@@ -10133,6 +10120,14 @@ doign->doing
 doiing->doing
 doiuble->double
 doiubled->doubled
+dokc->dock
+dokced->docked
+dokcer->docker
+dokcerd->dockerd
+dokcing->docking
+dokcre->docker
+dokcred->dockerd
+dokcs->docks
 doller->dollar
 dollers->dollars
 dollor->dollar
@@ -13864,8 +13859,8 @@ gitatributes->gitattributes
 gived->given, gave
 giveing->giving
 givem->given, give them, give 'em,
-givven->given
 givveing->giving
+givven->given
 givving->giving
 glamourous->glamorous
 glight->flight

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7894,6 +7894,7 @@ dcoker->docker
 dcokerd->dockerd
 dcoking->docking
 dcoks->docks
+dcument->document
 dcumented->documented
 dcumenting->documenting
 dcuments->documents
@@ -13856,7 +13857,7 @@ gisers->geysers
 gitar->guitar
 gitars->guitars
 gitatributes->gitattributes
-gived->given, gave
+gived->given, gave,
 giveing->giving
 givem->given, give them, give 'em,
 givveing->giving

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1328,7 +1328,6 @@ allcoaters->allocators
 allcoating->allocating
 allcoation->allocation
 allcoator->allocator
-allcoator->allocator
 allcoators->allocators
 allcommnads->allcommands, all commands,
 alle->all, alley,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1303,6 +1303,9 @@ alignrigh->alignright
 alikes->alike, likes,
 aline->align, a line, line, saline,
 alined->aligned
+aling->align
+alinged->aligned
+alinging->aligning
 alingment->alignment
 alinment->alignment
 alinments->alignments
@@ -1341,6 +1344,9 @@ alllocation->allocation
 alllow->allow
 alllows->allows
 allmost->almost
+allcoate->allocate
+allcoated->allocated
+allcoating
 alloacate->allocate
 alloate->allocate, allotted, allot,
 alloated->allocated, allotted,
@@ -3818,6 +3824,10 @@ bloddy->bloody
 blodk->block
 blohted->bloated
 blokcer->blocker
+blokcs->blocks
+blokc->block
+blokcing->blocking
+blokcss->blocks
 blokchain->blockchain
 blokchains->blockchains
 bloking->blocking
@@ -7880,6 +7890,9 @@ daty->data, date,
 daugher->daughter
 DCHP->DHCP
 dcoker->docker
+dokcer->docker
+dokcre->docker
+dockre->docker
 dcument->document
 dcumented->documented
 dcumenting->documenting
@@ -13835,9 +13848,12 @@ gisers->geysers
 gitar->guitar
 gitars->guitars
 gitatributes->gitattributes
-gived->given
+gived->given, gave
 giveing->giving
 givem->given, give them, give 'em,
+givven->given
+givveing->giving
+givving->giving
 glamourous->glamorous
 glight->flight
 gloab->globe

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3838,8 +3838,8 @@ blockin->blocking
 bloddy->bloody
 blodk->block
 bloek->bloke
-bloeks->blokes
 bloekes->blokes
+bloeks->blokes
 bloekss->blokes
 blohted->bloated
 blokc->block, bloke,
@@ -10144,10 +10144,10 @@ doiubled->doubled
 dokc->dock
 dokced->docked
 dokcer->docker
-dokcerd->dockerd
+dokcerd->dockerd, docked, docker,
 dokcing->docking
 dokcre->docker
-dokcred->dockerd
+dokcred->dockerd, docked, docker,
 dokcs->docks
 doller->dollar
 dollers->dollars

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1303,10 +1303,11 @@ alignrigh->alignright
 alikes->alike, likes,
 aline->align, a line, line, saline,
 alined->aligned
-aling->align
+aling->align, along, a line, ailing, sling, 
 alinged->aligned
 alinging->aligning
 alingment->alignment
+alings->aligns, slings,
 alinment->alignment
 alinments->alignments
 alising->aliasing
@@ -1346,7 +1347,7 @@ alllows->allows
 allmost->almost
 allcoate->allocate
 allcoated->allocated
-allcoating
+allcoating->allocating
 alloacate->allocate
 alloate->allocate, allotted, allot,
 alloated->allocated, allotted,
@@ -7889,10 +7890,22 @@ datsets->datasets
 daty->data, date,
 daugher->daughter
 DCHP->DHCP
+dcok->dock
+dcoked->docked
 dcoker->docker
-dokcer->docker
-dokcre->docker
+dcokerd->dockerd
+dcoking->docking
+dcoks->docks
 dockre->docker
+dockred->dockerd
+dokc->dock
+dokced->docked
+dokcer->docker
+dokcerd->dockerd
+dokcing->docking
+dokcre->docker
+dokcred->dockerd
+dokcs->docks
 dcument->document
 dcumented->documented
 dcumenting->documenting

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1313,12 +1313,25 @@ alinments->alignments
 alising->aliasing
 aliver->alive, liver, a liver, sliver,
 allcate->allocate
+allcateing->allocating
+allcater->allocator
+allcaters->allocators
+allcating->allocating
 allcation->allocation
+allcator->allocator
 allcator->allocator
 allcoate->allocate
 allcoated->allocated
+allcoateing->allocating
+allcoateng->allocating
+allcoater->allocator
+allcoaters->allocators
 allcoating->allocating
-allcommnads->allcommands
+allcoation->allocation
+allcoator->allocator
+allcoator->allocator
+allcoators->allocators
+allcommnads->allcommands, all commands,
 alle->all, alley,
 alled->called, allied,
 alledge->allege
@@ -1371,6 +1384,8 @@ allocat->allocate
 allocatbale->allocatable
 allocatedi->allocated
 allocatedp->allocated
+allocateing->allocating
+allocateng->allocating
 allocaton->allocation
 allocatoor->allocator
 allocatote->allocate
@@ -3822,14 +3837,18 @@ blockhains->blockchains
 blockin->blocking
 bloddy->bloody
 blodk->block
+bloek->bloke
+bloeks->blokes
+bloekes->blokes
+bloekss->blokes
 blohted->bloated
-blokc->block
+blokc->block, bloke,
 blokcer->blocker
 blokchain->blockchain
 blokchains->blockchains
 blokcing->blocking
-blokcs->blocks
-blokcss->blocks
+blokcs->blocks, blokes,
+blokcss->blocks, blokes,
 bloking->blocking
 blong->belong
 blonged->belonged
@@ -7892,7 +7911,7 @@ DCHP->DHCP
 dcok->dock
 dcoked->docked
 dcoker->docker
-dcokerd->dockerd
+dcokerd->dockerd, docked, docker,
 dcoking->docking
 dcoks->docks
 dcument->document

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1319,7 +1319,6 @@ allcaters->allocators
 allcating->allocating
 allcation->allocation
 allcator->allocator
-allcator->allocator
 allcoate->allocate
 allcoated->allocated
 allcoateing->allocating

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1314,6 +1314,7 @@ alising->aliasing
 aliver->alive, liver, a liver, sliver,
 allcate->allocate
 allcation->allocation
+allcator->allocator
 allcoate->allocate
 allcoated->allocated
 allcoating->allocating


### PR DESCRIPTION
With `-ing` and `-ed` form