### PR TITLE
Make all dictionary entries lowercase

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -558,10 +558,10 @@ achor->anchor
 achored->anchored
 achoring->anchoring
 achors->anchors
-ACI->ACPI
+aci->acpi
 acident->accident
 acient->ancient
-ACII->ASCII
+acii->ascii
 acition->action
 acitions->actions
 acitivate->activate
@@ -981,7 +981,7 @@ agaisnt->against
 agaist->against
 agancies->agencies
 agancy->agency
-aganda->agenda, Uganda,
+aganda->agenda, uganda,
 aganist->against
 agant->agent
 agants->agents, against,
@@ -1073,7 +1073,7 @@ airlfow->airflow
 airloom->heirloom
 airporta->airports
 airrcraft->aircraft
-aisian->Asian
+aisian->asian
 aixs->axis
 aizmuth->azimuth
 ajacence->adjacence
@@ -1656,7 +1656,7 @@ amdgput->amdgpu
 amendement->amendment
 amendmant->amendment
 amened->amended, amend,
-Amercia->America
+amercia->america
 amerliorate->ameliorate
 amgle->angle
 amgles->angles
@@ -1765,7 +1765,7 @@ andoid->android
 androgenous->androgynous
 androgeny->androgyny
 androidextra->androidextras
-androind->Android
+androind->android
 andthe->and the
 ane->and
 anevironment->environment
@@ -1938,7 +1938,7 @@ apender->appender
 apendices->appendices
 apending->appending
 apendix->appendix
-apenines->Apennines
+apenines->apennines
 aperatures->apertures
 aperure->aperture
 aperures->apertures
@@ -1996,7 +1996,7 @@ appendign->appending
 appendt->append
 appened->append, appended, happened,
 appeneded->appended
-appenines->Apennines
+appenines->apennines
 appens->appends
 appent->append
 apperance->appearance
@@ -2413,7 +2413,7 @@ archving->archiving
 arcitecture->architecture
 arcitectures->architectures
 arcticle->article
-Ardiuno->Arduino
+ardiuno->arduino
 are'nt->aren't
 aready->already
 areea->area
@@ -2573,8 +2573,8 @@ arugment->argument
 arugments->arguments
 aruments->arguments
 arund->around
-asai->Asia
-asain->Asian
+asai->asia
+asain->asian
 asbolute->absolute
 asbolutelly->absolutely
 asbolutely->absolutely
@@ -2643,7 +2643,7 @@ assasins->assassins
 assassintation->assassination
 asscciated->associated
 assciated->associated
-asscii->ASCII
+asscii->ascii
 asscociated->associated
 asscoitaed->associated
 assebly->assembly
@@ -2903,8 +2903,8 @@ atendee->attendee
 atends->attends
 atention->attention
 atheistical->atheistic
-athenean->Athenian
-atheneans->Athenians
+athenean->athenian
+atheneans->athenians
 ather->other
 athiesm->atheism
 athiest->atheist
@@ -3076,11 +3076,11 @@ auospacing->autospacing
 auot->auto
 auotmatic->automatic
 auromated->automated
-aussian->Gaussian, Russian, Austrian,
-austrailia->Australia
-austrailian->Australian
-Australien->Australian
-Austrlaian->Australian
+aussian->gaussian, russian, austrian,
+austrailia->australia
+austrailian->australian
+australien->australian
+austrlaian->australian
 autasave->autosave
 autasaves->autosaves
 autenticate->authenticate
@@ -3889,8 +3889,8 @@ benig->being
 beond->beyond
 berforming->performing
 bergamont->bergamot
-Berkley->Berkeley
-Bernouilli->Bernoulli
+berkley->berkeley
+bernouilli->bernoulli
 berween->between
 besed->based
 beseige->besiege
@@ -4011,7 +4011,7 @@ blessure->blessing
 bletooth->bluetooth
 bleutooth->bluetooth
 blindy->blindly
-Blitzkreig->Blitzkrieg
+blitzkreig->blitzkrieg
 bload->bloat
 bloaded->bloated
 blocack->blockack
@@ -4071,7 +4071,7 @@ bolor->color
 bombardement->bombardment
 bombarment->bombardment
 bondary->boundary
-Bonnano->Bonanno
+bonnano->bonanno
 bood->boot
 bookeeping->bookkeeping
 bookkeeing->bookkeeping
@@ -4240,9 +4240,9 @@ brancket->bracket
 branckets->brackets
 brane->brain
 braodcasted->broadcasted
-Brasillian->Brazilian
+brasillian->brazilian
 brazeer->brassiere
-brazillian->Brazilian
+brazillian->brazilian
 bre->be, brie,
 breakes->breaks
 breakthough->breakthrough
@@ -4286,8 +4286,8 @@ briteners->brighteners
 britenes->brightenes
 britening->brightening
 briter->brighter
-Britian->Britain
-Brittish->British
+britian->britain
+brittish->british
 brnach->branch
 brnaches->branches
 broacasted->broadcast
@@ -4345,8 +4345,8 @@ btye->byte
 btyes->bytes
 buad->baud
 bubbless->bubbles
-Buddah->Buddha
-Buddist->Buddhist
+buddah->buddha
+buddist->buddhist
 bufefr->buffer
 bufer->buffer
 bufers->buffers
@@ -4476,7 +4476,7 @@ caculator->calculator
 cacuses->caucuses
 cadidate->candidate
 caefully->carefully
-Caesarian->Caesarean
+caesarian->caesarean
 cahacter->character
 cahacters->characters
 cahange->change
@@ -4618,7 +4618,7 @@ calulates->calculates
 calulating->calculating
 calulation->calculation
 calulations->calculations
-Cambrige->Cambridge
+cambrige->cambridge
 camoflage->camouflage
 camoflague->camouflage
 campagin->campaign
@@ -4701,7 +4701,7 @@ capbability->capability
 capbale->capable
 capela->capella
 caperbility->capability
-Capetown->Cape Town
+capetown->cape town
 capibilities->capabilities
 capible->capable
 capitolize->capitalize
@@ -4720,7 +4720,7 @@ caracteristic->characteristic
 caracterized->characterized
 caracters->characters
 carbus->cardbus
-carcas->carcass, Caracas,
+carcas->carcass, caracas,
 carefull->careful, carefully,
 carefuly->carefully
 careing->caring
@@ -4729,21 +4729,21 @@ cariage->carriage
 caridge->carriage
 cariier->carrier
 carismatic->charismatic
-Carmalite->Carmelite
-Carnagie->Carnegie
-Carnagie-Mellon->Carnegie-Mellon
-carnege->carnage, Carnegie,
-carnige->carnage, Carnegie,
-Carnigie->Carnegie
-Carnigie-Mellon->Carnegie-Mellon
+carmalite->carmelite
+carnagie->carnegie
+carnagie-mellon->carnegie-mellon
+carnege->carnage, carnegie,
+carnige->carnage, carnegie,
+carnigie->carnegie
+carnigie-mellon->carnegie-mellon
 carniverous->carnivorous
 carreer->career
 carreid->carried
 carrers->careers
 carret->caret
 carriadge->carriage
-Carribbean->Caribbean
-Carribean->Caribbean
+carribbean->caribbean
+carribean->caribbean
 carridge->carriage, cartridge,
 carrien->carrier
 carrige->carriage
@@ -4751,7 +4751,7 @@ carrrier->carrier
 carryintg->carrying
 carryng->carrying
 cartdridge->cartridge
-Carthagian->Carthaginian
+carthagian->carthaginian
 carthographer->cartographer
 cartiesian->cartesian
 cartilege->cartilage
@@ -4785,7 +4785,7 @@ catagorie->category, categories,
 catagories->categories
 catagorized->categorized
 catagory->category
-Cataline->Catiline, Catalina,
+cataline->catiline, catalina,
 catapillar->caterpillar
 catapillars->caterpillars
 catapiller->caterpillar
@@ -4857,7 +4857,7 @@ ccoutant->accountant
 ccpcheck->cppcheck
 cdecompress->decompress
 ceartype->cleartype
-Ceasar->Caesar
+ceasar->caesar
 ceate->create
 ceated->created
 ceates->creates
@@ -4875,7 +4875,7 @@ cehcked->checked
 cehcker->checker
 cehcking->checking
 cehcks->checks
-Celcius->Celsius
+celcius->celsius
 celles->cells
 cellpading->cellpadding
 cellst->cells
@@ -4980,7 +4980,7 @@ certitication->certification
 cervial->cervical, servile, serval,
 cetrainly->certainly
 cetting->setting
-Cgywin->Cygwin
+cgywin->cygwin
 chaarges->charges
 chacacter->character
 chacacters->characters
@@ -5010,7 +5010,7 @@ challanges->challenges
 challege->challenge
 chambre->chamber
 chambres->chambers
-Champange->Champagne
+champange->champagne
 chanage->change
 chanaged->changed
 chanager->changer
@@ -5220,8 +5220,8 @@ childs->children, child's,
 chiled->child, chilled,
 chiledren->children
 chilren->children
-chineese->Chinese
-chinense->Chinese
+chineese->chinese
+chinense->chinese
 chiop->chip, chop,
 chiper->cipher, chipper, chimer,
 chipers->ciphers, chippers, chimers,
@@ -5295,8 +5295,8 @@ cilinders->cylinders
 cilyndre->cylinder
 cilyndres->cylinders
 cilyndrs->cylinders
-Cincinatti->Cincinnati
-Cincinnatti->Cincinnati
+cincinatti->cincinnati
+cincinnatti->cincinnati
 cinfiguration->configuration
 cinfigurations->configurations
 cintaner->container
@@ -5350,8 +5350,8 @@ ciricular->circular
 ciricularise->circularise
 ciricularize->circularize
 ciriculum->curriculum
-cirilic->Cyrillic
-cirillic->Cyrillic
+cirilic->cyrillic
+cirillic->cyrillic
 ciritc->critic
 ciritcal->critical
 ciritcality->criticality
@@ -6817,7 +6817,7 @@ conneiction->connection
 connektors->connectors
 connetced->connected
 connetcion->connection
-Conneticut->Connecticut
+conneticut->connecticut
 connetion->connection
 connetor->connector
 connexion->connection
@@ -7561,7 +7561,7 @@ corelated->correlated
 corelates->correlates
 corellation->correlation
 corener->corner, coroner,
-coreolis->Coriolis
+coreolis->coriolis
 corerct->correct
 corerctly->correctly
 corespond->correspond
@@ -8157,7 +8157,7 @@ cylindre->cylinder
 cylnder->cylinder
 cylnders->cylinders
 cylynders->cylinders
-cymk->CMYK
+cymk->cmyk
 cyphersuite->ciphersuite
 cyphersuites->ciphersuites
 cyphertext->ciphertext
@@ -8165,10 +8165,10 @@ cyphertexts->ciphertexts
 cyprt->crypt
 cyprtic->cryptic
 cyprto->crypto
-Cyrllic->Cyrillic
+cyrllic->cyrillic
 cyrpto->crypto
 cyrrent->current
-cyrrilic->Cyrillic
+cyrrilic->cyrillic
 cyrstal->crystal
 cyrstalline->crystalline
 cyrstallisation->crystallisation
@@ -8177,7 +8177,7 @@ cyrstallization->crystallization
 cyrstallize->crystallize
 cyrstals->crystals
 cyrto->crypto
-cywgin->Cygwin
+cywgin->cygwin
 daa->data
 dabase->database
 daclaration->declaration
@@ -8194,10 +8194,10 @@ dafualted->defaulted
 dafualts->defaults
 daita->data
 dake->take
-dalmation->Dalmatian
+dalmation->dalmatian
 dalta->delta
 damenor->demeanor
-dameon->daemon, demon, Damien,
+dameon->daemon, demon, damien,
 damge->damage
 dammage->damage
 dammages->damages
@@ -8206,7 +8206,7 @@ damons->daemons, demons,
 danceing->dancing
 dandidates->candidates
 daplicating->duplicating
-Dardenelles->Dardanelles
+dardenelles->dardanelles
 dasdot->dashdot
 dashbaord->dashboard
 dashbord->dashboard
@@ -8266,7 +8266,7 @@ datset->dataset
 datsets->datasets
 daty->data, date,
 daugher->daughter
-DCHP->DHCP
+dchp->dhcp
 dcok->dock
 dcoked->docked
 dcoker->docker
@@ -8364,14 +8364,14 @@ deattaching->detaching
 deattachment->detachment
 deaults->defaults
 deauthenication->deauthentication
-debain->Debian
+debain->debian
 debateable->debatable
 debbuger->debugger
 debgu->debug
 debgug->debug
 debguging->debugging
-debiab->Debian
-debians->Debian's
+debiab->debian
+debians->debian's
 debloking->deblocking
 debth->depth
 debths->depths
@@ -8405,7 +8405,7 @@ deccelerates->decelerates
 deccelerating->decelerating
 decceleration->deceleration
 decelaration->declaration
-Decemer->December
+decemer->december
 decend->descend
 decendant->descendant
 decendants->descendants
@@ -10724,7 +10724,7 @@ drastical->drastically
 drasticaly->drastically
 drats->drafts
 draughtman->draughtsman
-Dravadian->Dravidian
+dravadian->dravidian
 draview->drawview
 drawack->drawback
 drawacks->drawbacks
@@ -10894,7 +10894,7 @@ eaturn->return, saturn,
 eaxct->exact
 ebale->enable
 ebaled->enabled
-EBCIDC->EBCDIC
+ebcidc->ebcdic
 ebedded->embedded
 eccessive->excessive
 ecclectic->eclectic
@@ -10918,7 +10918,7 @@ ecxited->excited
 ecxites->excites
 ecxiting->exciting
 ecxtracted->extracted
-EDCDIC->EBCDIC
+edcdic->ebcdic
 edditable->editable
 ede->edge
 ediable->editable
@@ -10936,7 +10936,7 @@ edn->end
 ednif->endif
 edxpected->expected
 eearly->early
-eeeprom->EEPROM
+eeeprom->eeprom
 eescription->description
 eevery->every
 eeverything->everything
@@ -11003,7 +11003,7 @@ ehen->when, hen, even, then,
 ehenever->whenever
 ehough->enough
 ehr->her
-ehternet->Ethernet
+ehternet->ethernet
 ehther->ether, either,
 ehthernet->ethernet
 eighter->either
@@ -11368,7 +11368,7 @@ enivronment->environment
 enlargment->enlargement
 enlargments->enlargements
 enlightnment->enlightenment
-Enlish->English, enlist,
+enlish->english, enlist,
 enlose->enclose
 enmpty->empty
 enmum->enum
@@ -11742,7 +11742,7 @@ etensible->extensible
 etension->extension
 etensions->extensions
 ethe->the
-etherenet->Ethernet
+etherenet->ethernet
 ethernal->eternal
 ethnocentricm->ethnocentrism
 ethose->those, ethos,
@@ -11763,10 +11763,10 @@ euqivalent->equivalent
 euqivalents->equivalents
 euristic->heuristic
 euristics->heuristics
-Europian->European
-Europians->Europeans
-Eurpean->European
-Eurpoean->European
+europian->european
+europians->europeans
+eurpean->european
+eurpoean->european
 evalation->evaluation
 evaluataion->evaluation
 evaluataions->evaluations
@@ -13219,7 +13219,7 @@ factorys->factories
 fadind->fading
 faeture->feature
 faetures->features
-Fahrenheight->Fahrenheit
+fahrenheight->fahrenheit
 faied->failed, fade,
 faield->failed
 faild->failed
@@ -13279,8 +13279,8 @@ famoust->famous
 fanatism->fanaticism
 fancyness->fanciness
 farction->fraction, faction,
-Farenheight->Fahrenheit
-Farenheit->Fahrenheit
+farenheight->fahrenheit
+farenheit->fahrenheit
 farest->fairest, farthest,
 faries->fairies
 farmework->framework
@@ -13336,9 +13336,9 @@ featurs->features
 feautre->feature
 feauture->feature
 feautures->features
-febewary->February
-Febuary->February
-Feburary->February
+febewary->february
+febuary->february
+feburary->february
 fecthing->fetching
 fedality->fidelity
 fedreally->federally
@@ -13475,7 +13475,7 @@ fingeprint->fingerprint
 finialization->finalization
 finializing->finalizing
 finilizes->finalizes
-finisch->finish, Finnish,
+finisch->finish, finnish,
 finisched->finished
 finishe->finished, finish,
 finishied->finished
@@ -13564,7 +13564,7 @@ flawess->flawless
 fle->file
 fleed->fled, freed,
 flem->phlegm
-Flemmish->Flemish
+flemmish->flemish
 flewant->fluent
 flexability->flexibility
 flexable->flexible
@@ -13853,7 +13853,7 @@ foriegn->foreign
 forld->fold
 forlder->folder
 forlders->folders
-Formalhaut->Fomalhaut
+formalhaut->fomalhaut
 formallize->formalize
 formallized->formalized
 formaly->formally, formerly,
@@ -13930,7 +13930,7 @@ foult->fault
 foults->faults
 foundaries->foundries
 foundary->foundry
-Foundland->Newfoundland
+foundland->newfoundland
 fourties->forties
 fourty->forty
 fouth->fourth
@@ -13965,8 +13965,8 @@ framwork->framework
 framworks->frameworks
 frane->frame
 frankin->franklin
-Fransiscan->Franciscan
-Fransiscans->Franciscans
+fransiscan->franciscan
+fransiscans->franciscans
 franzise->franchise
 frecuencies->frequencies
 frecuency->frequency
@@ -14169,12 +14169,12 @@ fysisit->physicist
 gabage->garbage
 gadged->gadget, gauged,
 galatic->galactic
-Galations->Galatians
+galations->galatians
 gallaries->galleries
 gallary->gallery
 gallaxies->galaxies
 galvinized->galvanized
-Gameboy->Game Boy
+gameboy->game boy
 ganbia->gambia
 ganerate->generate
 ganes->games
@@ -14216,9 +14216,9 @@ gaurd->guard, gourd,
 gaurentee->guarantee
 gaurenteed->guaranteed
 gaurentees->guarantees
-gaus'->Gauss'
-gaus's->Gauss'
-gaus->Gauss, gauze,
+gaus'->gauss'
+gaus's->gauss'
+gaus->gauss, gauze,
 gausian->gaussian
 geeneric->generic
 geenrate->generate
@@ -14379,10 +14379,10 @@ getttext->gettext
 getttime->gettime
 getttimeofday->gettimeofday
 gettting->getting
-ggogle->goggle, Google,
-ggogled->Googled
-ggogles->goggles, Googles,
-Ghandi->Gandhi
+ggogle->goggle, google,
+ggogled->googled
+ggogles->goggles, googles,
+ghandi->gandhi
 ghostscritp->ghostscript
 ghraphic->graphic
 gigibit->gigabit
@@ -14426,11 +14426,11 @@ gnorung->ignoring
 gobal->global
 godess->goddess
 godesses->goddesses
-Godounov->Godunov
+godounov->godunov
 goemetries->geometries
 goess->goes
 gogether->together
-gogin->going, Gauguin,
+gogin->going, gauguin,
 goign->going
 goin->going
 goind->going
@@ -14443,8 +14443,8 @@ gord->gourd
 gormay->gourmet
 gorry->gory
 gost->ghost
-Gothenberg->Gothenburg
-Gottleib->Gottlieb
+gothenberg->gothenburg
+gottleib->gottlieb
 gouvener->governor
 govement->government
 govenment->government
@@ -14503,7 +14503,7 @@ grephic->graphic
 grestest->greatest
 greysacles->greyscales
 gridles->griddles
-grigorian->Gregorian
+grigorian->gregorian
 grobal->global
 grobally->globally
 grometry->geometry
@@ -14523,8 +14523,8 @@ gruop->group
 gruopd->grouped
 gruops->groups
 grwo->grow
-Guaduloupe->Guadalupe, Guadeloupe,
-Guadulupe->Guadalupe, Guadeloupe,
+guaduloupe->guadalupe, guadeloupe,
+guadulupe->guadalupe, guadeloupe,
 guage->gauge
 guaranted->guaranteed
 guaranteey->guaranty
@@ -14653,14 +14653,14 @@ guaruntees->guarantees
 guarunteing->guaranteeing
 guaruntes->guarantees
 guarunty->guaranty
-guas'->Gauss'
-guas's->Gauss'
-guas->Gauss
-guass'->Gauss'
-guass->Gauss
-guassian->Gaussian
-Guatamala->Guatemala
-Guatamalan->Guatemalan
+guas'->gauss'
+guas's->gauss'
+guas->gauss
+guass'->gauss'
+guass->gauss
+guassian->gaussian
+guatamala->guatemala
+guatamalan->guatemalan
 gud->good
 gude->guide, good,
 guerrila->guerrilla
@@ -14669,10 +14669,10 @@ gueswork->guesswork
 guidence->guidance
 guidline->guideline
 guidlines->guidelines
-Guilia->Giulia
-Guilio->Giulio
-Guiness->Guinness
-Guiseppe->Giuseppe
+guilia->giulia
+guilio->giulio
+guiness->guinness
+guiseppe->giuseppe
 gunanine->guanine
 gurantee->guarantee
 guranteed->guaranteed
@@ -14689,7 +14689,7 @@ habaeus->habeas
 habbit->habit
 habeus->habeas
 hability->ability
-Habsbourg->Habsburg
+habsbourg->habsburg
 hace->have
 hach->hatch, hack, hash,
 hachish->hackish
@@ -14703,7 +14703,7 @@ hahve->have, halve, half,
 halarious->hilarious
 hald->held
 halfs->halves
-Hallowean->Hallowe'en, Halloween,
+hallowean->hallowe'en, halloween,
 halp->help
 halpoints->halfpoints
 hammmer->hammer
@@ -14834,7 +14834,7 @@ hasn;t->hasn't
 hasnt'->hasn't
 hasnt->hasn't
 hass->hash
-Hatian->Haitian
+hatian->haitian
 hauty->haughty
 hav->have, half,
 hava->have, have a,
@@ -14865,7 +14865,7 @@ healthercare->healthcare
 heared->heard, header,
 heathy->healthy
 hefer->heifer
-Heidelburg->Heidelberg
+heidelburg->heidelberg
 heigest->highest
 heigh->height, high,
 heigher->higher
@@ -14900,7 +14900,7 @@ henc->hence
 henderence->hindrance
 hendler->handler
 hepler->helper
-herad->heard, Hera,
+herad->heard, hera,
 herat->heart
 heree->here
 heridity->heredity
@@ -15195,8 +15195,8 @@ hypvervisor->hypervisor
 hypvervisors->hypervisors
 hypvisor->hypervisor
 hypvisors->hypervisors
-I'sd->I'd
-i;ll->I'll
+i'sd->i'd
+i;ll->i'll
 iamge->image
 ibrary->library
 icesickle->icicle
@@ -15316,7 +15316,7 @@ igored->ignored
 igores->ignores
 igoring->ignoring
 igrnore->ignore
-Ihaca->Ithaca
+ihaca->ithaca
 ihs->his
 iif->if
 iimmune->immune
@@ -17129,7 +17129,7 @@ isntance->instance
 isntances->instances
 isotrophically->isotropically
 isplay->display
-Israelies->Israelis
+israelies->israelis
 isssue->issue
 isssued->issued
 isssues->issues
@@ -17200,17 +17200,17 @@ iwth->with
 jagid->jagged
 jagwar->jaguar
 jalusey->jealousy, jalousie,
-januar->January
-janurary->January
-Januray->January
+januar->january
+janurary->january
+januray->january
 japanease->japanese
-japaneese->Japanese
-Japanes->Japanese
-japanses->Japanese
+japaneese->japanese
+japanes->japanese
+japanses->japanese
 jaques->jacques
 javacript->javascript
 javascipt->javascript
-JavaSciript->JavaScript
+javasciript->javascript
 javascritp->javascript
 javascropt->javascript
 javasript->javascript
@@ -17223,17 +17223,17 @@ jelous->jealous
 jelousy->jealousy
 jelusey->jealousy
 jepordize->jeopardize
-jewl->Jew, jewel,
+jewl->jew, jewel,
 jewllery->jewellery
 jitterr->jitter
 jitterring->jittering
 jodpers->jodhpurs
-Johanine->Johannine
+johanine->johannine
 joineable->joinable
 joinning->joining
 jornal->journal
 jorunal->journal
-Jospeh->Joseph
+jospeh->joseph
 jossle->jostle
 jouney->journey
 journied->journeyed
@@ -17243,8 +17243,8 @@ jpng->png, jpg, jpeg,
 jscipt->jscript
 jstu->just
 jsut->just
-Juadaism->Judaism
-Juadism->Judaism
+juadaism->judaism
+juadism->judaism
 judical->judicial
 judisuary->judiciary
 juducial->judicial
@@ -17256,7 +17256,7 @@ jumpt->jumped, jump,
 juristiction->jurisdiction
 juristictions->jurisdictions
 jus->just
-juse->just, juice, Jude, June,
+juse->just, juice, jude, june,
 justfied->justified
 justication->justification
 justifed->justified
@@ -17268,7 +17268,7 @@ juxtified->justified
 juxtifies->justifies
 juxtifying->justifying
 kake->cake, take,
-kazakstan->Kazakhstan
+kazakstan->kazakhstan
 keep-alives->keep-alive
 keept->kept
 kenel->kernel, kennel,
@@ -17344,19 +17344,19 @@ konws->knows
 koordinate->coordinate
 koordinates->coordinates
 kown->known
-kubenates->Kubernetes
-kubenernetes->Kubernetes
-kubenertes->Kubernetes
-kubenetes->Kubernetes
-kubenretes->Kubernetes
-kuberenetes->Kubernetes
-kuberentes->Kubernetes
-kuberetes->Kubernetes
-kubermetes->Kubernetes
-kubernates->Kubernetes
-kubernests->Kubernetes
-kubernete->Kubernetes
-kuberntes->Kubernetes
+kubenates->kubernetes
+kubenernetes->kubernetes
+kubenertes->kubernetes
+kubenetes->kubernetes
+kubenretes->kubernetes
+kuberenetes->kubernetes
+kuberentes->kubernetes
+kuberetes->kubernetes
+kubermetes->kubernetes
+kubernates->kubernetes
+kubernests->kubernetes
+kubernete->kubernetes
+kuberntes->kubernetes
 kwno->know
 kwoledgebase->knowledge base
 kyrillic->cyrillic
@@ -17423,7 +17423,7 @@ laod->load
 laoded->loaded
 laoding->loading
 laods->loads
-Laotion->Laotian
+laotion->laotian
 laout->layout
 larg->large
 larget->larger, largest, target,
@@ -17831,18 +17831,18 @@ losen->loosen
 losened->loosened
 losted->listed, lost, lasted,
 lotation->rotation, flotation,
-lotharingen->Lothringen
+lotharingen->lothringen
 lowd->load, low, loud,
 lpatform->platform
 lsat->last, slat, sat,
 lsit->list, slit, sit,
 lsits->lists, slits, sits,
-lukid->lucid, Likud,
+lukid->lucid, likud,
 luminose->luminous
 luminousity->luminosity
 lveo->love
 lvoe->love
-Lybia->Libya
+lybia->libya
 maake->make
 mabe->maybe
 mabye->maybe
@@ -17902,8 +17902,8 @@ maintiain->maintain
 maintians->maintains
 maintinaing->maintaining
 maintioned->mentioned
-mairabd->MariaDB
-mairadb->MariaDB
+mairabd->mariadb
+mairadb->mariadb
 maitain->maintain
 maitainance->maintenance
 maitained->maintained
@@ -17921,12 +17921,12 @@ makrs->makes, makers, macros,
 maks->mask, masks, makes, make,
 makse->makes, masks,
 makss->masks, makes,
-Malcom->Malcolm
+malcom->malcolm
 malicous->malicious
 malicously->maliciously
 malplace->misplace
 malplaced->misplaced
-maltesian->Maltese
+maltesian->maltese
 mamagement->management
 mamal->mammal
 mamalian->mammalian
@@ -18039,7 +18039,7 @@ marger->merger, marker,
 margers->mergers, markers,
 marging->margin, merging,
 margings->margins
-mariabd->MariaDB
+mariabd->mariadb
 mariage->marriage
 marjority->majority
 markes->marks, marked, markers,
@@ -18063,8 +18063,8 @@ maskeraid->masquerade
 masos->macos
 masquarade->masquerade
 masqurade->masquerade
-Massachussets->Massachusetts
-Massachussetts->Massachusetts
+massachussets->massachusetts
+massachussetts->massachusetts
 massagebox->messagebox
 massectomy->mastectomy
 massewer->masseur
@@ -18144,7 +18144,7 @@ maxumum->maximum
 maybee->maybe
 mayority->majority
 mayu->may
-mazilla->Mozilla
+mazilla->mozilla
 mccarthyst->mccarthyist
 mchanic->mechanic
 mchanical->mechanical
@@ -18235,7 +18235,7 @@ mediciney->medicine, medicinal,
 mediciny->medicine, medicinal,
 medievel->medieval
 mediterainnean->mediterranean
-Mediteranean->Mediterranean
+mediteranean->mediterranean
 meeds->needs
 meens->means
 meerkrat->meerkat
@@ -18298,7 +18298,7 @@ menue->menu
 menues->menus
 menutitems->menuitems
 meny->menu, many,
-meranda->veranda, Miranda,
+meranda->veranda, miranda,
 mercahnt->merchant
 mercentile->mercantile
 merchantibility->merchantability
@@ -18390,21 +18390,21 @@ miagic->magic
 miagical->magical
 mial->mail
 mices->mice
-Michagan->Michigan
+michagan->michigan
 micorcode->microcode
 micorcodes->microcodes
-Micorsoft->Microsoft
+micorsoft->microsoft
 micoscope->microscope
 micoscopes->microscopes
 micoscopic->microscopic
 micoscopies->microscopies
 micoscopy->microscopy
-Micosoft->Microsoft
+micosoft->microsoft
 micrcontroller->microcontroller
 micrcontrollers->microcontrollers
 microcontroler->microcontroller
 microcontrolers->microcontrollers
-Microfost->Microsoft
+microfost->microsoft
 microntroller->microcontroller
 microntrollers->microcontrollers
 micropone->microphone
@@ -18413,13 +18413,13 @@ microprocesspr->microprocessor
 microprocessprs->microprocessors
 microseond->microsecond
 microseonds->microseconds
-Microsft->Microsoft
+microsft->microsoft
 microship->microchip
 microships->microchips
-Microsof->Microsoft
-Microsofot->Microsoft
-Micrsft->Microsoft
-Micrsoft->Microsoft
+microsof->microsoft
+microsofot->microsoft
+micrsft->microsoft
+micrsoft->microsoft
 midified->modified
 migrateable->migratable
 migt->might, midget,
@@ -18505,7 +18505,7 @@ miminaly->minimally
 miminize->minimize
 minature->miniature
 minerial->mineral
-MingGW->MinGW
+minggw->mingw
 minimam->minimum
 minimial->minimal
 minimium->minimum
@@ -18551,7 +18551,7 @@ mircophone->microphone
 mircophones->microphones
 mircoscope->microscope
 mircoscopes->microscopes
-mircosoft->Microsoft
+mircosoft->microsoft
 mirgate->migrate
 mirgated->migrated
 mirgates->migrates
@@ -18585,7 +18585,7 @@ mischeivous->mischievous
 mischevious->mischievous
 mischievious->mischievous
 misconfiged->misconfigured
-Miscrosoft->Microsoft
+miscrosoft->microsoft
 misdameanor->misdemeanor
 misdameanors->misdemeanors
 misdemenor->misdemeanor
@@ -18606,7 +18606,7 @@ mismaching->mismatching
 mismactch->mismatch
 mismatchd->mismatched
 mismatich->mismatch
-Misouri->Missouri
+misouri->missouri
 mispell->misspell
 mispelled->misspelled
 mispelling->misspelling
@@ -18623,8 +18623,8 @@ missign->missing
 missin->mission, missing,
 missingassignement->missingassignment
 missings->missing
-Missisipi->Mississippi
-Missisippi->Mississippi
+missisipi->mississippi
+missisippi->mississippi
 missle->missile
 missleading->misleading
 missmanaged->mismanaged
@@ -18681,7 +18681,7 @@ mocroprocessor->microprocessor
 mocroprocessors->microprocessors
 mocrosecond->microsecond
 mocroseconds->microseconds
-Mocrosoft->Microsoft
+mocrosoft->microsoft
 mocule->module
 mocules->modules
 moddel->model
@@ -18797,6 +18797,7 @@ mofification->modification
 mofified->modified
 mofifies->modifies
 mofify->modify
+mohammedan->muslim
 mohammedans->muslims
 moint->mount
 moleclues->molecules
@@ -18834,12 +18835,12 @@ monotir->monitor
 monotired->monitored
 monotiring->monitoring
 monotirs->monitors
-Monserrat->Montserrat
+monserrat->montserrat
 monstrum->monster
 montains->mountains
 montanous->mountainous
 montly->monthly
-Montnana->Montana
+montnana->montana
 monts->months
 montypic->monotypic
 moodify->modify
@@ -18909,10 +18910,10 @@ movemnt->movement
 movemnts->movements
 movied->moved, movie,
 movment->movement
-mozila->Mozilla
+mozila->mozilla
 mozzilla->mozilla
 mroe->more
-MSDOS->MS-DOS
+msdos->ms-dos
 mssing->missing
 msssge->message
 mthod->method
@@ -19056,7 +19057,7 @@ mysogynist->misogynist
 mysogyny->misogyny
 mysterous->mysterious
 mystql->mysql
-Mythraic->Mithraic
+mythraic->mithraic
 myu->my
 nadly->badly
 naerly->nearly, gnarly,
@@ -19084,9 +19085,9 @@ nanosencond->nanosecond
 nanosenconds->nanoseconds
 nanoseond->nanosecond
 nanoseonds->nanoseconds
-Naploeon->Napoleon
-Napolean->Napoleon
-Napoleonian->Napoleonic
+naploeon->napoleon
+napolean->napoleon
+napoleonian->napoleonic
 nastly->nasty
 nastyness->nastiness
 nativelyx->natively
@@ -19108,7 +19109,7 @@ nax->max, nad,
 naxima->maxima
 naximal->maximal
 naximum->maximum
-Nazereth->Nazareth
+nazereth->nazareth
 nclude->include
 nd->and, 2nd,
 nead->need
@@ -19633,7 +19634,7 @@ neworks->networks
 newslines->newlines
 newthon->newton
 newtork->network
-Newyorker->New Yorker
+newyorker->new yorker
 nighbor->neighbor
 nighborhood->neighborhood
 nighboring->neighboring
@@ -19838,8 +19839,8 @@ notse->notes, note,
 nott->not
 notwhithstanding->notwithstanding
 noveau->nouveau
-Novemer->November
-Novermber->November
+novemer->november
+novermber->november
 nowadys->nowadays
 nowdays->nowadays
 nowe->now
@@ -19854,7 +19855,7 @@ nuculear->nuclear
 nuisanse->nuisance
 nuissance->nuisance
 nulk->null
-Nullabour->Nullarbor
+nullabour->nullarbor
 nulll->null
 numberal->numeral
 numberals->numerals
@@ -19888,14 +19889,14 @@ numver->number
 numvers->numbers
 nunber->number
 nunbers->numbers
-Nuremburg->Nuremberg
+nuremburg->nuremberg
 nusance->nuisance
 nutritent->nutrient
 nutritents->nutrients
 nuturing->nurturing
 nwe->new
 nwo->now
-o'caml->OCaml
+o'caml->ocaml
 oaram->param
 obay->obey
 obect->object
@@ -20102,7 +20103,7 @@ ojects->objects
 ojekts->objects
 okat->okay
 oldes->oldest
-oll->all, ole, old, Olly, oil,
+oll->all, ole, old, olly, oil,
 olny->only
 olt->old
 olther->other
@@ -20794,9 +20795,9 @@ palces->places, pales,
 paleolitic->paleolithic
 palete->palette
 paliamentarian->parliamentarian
-Palistian->Palestinian
-Palistinian->Palestinian
-Palistinians->Palestinians
+palistian->palestinian
+palistinian->palestinian
+palistinians->palestinians
 pallete->palette
 pallette->palette
 palletted->paletted
@@ -20812,7 +20813,7 @@ pannels->panels
 pantomine->pantomime
 paoition->position
 paor->pair
-Papanicalou->Papanicolaou
+papanicalou->papanicolaou
 paradime->paradigm
 paradym->paradigm
 paraemeter->parameter
@@ -20932,7 +20933,7 @@ paritition->partition
 parititions->partitions
 parituclar->particular
 parliment->parliament
-parm->param, pram, Parma,
+parm->param, pram, parma,
 parmaeter->parameter
 parmaeters->parameters
 parmameter->parameter
@@ -21105,7 +21106,7 @@ peirod->period
 peirodical->periodical
 peirodicals->periodicals
 peirods->periods
-Peloponnes->Peloponnese, Peloponnesus,
+peloponnes->peloponnese, peloponnesus,
 penalities->penalties
 penality->penalty
 penatly->penalty
@@ -21120,7 +21121,7 @@ pennals->panels
 penninsula->peninsula
 penninsular->peninsular
 pennisula->peninsula
-Pennyslvania->Pennsylvania
+pennyslvania->pennsylvania
 pensinula->peninsula
 pensle->pencil
 penultimante->penultimate
@@ -21378,7 +21379,7 @@ petetion->petition
 pevent->prevent
 pevents->prevents
 pezier->bezier
-Pharoah->Pharaoh
+pharoah->pharaoh
 phasepsace->phasespace
 phasis->phases
 phenomenom->phenomenon
@@ -21388,19 +21389,19 @@ phenomonenon->phenomenon
 phenomonon->phenomenon
 phenonmena->phenomena
 pheriparials->peripherals
-Philipines->Philippines
+philipines->philippines
 philisopher->philosopher
 philisophical->philosophical
 philisophy->philosophy
-Phillipine->Philippine
+phillipine->philippine
 phillipines->philippines
-Phillippines->Philippines
+phillippines->philippines
 phillosophically->philosophically
 philospher->philosopher
 philosphies->philosophies
 philosphy->philosophy
 phisosophy->philosophy
-Phonecian->Phoenecian
+phonecian->phoenecian
 phoneticly->phonetically
 phongraph->phonograph
 phote->photo
@@ -21654,7 +21655,7 @@ polysaccaride->polysaccharide
 polysaccharid->polysaccharide
 pomegranite->pomegranate
 pomotion->promotion
-pompay->Pompeii
+pompay->pompeii
 poninter->pointer
 poniter->pointer
 pont->point
@@ -21722,13 +21723,13 @@ portait->portrait
 portaits->portraits
 portayed->portrayed
 portected->protected
-portguese->Portuguese
+portguese->portuguese
 portioon->portion
 portrail->portrayal, portrait,
 portraing->portraying
-portugese->Portuguese
-portuguease->Portuguese
-portugues->Portuguese
+portugese->portuguese
+portuguease->portuguese
+portugues->portuguese
 posative->positive
 posatives->positives
 posativity->positivity
@@ -21748,7 +21749,7 @@ posibly->possibly
 posiitive->positive
 posiitives->positives
 posiitivity->positivity
-posion->poison, Psion,
+posion->poison, psion,
 posioned->positioned, poisoned,
 posioning->poisoning
 posisition->position
@@ -21771,7 +21772,7 @@ positoning->positioning
 positons->positions, positrons,
 positve->positive
 positves->positives
-POSIX-complient->POSIX-compliant
+posix-complient->posix-compliant
 pospone->postpone
 posponed->postponed
 posption->position
@@ -21823,10 +21824,10 @@ post-proces->post-process
 post-procesing->post-processing
 postcondtion->postcondition
 postcondtions->postconditions
-Postdam->Potsdam
-postgress->PostgreSQL
-postgressql->PostgreSQL
-postgrsql->PostgreSQL
+postdam->potsdam
+postgress->postgresql
+postgressql->postgresql
+postgrsql->postgresql
 posthomous->posthumous
 postiional->positional
 postiive->positive
@@ -22070,7 +22071,7 @@ preminence->preeminence
 premission->permission
 premit->permit
 premits->permits
-Premonasterians->Premonstratensians
+premonasterians->premonstratensians
 premption->preemption
 premptive->preemptive
 premptively->preemptively
@@ -22898,9 +22899,9 @@ publushers->publishers
 publushes->publishes
 publushing->publishing
 puchasing->purchasing
-Pucini->Puccini
-Puertorrican->Puerto Rican
-Puertorricans->Puerto Ricans
+pucini->puccini
+puertorrican->puerto rican
+puertorricans->puerto ricans
 pulisher->publisher
 pullrequenst->pull requests, pull request,
 pullrequest->pull request
@@ -22982,7 +22983,7 @@ quating->quoting, squatting,
 quckstarter->quickstarter
 qudrangles->quadrangles
 quee->queue
-Queenland->Queensland
+queenland->queensland
 queing->queueing
 queiried->queried
 queisce->quiesce
@@ -23330,7 +23331,7 @@ readble->readable
 readby->read, read by,
 readeable->readable
 readed->read, readd, readded,
-reademe->README
+reademe->readme
 readiable->readable
 readibility->readability
 readible->readable
@@ -23376,7 +23377,7 @@ realtions->relations, reactions,
 realtive->relative, reactive,
 realy->really
 realyl->really
-reamde->README
+reamde->readme
 reamins->remains
 reampping->remapping, revamping,
 reander->render
@@ -25300,7 +25301,7 @@ roatation->rotation
 roated->rotated
 roation->rotation
 roboustness->robustness
-Rockerfeller->Rockefeller
+rockerfeller->rockefeller
 rococco->rococo
 rocord->record
 roduce->reduce, produce,
@@ -25402,8 +25403,8 @@ runnung->running
 runtine->runtime, routine,
 runting->runtime
 rurrent->current
-russina->Russian
-Russion->Russian
+russina->russian
+russion->russian
 rwite->write
 rysnc->rsync
 rythem->rhythm
@@ -25420,7 +25421,7 @@ sacarin->saccharin
 sacle->scale
 sacrafice->sacrifice
 sacreligious->sacrilegious
-Sacremento->Sacramento
+sacremento->sacramento
 sacrifical->sacrificial
 sacrifying->sacrificing
 sacrilegeous->sacrilegious
@@ -25434,7 +25435,7 @@ safeing->saving
 safepooint->safepoint
 safepooints->safepoints
 safequard->safeguard
-saferi->Safari
+saferi->safari
 safetly->safely
 safly->safely
 saftey->safety
@@ -25447,14 +25448,14 @@ samll->small
 samller->smaller
 sammon->salmon
 samori->samurai
-samue->same, Samuel,
+samue->same, samuel,
 samwich->sandwich
 samwiches->sandwiches
 sanaty->sanity
 sanctionning->sanctioning
 sandobx->sandbox
 sandwhich->sandwich
-Sanhedrim->Sanhedrin
+sanhedrim->sanhedrin
 sanitizisation->sanitization
 sanizer->sanitizer
 santioned->sanctioned
@@ -25480,8 +25481,8 @@ satelites->satellites
 satelitte->satellite
 satement->statement
 satements->statements
-saterday->Saturday
-saterdays->Saturdays
+saterday->saturday
+saterdays->saturdays
 satified->satisfied
 satifies->satisfies
 satify->satisfy
@@ -25503,8 +25504,8 @@ sattelite->satellite
 sattelites->satellites
 sattellite->satellite
 sattellites->satellites
-satuaday->Saturday
-satuadays->Saturdays
+satuaday->saturday
+satuadays->saturdays
 saught->sought
 sav->save
 savees->saves
@@ -25524,7 +25525,7 @@ scaleability->scalability
 scaleable->scalable
 scaleing->scaling
 scalled->scaled
-scandanavia->Scandinavia
+scandanavia->scandinavia
 scaned->scanned
 scaning->scanning
 scannning->scanning
@@ -26025,7 +26026,7 @@ seprate->separate
 seprated->separated
 seprator->separator
 seprators->separators
-Septemer->September
+septemer->september
 sepulchure->sepulchre, sepulcher,
 sepulcre->sepulchre, sepulcher,
 seqence->sequence
@@ -26200,7 +26201,7 @@ shandeleer->chandelier
 shandeleers->chandeliers
 shandow->shadow
 shaneal->chenille
-shanghi->Shanghai
+shanghi->shanghai
 sharable->shareable
 shareed->shared
 sharloton->charlatan
@@ -26505,8 +26506,8 @@ sintaks->syntax
 sintakt->syntax
 sintakts->syntax
 sintax->syntax
-Sionist->Zionist
-Sionists->Zionists
+sionist->zionist
+sionists->zionists
 siply->simply
 sircle->circle
 sircles->circles
@@ -26584,10 +26585,10 @@ sivible->visible
 siwtch->switch
 siwtched->switched
 siwtching->switching
-Sixtin->Sistine, Sixteen,
+sixtin->sistine, sixteen,
 siz->size, six,
 sizre->size
-Skagerak->Skagerrak
+skagerak->skagerrak
 skalar->scalar
 skateing->skating
 skecth->sketch
@@ -26609,8 +26610,8 @@ skiped->skipped, skyped,
 skiping->skipping
 skipp->skip, skipped,
 skippd->skipped
-skipt->skip, Skype, skipped,
-skyp->skip, Skype,
+skipt->skip, skype, skipped,
+skyp->skip, skype,
 slach->slash
 slaches->slashes
 slase->slash
@@ -26659,7 +26660,7 @@ smooting->smoothing
 smouth->smooth
 smouthness->smoothness
 smove->move
-smpt->SMTP, SMTPE,
+smpt->smtp, smtpe,
 snaped->snapped
 snaphot->snapshot
 snaphsot->snapshot
@@ -26675,7 +26676,7 @@ snpashot->snapshot
 snpashots->snapshots
 snyc->sync
 snytax->syntax
-Soalris->Solaris
+soalris->solaris
 socail->social
 socalism->socialism
 socekts->sockets
@@ -26829,7 +26830,7 @@ spageti->spaghetti
 spagetti->spaghetti
 spagheti->spaghetti
 spagnum->sphagnum
-spainish->Spanish
+spainish->spanish
 spaning->spanning
 sparate->separate
 sparately->separately
@@ -28618,8 +28619,8 @@ targte->target
 tarmigan->ptarmigan
 tarnsparent->transparent
 tarpolin->tarpaulin
-tarvis->Travis
-tarvisci->TravisCI
+tarvis->travis
+tarvisci->travisci
 tasbar->taskbar
 taskelt->tasklet
 tast->taste
@@ -29216,7 +29217,7 @@ tolens->tokens
 toleranz->tolerance
 tolerence->tolerance
 tolernce->tolerance
-Tolkein->Tolkien
+tolkein->tolkien
 tollerable->tolerable
 tollerance->tolerance
 tollerances->tolerances
@@ -29811,7 +29812,7 @@ turorial->tutorial
 turorials->tutorials
 turtorial->tutorial
 turtorials->tutorials
-Tuscon->Tucson
+tuscon->tucson
 tust->trust
 tution->tuition
 tutoriel->tutorial
@@ -29859,13 +29860,13 @@ tyrranies->tyrannies
 tyrrany->tyranny
 ubelieveble->unbelievable
 ubelievebly->unbelievably
-ubernetes->Kubernetes
+ubernetes->kubernetes
 ubiquitious->ubiquitous
 ubiquituously->ubiquitously
 ubitquitous->ubiquitous
 ublisher->publisher
-ubunut->Ubuntu
-ubutunu->Ubuntu
+ubunut->ubuntu
+ubutunu->ubuntu
 udated->updated, dated,
 udater->updater, dater,
 udating->updating, dating,
@@ -29892,7 +29893,7 @@ uites->suites
 uknown->unknown
 uknowns->unknowns
 ukowns->unknowns, unknown,
-Ukranian->Ukrainian
+ukranian->ukrainian
 ulimited->unlimited
 ulter->alter
 ulteration->alteration
@@ -30223,7 +30224,7 @@ unhandeled->unhandled
 unhilight->unhighlight
 unhilighted->unhighlighted
 unhilights->unhighlights
-Unicde->Unicode
+unicde->unicode
 unich->unix
 unidentifiedly->unidentified
 unidimensionnal->unidimensional
@@ -30288,7 +30289,7 @@ uniqe->unique
 uniqu->unique
 uniquness->uniqueness
 uniterrupted->uninterrupted
-UnitesStates->UnitedStates
+unitesstates->unitedstates
 unitialize->uninitialize
 unitialized->uninitialized
 unitilised->uninitialised
@@ -30396,7 +30397,7 @@ unnessessary->unnecessary
 unning->running
 unnnecessary->unnecessary
 unnsupported->unsupported
-unocde->Unicode
+unocde->unicode
 unoffical->unofficial
 unoin->union
 unompress->uncompress
@@ -30827,7 +30828,7 @@ usersapce->userspace
 userspase->userspace
 usesfull->useful
 usespace->userspace
-usetnet->Usenet
+usetnet->usenet
 usibility->usability
 usible->usable
 usig->using
@@ -30853,7 +30854,7 @@ usueful->useful
 usupported->unsupported
 ususal->usual
 ususally->usually
-UTF8ness->UTF-8-ness
+utf8ness->utf-8-ness
 utiilties->utilities
 utilies->utilities
 utililties->utilities
@@ -31145,7 +31146,7 @@ vetween->between
 vew->view
 veyr->very
 vhild->child
-viatnamese->Vietnamese
+viatnamese->vietnamese
 vice-fersa->vice-versa
 vice-wersa->vice-versa
 vicefersa->vice-versa
@@ -31155,7 +31156,7 @@ viee->view
 viees->views
 vieport->viewport
 vieports->viewports
-vietnamesea->Vietnamese
+vietnamesea->vietnamese
 viewtransfromation->viewtransformation
 vigeur->vigueur, vigour, vigor,
 vigilence->vigilance
@@ -31311,7 +31312,7 @@ vriety->variety
 vrifier->verifier
 vrifies->verifies
 vrify->verify
-vrilog->Verilog
+vrilog->verilog
 vritual->virtual
 vritualenv->virtualenv
 vritualisation->virtualisation
@@ -31321,8 +31322,8 @@ vritualize->virtualize
 vrituoso->virtuoso
 vrsion->version
 vrsions->versions
-Vulacn->Vulcan
-Vulakn->Vulkan
+vulacn->vulcan
+vulakn->vulkan
 vulbearable->vulnerable
 vulbearabule->vulnerable
 vulbearbilities->vulnerabilities
@@ -31496,8 +31497,8 @@ weas->was
 webage->webpage
 webaserver->web server, webserver,
 webiste->website
-wedensday->Wednesday
-wednesdaay->Wednesday
+wedensday->wednesday
+wednesdaay->wednesday
 wege->wedge
 wehere->where
 wehn->when
@@ -31512,9 +31513,9 @@ weired->weird
 weitght->weight
 well-reknown->well-renowned, well renown,
 well-reknowned->well-renowned, well renowned,
-wendesday->Wednesday
-wendsay->Wednesday
-wensday->Wednesday
+wendesday->wednesday
+wendsay->wednesday
+wensday->wednesday
 were'nt->weren't
 wereabouts->whereabouts
 wereas->whereas
@@ -31728,7 +31729,7 @@ wnat->want, what,
 wnated->wanted
 wnating->wanting
 wnats->wants
-wnen->when, Wen,
+wnen->when, wen,
 wnidow->window, widow,
 wnidows->windows, widows,
 woh->who
@@ -31752,7 +31753,7 @@ woraround->workaround
 worarounds->workarounds
 worbench->workbench
 worbenches->workbenches
-worchester->Worcester
+worchester->worcester
 wordlwide->worldwide
 wordpres->wordpress
 worfklow->workflow
@@ -31913,7 +31914,7 @@ yeld->yield
 yelded->yielded
 yelding->yielding
 yelds->yields
-Yementite->Yemenite, Yemeni,
+yementite->yemenite, yemeni,
 yera->year
 yeras->years
 yersa->years
@@ -31932,7 +31933,7 @@ youseff->yourself, yousef,
 youself->yourself
 ypes->types
 yrea->year
-yse->yes, use, NYSE,
+yse->yes, use, nyse,
 ytou->you
 yugoslac->yugoslav
 yuo->you


### PR DESCRIPTION
This PR is a proposal to, for consistency, make all dictionary entries (typo, suggestions, and hints) lowercase.

I'm doing this for two reasons:
1. because I've observed that proper capitalization of various proper nouns is hard enforce everywhere, and all over the dict there are messed up capitalizations.

2. There is **no** point to having them capitalized, because `build_dict()` converts them to lowercase before it uses them:
   https://github.com/codespell-project/codespell/blob/c6293a665b64d7d19e31b907a28335619a0b4923/codespell_lib/_codespell.py#L458-L461