### PR TITLE
Typos from marvin.cs.uidaho.edu/misspell.html (rework of #1374): J

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -17220,6 +17220,12 @@ jossle->jostle
 jouney->journey
 journied->journeyed
 journies->journeys
+journing->journeying
+journy->journey
+journyed->journeyed
+journyes->journeyed
+journying->journeying
+journys->journeys
 joystik->joystick
 jpng->png, jpg, jpeg,
 jscipt->jscript
@@ -17237,6 +17243,18 @@ jumpimng->jumping
 jumpt->jumped, jump,
 juristiction->jurisdiction
 juristictions->jurisdictions
+jurnal->journal
+jurnaled->journaled
+jurnaler->journaler
+jurnales->journals
+jurnaling->journaling
+jurnals->journals
+jurnied->journeyed
+jurnies->journeys
+jurny->journey
+jurnyed->journeyed
+jurnyes->journeys
+jurnys->journeys
 jus->just
 juse->just, juice, Jude, June,
 justfied->justified


### PR DESCRIPTION
For #1949