### PR TITLE
Correct variants of "debug" with three g's

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8138,6 +8138,12 @@ debufs->debugfs
 debugee->debuggee
 debuger->debugger
 debugg->debug
+debuggg->debug
+debuggge->debuggee
+debuggged->debugged
+debugggee->debuggee
+debuggger->debugger
+debuggging->debugging
 debugginf->debugging
 debuggs->debugs
 debuging->debugging

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8144,6 +8144,7 @@ debuggged->debugged
 debugggee->debuggee
 debuggger->debugger
 debuggging->debugging
+debugggs->debugs
 debugginf->debugging
 debuggs->debugs
 debuging->debugging


### PR DESCRIPTION
https://codesearch.debian.net/search?q=debuggg shows 8 pages of
results for variants of "debug" with three g's.

I've tried to capture them all here.