### PR TITLE
Remove cancelability from the dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -4478,7 +4478,6 @@ camparing->comparing
 can;t->can't
 canadan->canadian
 canbe->can be
-cancelability->cancellability
 cancelaltion->cancellation
 cancelation->cancellation
 cancelations->cancellations

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -16,6 +16,7 @@ busses->buses
 calculatable->calculable
 calender->calendar
 calenders->calendars
+cancelability->cancellability
 cant->can't
 chack->check, chalk, cheque,
 chancel->cancel


### PR DESCRIPTION
cancelability and cancellability both are correct spellings. 

Remove it from the dictionary
And add it to dictionary_rare.

We can see many uses here: https://linux.die.net/man/3/pthread_setcanceltype