### PR TITLE
Add typos and variants from w3c/silver#248

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -310,6 +310,9 @@ accesed->accessed
 acceses->accesses
 accesibility->accessibility
 accesible->accessible
+accesiblity->accessibility
+accesiibility->accessibility
+accesiiblity->accessibility
 accesing->accessing
 accesnt->accent
 accesor->accessor
@@ -323,9 +326,12 @@ accessibile->accessible
 accessibiliity->accessibility
 accessibilitiy->accessibility
 accessibiliy->accessibility, accessible,
+accessibiltiy->accessibility
 accessibilty->accessibility
 accessiblilty->accessibility
 accessiblity->accessibility
+accessiibility->accessibility
+accessiiblity->accessibility
 accessile->accessible
 accessintg->accessing
 accessisble->accessible
@@ -334,7 +340,10 @@ accessoires->accessories, accessorise,
 accessoirez->accessorize, accessories,
 accessort->accessor
 accesss->access
+accesssibility->accessibility
 accesssible->accessible
+accesssiblity->accessibility
+accesssiiblity->accessibility
 accesssing->accessing
 accesssor->accessor
 accesssors->accessors
@@ -2054,6 +2063,10 @@ appologies->apologies
 appology->apology
 appon->upon
 appopriate->appropriate
+apporach->approach
+apporached->approached
+apporaches->approaches
+apporaching->approaching
 apporiate->appropriate
 apporoximate->approximate
 apporoximated->approximated
@@ -5502,6 +5515,7 @@ clonning->cloning
 clory->glory
 clos->close
 closeing->closing
+closesly->closely
 closests->closest, closets,
 closig->closing
 clossed->closed
@@ -6747,6 +6761,8 @@ congifuration->configuration
 congifure->configure
 congifured->configured
 congigure->configure
+congnition->cognition
+congnitive->cognitive
 congradulations->congratulations
 congresional->congressional
 conider->consider
@@ -7302,6 +7318,10 @@ controversey->controversy
 controversials->controversial
 controvertial->controversial
 controvery->controversy
+contrst->contrast
+contrsted->contrasted
+contrsting->contrasting
+contrsts->contrasts
 contrtoller->controller
 contruct->construct
 contructed->constructed
@@ -9561,6 +9581,8 @@ devleop->develop
 devleoped->developed
 devleoper->developer
 devleopers->developers
+devleoping->developing
+devleopment->development
 devleopper->developer
 devleoppers->developers
 devlop->develop
@@ -9946,6 +9968,10 @@ disabe->disable
 disabeling->disabling
 disabels->disables
 disabes->disables
+disabilitiles->disabilities
+disabilitily->disability
+disabiltities->disabilities
+disabiltitiy->disability
 disabl->disable
 disablle->disable
 disadvantadge->disadvantage
@@ -14408,6 +14434,8 @@ glight->flight
 gloab->globe
 gloabal->global
 gloabl->global
+gloassaries->glossaries
+gloassary->glossary
 globablly->globally
 globbal->global
 globel->global
@@ -15429,6 +15457,8 @@ immitating->imitating
 immitator->imitator
 immmediate->immediate
 immmediately->immediately
+immsersive->immersive
+immsersively->immersively
 immuniy->immunity
 immunosupressant->immunosuppressant
 immutible->immutable
@@ -16727,6 +16757,7 @@ interchangably->interchangeably
 intercollegate->intercollegiate
 intercontinential->intercontinental
 intercontinetal->intercontinental
+interdependant->interdependent
 interecptor->interceptor
 intered->interred, interned,
 intereested->interested
@@ -17168,6 +17199,8 @@ iterrupt->interrupt
 itertation->iteration
 iteself->itself
 itesm->items
+itheir->their
+itheirs->theirs
 itialise->initialise
 itialised->initialised
 itialises->initialises
@@ -18193,6 +18226,12 @@ meatadata->metadata
 meatfile->metafile
 meathod->method
 meaure->measure
+meaured->measured
+meaurement->measurement
+meaurements->measurements
+meaurer->measurer
+meaurers->measurers
+meaures->measures
 meauring->measuring
 meausure->measure
 meausures->measures
@@ -19111,8 +19150,13 @@ naximum->maximum
 Nazereth->Nazareth
 nclude->include
 nd->and, 2nd,
-nead->need
-neaded->needed, kneaded,
+nead->need, knead, head,
+neaded->needed, kneaded, headed,
+neader->header, kneader,
+neaders->headers, kneaders,
+neading->needing, kneading, heading,
+neads->needs, kneads, heads,
+neady->needy
 neagtive->negative
 nealy->nearly, newly,
 neares->nearest
@@ -20380,8 +20424,18 @@ organiztion->organization
 organiztions->organizations
 organsiation->organisation
 organsiations->organisations
+organsied->organised
+organsier->organiser
+organsiers->organisers
+organsies->organises
+organsiing->organising
 organziation->organization
 organziations->organizations
+organzied->organized
+organzier->organizer
+organziers->organizers
+organzies->organizes
+organziing->organizing
 orgiginal->original
 orgiginally->originally
 orgiginals->originals
@@ -21136,8 +21190,13 @@ peprocessor->preprocessor
 per-interpeter->per-interpreter
 perade->parade
 peraphs->perhaps
+percentange->percentage
+percentanges->percentages
 percentil->percentile
 percepted->perceived
+percievable->perceivable
+percievabley->perceivably
+percievably->perceivably
 percieve->perceive
 percieved->perceived
 percision->precision
@@ -22742,7 +22801,9 @@ protoganist->protagonist
 protoge->protege
 prototyes->prototypes
 protoype->prototype
+protoyped->prototyped
 protoypes->prototypes
+protoyping->prototyping
 protoytpe->prototype
 protoytpes->prototypes
 protrayed->portrayed
@@ -28666,6 +28727,8 @@ technic->technique
 technics->techniques
 technik->technique
 techniks->techniques
+techniquest->techniques
+techniquet->technique
 technitian->technician
 technition->technician
 technlogy->technology


### PR DESCRIPTION
From w3c/silver#248

22 typos + 43 variants = 65 total

The original typos were:

    accessibiltiy
    accessiiblity
    accesssibility
    apporach
    closesly
    congnition
    contrsts
    devleopment
    disabilitiles
    disabiltities
    enduser
    gloassary
    immsersive
    interdependant
    itheir
    meaured
    neads
    organzied
    percentange
    percievable
    protoyping
    techniquest