### PR TITLE
Add misspell: implicit. Not a noun with plural

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14993,6 +14993,7 @@ impletment->implement
 implicite->implicit, implicitly,
 implicitely->implicitly
 implicitley->implicitly
+implicits->implicit
 implict->implicit
 implictly->implicitly
 impliment->implement


### PR DESCRIPTION
* Add misspell: implicit
* Typical code search:
  * https://github.com/search?q=implicits&type=code
  * https://grep.app/search?q=implicits&words=true

Not a word in hunspell, aspell, ispell and major online dictionaries.
But it was found in many projects especially Scala.
According to Word Hippo, "The word implicit is not a noun with a plural"

Do you suggest to withdraw PR if it impacted Scala language?