### PR TITLE
Typos from marvin.cs.uidaho.edu/misspell.html (rework of #1374): H

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14681,10 +14681,15 @@ hadnler->handler
 haeder->header
 haemorrage->haemorrhage
 haev->have, heave,
+hagas->haggis
+hagases->haggises
+hagasses->haggises
 hahve->have, halve, half,
 halarious->hilarious
 hald->held
 halfs->halves
+hallaluja->hallelujah
+hallaluya->hallelujah
 Hallowean->Hallowe'en, Halloween,
 halp->help
 halpoints->halfpoints
@@ -14735,6 +14740,8 @@ handskake->handshake
 handwirting->handwriting
 hanel->handle
 hangig->hanging
+hankerchif->handkerchief
+hankerchifs->handkerchiefs
 hanlde->handle
 hanlded->handled
 hanlder->handler
@@ -14790,6 +14797,10 @@ hardward->hardware
 hardwdare->hardware
 hardwirted->hardwired
 harge->charge
+harrang->harangue
+harranged->harangued
+harranges->harangues
+harranging->haranguing
 harras->harass
 harrased->harassed
 harrases->harasses
@@ -14877,7 +14888,7 @@ helpped->helped
 hemishpere->hemisphere
 hemishperes->hemispheres
 hemmorhage->hemorrhage
-hemorage->haemorrhage
+hemorage->hemorrhage
 henc->hence
 henderence->hindrance
 hendler->handler
@@ -14972,6 +14983,7 @@ hilighted->highlighted
 hilighting->highlighting
 hilights->highlights
 hillarious->hilarious
+hims->his, hymns,
 himselv->himself
 hinderance->hindrance
 hinderence->hindrance

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14983,7 +14983,6 @@ hilighted->highlighted
 hilighting->highlighting
 hilights->highlights
 hillarious->hilarious
-hims->his, hymns,
 himselv->himself
 hinderance->hindrance
 hinderence->hindrance

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -70,6 +70,7 @@ guerillas->guerrillas
 hart->heart, harm,
 heterogenous->heterogeneous
 hided->hidden, hid,
+hims->his, hymns,
 hist->heist, his,
 hove->have, hover, love,
 impassible->impassable


### PR DESCRIPTION
For #1949