### PR TITLE
Typos from marvin.cs.uidaho.edu/misspell.html (rework of #1374): Y

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -31882,6 +31882,7 @@ yeld->yield
 yelded->yielded
 yelding->yielding
 yelds->yields
+yello->yellow
 Yementite->Yemenite, Yemeni,
 yera->year
 yeras->years
@@ -31889,7 +31890,13 @@ yersa->years
 yhe->the
 yieldin->yielding
 ymbols->symbols
+yoman->yeoman
+yomen->yeomen
+yot->yacht
 yotube->youtube
+youforic->euphoric
+youforically->euphorically
+youlogy->eulogy
 youn->your, you, young,
 youre->your, you're,
 yourr->your, you're,
@@ -31899,10 +31906,13 @@ yourselv->yourself, yourselves,
 yourselve->yourselves, yourself,
 youseff->yourself, yousef,
 youself->yourself
+youthinasia->euthanasia
 ypes->types
 yrea->year
 yse->yes, use, NYSE,
 ytou->you
+yuforic->euphoric
+yuforically->euphorically
 yugoslac->yugoslav
 yuo->you
 yuor->your


### PR DESCRIPTION
For #1949