### PR TITLE
Add spelling corrections for render and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -23467,6 +23467,10 @@ renderr->render
 renderring->rendering
 rendevous->rendezvous
 rendezous->rendezvous
+rendired->rendered
+rendirer->renderer
+rendirers->renderers
+rendiring->rendering
 renedered->rendered
 renegatiotiable->renegotiable
 renegatiotiate->renegotiate

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -30,6 +30,8 @@ protecten->protection
 reday->ready
 referer->referrer
 rela->real
+rendir->render
+rendirs->renders
 seeked->sought
 sinc->sync, sink, since,
 sincs->syncs, sinks, since,


### PR DESCRIPTION
See e.g.:

https://github.com/search?q=rendiring&type=code (has more hits then grep.app)
https://grep.app/search?q=rendiring

https://github.com/search?q=rendired&type=code (grep.app doesn't have any hits for this one)

https://grep.app/search?q=rendir&words=true

I have put "rendir" and "rendirs" into the code dictionary because it could also be an variable name for "rename dir" or similar.

Not absolutely sure if all checks / corrections makes sense, any feedback is welcome.