### PR TITLE
Add spelling correction for sycle and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25863,6 +25863,7 @@ sintax->syntax
 Sionist->Zionist
 Sionists->Zionists
 siply->simply
+sircle->circle
 sircular->circular
 sirect->direct
 sirected->directed
@@ -27651,8 +27652,9 @@ sychronously->synchronously
 sycle->cycle
 sycled->cycled
 sycles->cycles
-syclic->cyclic
-syclical->cyclical
+syclic->cyclic, psychic,
+syclical->cyclical, physical,
+sycling->cycling
 sycn->sync
 sycology->psychology
 sycronise->synchronise

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25863,6 +25863,7 @@ sintax->syntax
 Sionist->Zionist
 Sionists->Zionists
 siply->simply
+sircular->circular
 sirect->direct
 sirected->directed
 sirecting->directing
@@ -27647,6 +27648,11 @@ sychronizes->synchronizes
 sychronmode->synchronmode
 sychronous->synchronous
 sychronously->synchronously
+sycle->cycle
+sycled->cycled
+sycles->cycles
+syclic->cyclic
+syclical->cyclical
 sycn->sync
 sycology->psychology
 sycronise->synchronise
@@ -27667,6 +27673,8 @@ sylabuses->syllabuses, syllabi,
 syle->style
 syles->styles
 sylibol->syllable
+sylinder->cylinder
+sylinders->cylinders
 syllabills->syllabus, syllabification,
 sylog->syslog
 symantics->semantics

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25864,6 +25864,7 @@ Sionist->Zionist
 Sionists->Zionists
 siply->simply
 sircle->circle
+sircles->circles
 sircular->circular
 sirect->direct
 sirected->directed


### PR DESCRIPTION
See e.g.:

https://grep.app/search?q=sycle&words=true
https://grep.app/search?q=sycles&words=true (https://github.com/search?q=sycles&type=code has more hits)
https://github.com/search?q=sircular&type=code
https://github.com/search?q=syclical&type=code

There is https://www.iana.org/assignments/media-types/application/vnd.sycle+xml and a company called "Sycle" but that are IMHO edge cases and if hit these should be excluded by the user.