### PR TITLE
Typos from marvin.cs.uidaho.edu/misspell.html (rework of #1374): Q

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -23004,8 +23004,6 @@ quicklyu->quickly
 quicly->quickly
 quiessent->quiescent
 quinessential->quintessential
-quire->choir
-quires->choirs
 quitely->quite, quietly,
 quith->quit, with,
 quiting->quitting

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22941,13 +22941,21 @@ qouting->quoting
 qtuie->quite, quiet,
 quadddec->quaddec
 quadranle->quadrangle
+quadraped->quadruped
+quadrapeds->quadrupeds
+quadroople->quadruple
+quadrooples->quadruples
+quafeur->coiffure
+quafeured->coiffured
 quailified->qualified
 qualfied->qualified
 qualfy->qualify
 qualifer->qualifier
 qualitification->qualification
 qualitifications->qualifications
+quanities->quantities
 quanitified->quantified
+quanity->quantity
 quanlification->qualification, quantification,
 quanlified->qualified, quantified,
 quanlifies->qualifies, quantifies,
@@ -22973,10 +22981,16 @@ querries->queries
 queryies->queries
 queryinterace->queryinterface
 querys->queries
+quesant->croissant
+quesants->croissants
 quesiton->question
 quesitonable->questionable
 quesitons->questions
+quessant->croissant
+quessants->croissants
 questionaire->questionnaire
+questionare->questionnaire
+questionares->questionnaires
 questionnair->questionnaire
 questoin->question
 questoins->questions
@@ -22990,18 +23004,31 @@ quicklyu->quickly
 quicly->quickly
 quiessent->quiescent
 quinessential->quintessential
+quire->choir
+quires->choirs
 quitely->quite, quietly,
 quith->quit, with,
 quiting->quitting
 quitt->quit
 quitted->quit
 quizes->quizzes
+quizs->quizzes
+quizzs->quizzes
+quoshant->quotient
 quotaion->quotation
 quoteed->quoted
 quottes->quotes
 quried->queried
 quroum->quorum
 qutie->quite, quiet,
+quwesant->croissant
+quwesants->croissants
+quwessant->croissant
+quwessants->croissants
+qwesant->croissant
+qwesants->croissants
+qwessant->croissant
+qwessants->croissants
 rabinnical->rabbinical
 racaus->raucous
 ractise->practise

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -113,6 +113,8 @@ programing->programming
 prosses->process, processes, possess,
 purportive->supportive
 purvue->purview
+quire->choir
+quires->choirs
 readd->re-add, read,
 readded->read
 ream->stream


### PR DESCRIPTION
For #1949