### PR TITLE
Remove crate from the list of words

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -31,7 +31,6 @@ copping->coping, copying, cropping,
 covert->convert
 crasher->crash
 crashers->crashes
-crate->create
 crated->created
 creche->crèche
 cristal->crystal


### PR DESCRIPTION
I propose that we remove crate from codespell.
Two reasons:
* it is an english word: https://en.wikipedia.org/wiki/Crate
* it is the name of a library in Rust: https://doc.rust-lang.org/book/ch07-01-packages-and-crates.html

One of my project
```
$ codespell src|grep crate|wc -l
519
```
It had to be excluded from Firefox codespell integration:
https://searchfox.org/mozilla-central/source/tools/lint/spell/exclude-list.txt#10