### PR TITLE
Remove heterogenous->heterogeneous

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14558,7 +14558,7 @@ hertzs->hertz
 hesiate->hesitate
 hesistant->hesitant
 hestiate->hesitate
-hetrogenous->heterogeneous
+hetrogenous->heterogenous, heterogeneous,
 heuristc->heuristic
 heuristcs->heuristics
 heursitics->heuristics

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14558,7 +14558,6 @@ hertzs->hertz
 hesiate->hesitate
 hesistant->hesitant
 hestiate->hesitate
-heterogenous->heterogeneous
 hetrogenous->heterogeneous
 heuristc->heuristic
 heuristcs->heuristics

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14558,6 +14558,7 @@ hertzs->hertz
 hesiate->hesitate
 hesistant->hesitant
 hestiate->hesitate
+hetrogeneous->heterogeneous
 hetrogenous->heterogenous, heterogeneous,
 heuristc->heuristic
 heuristcs->heuristics

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -63,6 +63,7 @@ guarantied->guaranteed
 guerilla->guerrilla
 guerillas->guerrillas
 hart->heart, harm,
+heterogenous->heterogeneous
 hided->hidden, hid,
 hist->heist, his,
 hove->have, hover, love,


### PR DESCRIPTION
"heterogenous" is both a valid word with a distinct meaning, and an accepted alternative spelling of "heterogeneous": https://en.wiktionary.org/wiki/heterogenous.

In place of this correction, this PR adds hetrogeneous->heterogeneous.