### PR TITLE
Add ore->or to dictionary_rare.txt

### DIFF
--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -26,7 +26,6 @@ mut->must, mutt, moot,
 nto->not
 objext->object
 od->of
-ore->or
 process'->process's
 protecten->protection
 reday->ready

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -26,6 +26,7 @@ mut->must, mutt, moot,
 nto->not
 objext->object
 od->of
+ore->or
 process'->process's
 protecten->protection
 reday->ready

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -99,6 +99,7 @@ moil->soil, mohel,
 mot->not
 moue->mouse
 nickle->nickel
+ore->or
 panting->painting
 payed->paid
 planed->planned


### PR DESCRIPTION
There is a `ORE` library which seems to be commonly used. `ore` is also a valid word but also might be a spelling mistake of `or`, hope the placement in dictionary_code.txt is correct to handle such edge cases.