### PR TITLE
Add various spelling corrections for retrieve and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -24521,6 +24521,8 @@ retangles->rectangles
 retanslate->retranslate
 retcieve->retrieve, receive,
 retcieved->retrieved, received,
+retciever->retriever, receiver,
+retcievers->retrievers, receivers,
 retcieves->retrieves, receives,
 retet->reset, retest,
 retetting->resetting, retesting,
@@ -24589,6 +24591,8 @@ retruned->returned
 retruns->returns
 retrvieve->retrieve
 retrvieved->retrieved
+retrviever->retriever
+retrvievers->retrievers
 retrvieves->retrieves
 retsart->restart
 retsarts->restarts
@@ -24697,6 +24701,8 @@ revolutionar->revolutionary
 revrese->reverse
 revrieve->retrieve
 revrieved->retrieved
+revriever->retriever
+revrievers->retrievers
 revrieves->retrieves
 revsion->revision
 rewirtable->rewritable

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -24260,6 +24260,8 @@ rererences->references
 rerference->reference
 rerferences->references
 rerpesentation->representation
+rertieve->retrieve
+rertieved->retrieved
 rertieves->retrieves
 reruirement->requirement
 reruirements->requirements
@@ -24517,6 +24519,8 @@ retalitated->retaliated
 retalitation->retaliation
 retangles->rectangles
 retanslate->retranslate
+retcieve->retrieve, receive,
+retcieved->retrieved, received,
 retcieves->retrieves, receives,
 retet->reset, retest,
 retetting->resetting, retesting,
@@ -24583,6 +24587,9 @@ retriving->retrieving
 retrun->return
 retruned->returned
 retruns->returns
+retrvieve->retrieve
+retrvieved->retrieved
+retrvieves->retrieves
 retsart->restart
 retsarts->restarts
 retun->return
@@ -24689,6 +24696,7 @@ revoluion->revolution
 revolutionar->revolutionary
 revrese->reverse
 revrieve->retrieve
+revrieved->retrieved
 revrieves->retrieves
 revsion->revision
 rewirtable->rewritable

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -24262,6 +24262,8 @@ rerferences->references
 rerpesentation->representation
 rertieve->retrieve
 rertieved->retrieved
+rertiever->retriever
+rertievers->retrievers
 rertieves->retrieves
 reruirement->requirement
 reruirements->requirements


### PR DESCRIPTION
Examples for the `retrvieve` spelling (not much but it happens):

https://grep.app/search?q=retrvieve
https://github.com/search?q=retrvieve&type=code

While doing this addition i also noticed that a few of the `ed` and/or `es` variants for existing entries where missing and added them right away.