### PR TITLE
Skip files passed in if matching the skip glob

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 branch = True
 source = codespell_lib
 include = */codespell_lib/*
-omit =
+omit = */codespell_lib/tests/*

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -840,7 +840,7 @@ def main(*args):
                 # skip (relative) directories
                 dirs[:] = [dir_ for dir_ in dirs if not glob_match.match(dir_)]
 
-        else:
+        elif not glob_match.match(filename):  # skip files
             bad_count += parse_file(
                 filename, colors, summary, misspellings, exclude_lines,
                 file_opener, word_regex, ignore_word_regex, context, options)

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -288,10 +288,12 @@ def test_encoding(tmpdir, capsys):
 def test_ignore(tmpdir, capsys):
     """Test ignoring of files and directories."""
     d = str(tmpdir)
-    with open(op.join(d, 'good.txt'), 'w') as f:
+    goodtxt = op.join(d, 'good.txt')
+    with open(goodtxt, 'w') as f:
         f.write('this file is okay')
     assert cs.main(d) == 0
-    with open(op.join(d, 'bad.txt'), 'w') as f:
+    badtxt = op.join(d, 'bad.txt')
+    with open(badtxt, 'w') as f:
         f.write('abandonned')
     assert cs.main(d) == 1
     assert cs.main('--skip=bad*', d) == 0
@@ -305,6 +307,9 @@ def test_ignore(tmpdir, capsys):
     assert cs.main('--skip=*ignoredir*', d) == 1
     assert cs.main('--skip=ignoredir', d) == 1
     assert cs.main('--skip=*ignoredir/bad*', d) == 1
+    badjs = op.join(d, 'bad.js')
+    copyfile(badtxt, badjs)
+    assert cs.main('--skip=*.js', goodtxt, badtxt, badjs) == 1
 
 
 def test_check_filename(tmpdir, capsys):


### PR DESCRIPTION
This change skips files if they are passed in on the command line if they match the skip glob:

`codespell -S '*.js' docs/files/testing.js`

helps when running with pre-commit where all files get passed in individually 

Fixes https://github.com/codespell-project/codespell/issues/1528
