### PR TITLE
Add mistatch->mismatch

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18024,6 +18024,11 @@ misstype->mistype
 misstypes->mistypes
 missunderstood->misunderstood
 missuse->misuse
+mistatch->mismatch
+mistatchd->mismatched
+mistatched->mismatched
+mistatches->mismatches
+mistatching->mismatching
 misterious->mysterious
 mistery->mystery
 misteryous->mysterious


### PR DESCRIPTION
This mispelling was recently fixed in Linux: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3a57a643a851dbb1c4a1819394ca009e3bfa4813

It also occurs in other projects: https://grep.app/search?q=Mistatch