### PR TITLE
Add spelling correction for errot(s)->error(s).

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11336,6 +11336,8 @@ errornously->erroneously
 errorprone->error-prone
 errorr->error
 erros->errors
+errot->error
+errots->errors
 errro->error
 errror->error
 errrors->errors


### PR DESCRIPTION
The `t` key is next to the `r` key so this might be a reason for a common typo like this.

See e.g.:

https://grep.app/search?q=errot&words=true
https://grep.app/search?q=errots&words=true