### PR TITLE
Add exitst -> exits/exists

### DIFF
--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -13,6 +13,7 @@ dont->don't
 dur->due
 endcode->encode
 errorstring->error string
+exitst->exits, exists,
 files'->file's
 gae->game, Gael, gale,
 iam->I am, aim,


### PR DESCRIPTION
See e.g. https://grep.app/search?q=exitst&words=true

```
# password is null. Return 1 if the user $user\@$domain exitst.
```

Note that i have added it to the `code` dictionary because it seems that it is commonly used as an abbreviation for `exit status`. If you disagree with that please let me know.