### PR TITLE
add real world corrections from pyvista

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1655,6 +1655,7 @@ anarchim->anarchism
 anarchistm->anarchism
 anarquism->anarchism
 anarquist->anarchist
+anaylsis->analysis
 anbd->and
 ancapsulate->encapsulate
 ancesetor->ancestor
@@ -1895,6 +1896,7 @@ appens->appends
 appent->append
 apperance->appearance
 apperances->appearances
+apperant->apparent
 appereance->appearance
 appereances->appearances
 appered->appeared
@@ -7817,6 +7819,7 @@ cyclinders->cylinders
 cycular->circular
 cyle->cycle
 cylic->cyclic
+cylider->cylinder
 cylindre->cylinder
 cylnder->cylinder
 cylnders->cylinders
@@ -10183,6 +10186,7 @@ domians->domains
 dominaton->domination
 dominent->dominant
 dominiant->dominant
+domonstrate->demonstrate
 donain->domain
 donains->domains
 donejun->dungeon
@@ -10464,6 +10468,7 @@ easer->easier, eraser,
 easili->easily
 easiliy->easily
 easilly->easily
+easiy->easily
 easly->easily
 easyer->easier
 eaturn->return, saturn,
@@ -10514,6 +10519,8 @@ edxpected->expected
 eearly->early
 eeeprom->EEPROM
 eescription->description
+eevery->every
+eextracted->extracted
 efect->effect
 efective->effective
 efectively->effectively
@@ -11412,9 +11419,11 @@ examinated->examined
 examing->examining
 examinining->examining
 examles->examples
+examnples->examples
 exampel->example
 exampeles->examples
 exampels->examples
+examplee->example
 exampt->exempt
 exand->expand
 exansive->expansive
@@ -13845,6 +13854,7 @@ geometrys->geometries
 geomety->geometry
 geometyr->geometry
 geomitrically->geometrically
+geomoetric->geometric
 geomtry->geometry
 geomtrys->geometries
 georeferncing->georeferencing
@@ -17045,6 +17055,7 @@ ligh->light, lie, lye,
 ligher->lighter, liar, liger,
 lighers->lighters, liars, ligers,
 lightweigh->lightweight
+lightwieght->lightweight
 lightwight->lightweight
 lightyear->light year
 lightyears->light years
@@ -19115,6 +19126,7 @@ noone->no one
 noral->normal, moral,
 noralize->normalize
 noralized->normalized
+noramals->normals
 noraml->normal
 nore->nor, more,
 norhern->northern
@@ -19252,6 +19264,7 @@ obession->obsession
 obessions->obsessions
 obgect->object
 obgects->objects
+obhect->object
 obious->obvious
 obiously->obviously
 objec->object
@@ -19488,10 +19501,12 @@ ontainor->container
 ontainors->containers
 ontains->contains
 onthe->on the
+ontop->on top
 ontrolled->controlled
 ony->only
 onyl->only
 oommits->commits
+opactity->opacity
 opacy->opacity
 opague->opaque
 opatque->opaque
@@ -24693,6 +24708,7 @@ savy->savvy
 saxaphone->saxophone
 sbsampling->subsampling
 scahr->schar
+scalarr->scalar
 scaleability->scalability
 scaleable->scalable
 scaleing->scaling
@@ -25612,6 +25628,7 @@ sintakts->syntax
 sintax->syntax
 Sionist->Zionist
 Sionists->Zionists
+siply->simply
 sirect->direct
 sirected->directed
 sirecting->directing
@@ -27153,6 +27170,7 @@ suppored->supported
 supporession->suppression
 supportd->supported
 supporte->supported, supporter,
+supportes->supports
 supportet->supporter, supported,
 supportin->supporting
 supportted->supported
@@ -28266,6 +28284,10 @@ trageting->targeting
 tragets->targets
 traiing->trailing, training,
 trailling->trailing
+traingle->triangle
+traingular->triangular
+traingulation->triangulation
+traingulations->triangulations
 traker->tracker
 traking->tracking
 traling->trailing, trialing,
@@ -29104,6 +29126,7 @@ unidentifiedly->unidentified
 unidimensionnal->unidimensional
 unifiy->unify
 uniformely->uniformly
+uniformy->uniformly
 unifrom->uniform
 unifromed->uniformed
 unifromity->uniformity
@@ -29714,6 +29737,7 @@ utilies->utilities
 utililties->utilities
 utilis->utilise
 utilites->utilities
+utilitizes->utilizes
 utiliz->utilize
 utiliza->utilize
 utilizaton->utilization

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1896,7 +1896,7 @@ appens->appends
 appent->append
 apperance->appearance
 apperances->appearances
-apperant->apparent
+apperant->apparent, aberrant,
 appereance->appearance
 appereances->appearances
 appered->appeared
@@ -7820,6 +7820,7 @@ cycular->circular
 cyle->cycle
 cylic->cyclic
 cylider->cylinder
+cyliders->cylinders
 cylindre->cylinder
 cylnder->cylinder
 cylnders->cylinders
@@ -10187,6 +10188,9 @@ dominaton->domination
 dominent->dominant
 dominiant->dominant
 domonstrate->demonstrate
+domonstrates->demonstrates
+domonstrating->demonstrating
+domonstration->demonstration
 donain->domain
 donains->domains
 donejun->dungeon
@@ -10520,7 +10524,13 @@ eearly->early
 eeeprom->EEPROM
 eescription->description
 eevery->every
+eeverything->everything
+eeverywhere->everywhere
+eextract->extract
 eextracted->extracted
+eextracting->extracting
+eextraction->extraction
+eextracts->extracts
 efect->effect
 efective->effective
 efectively->effectively
@@ -11419,11 +11429,13 @@ examinated->examined
 examing->examining
 examinining->examining
 examles->examples
+examnple->example
 examnples->examples
 exampel->example
 exampeles->examples
 exampels->examples
-examplee->example
+examplee->example, examples,
+examplees->examples
 exampt->exempt
 exand->expand
 exansive->expansive
@@ -13855,6 +13867,8 @@ geomety->geometry
 geometyr->geometry
 geomitrically->geometrically
 geomoetric->geometric
+geomoetrically->geometrically
+geomoetry->geometry
 geomtry->geometry
 geomtrys->geometries
 georeferncing->georeferencing
@@ -19126,6 +19140,14 @@ noone->no one
 noral->normal, moral,
 noralize->normalize
 noralized->normalized
+noramalise->normalise
+noramalised->normalised
+noramalises->normalises
+noramalising->normalising
+noramalize->normalize
+noramalized->normalized
+noramalizes->normalizes
+noramalizing->normalizing
 noramals->normals
 noraml->normal
 nore->nor, more,
@@ -19265,6 +19287,13 @@ obessions->obsessions
 obgect->object
 obgects->objects
 obhect->object
+obhectification->objectification
+obhectifies->objectifies
+obhectify->objectify
+obhectifying->objectifying
+obhecting->objecting
+obhection->objection
+obhects->objects
 obious->obvious
 obiously->obviously
 objec->object
@@ -28286,6 +28315,10 @@ traiing->trailing, training,
 trailling->trailing
 traingle->triangle
 traingular->triangular
+traingulate->triangulate
+traingulated->triangulated
+traingulates->triangulates
+traingulating->triangulating
 traingulation->triangulation
 traingulations->triangulations
 traker->tracker
@@ -29126,7 +29159,7 @@ unidentifiedly->unidentified
 unidimensionnal->unidimensional
 unifiy->unify
 uniformely->uniformly
-uniformy->uniformly
+uniformy->uniform, uniformly,
 unifrom->uniform
 unifromed->uniformed
 unifromity->uniformity
@@ -29737,7 +29770,10 @@ utilies->utilities
 utililties->utilities
 utilis->utilise
 utilites->utilities
+utilitization->utilization
+utilitize->utilize
 utilitizes->utilizes
+utilitizing->utilizing
 utiliz->utilize
 utiliza->utilize
 utilizaton->utilization
@@ -30433,6 +30469,7 @@ widhtpoints->widthpoints
 widthn->width
 widthout->without
 wief->wife
+wieght->weight
 wieh->view
 wierd->weird
 wierdly->weirdly

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -19140,6 +19140,7 @@ noone->no one
 noral->normal, moral,
 noralize->normalize
 noralized->normalized
+noramal->normal
 noramalise->normalise
 noramalised->normalised
 noramalises->normalises
@@ -29159,7 +29160,7 @@ unidentifiedly->unidentified
 unidimensionnal->unidimensional
 unifiy->unify
 uniformely->uniformly
-uniformy->uniform, uniformly,
+uniformy->uniformly, uniform,
 unifrom->uniform
 unifromed->uniformed
 unifromity->uniformity
@@ -29769,7 +29770,13 @@ utiilties->utilities
 utilies->utilities
 utililties->utilities
 utilis->utilise
+utilisa->utilise
+utilisaton->utilisation
 utilites->utilities
+utilitisation->utilisation
+utilitise->utilise
+utilitises->utilises
+utilitising->utilising
 utilitization->utilization
 utilitize->utilize
 utilitizes->utilizes
@@ -30469,7 +30476,10 @@ widhtpoints->widthpoints
 widthn->width
 widthout->without
 wief->wife
+wieghed->weighed
 wieght->weight
+wieghted->weighted, weighed,
+wieghts->weights
 wieh->view
 wierd->weird
 wierdly->weirdly


### PR DESCRIPTION
These are some misspellings I found in the pyvista examples, which uses codespell.  A maintainer from there suggested I add the misspellings to codespell - see [this PR](https://github.com/pyvista/pyvista/pull/1084).