### PR TITLE
Fix typos from jupyter/jupyter#558

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5999,6 +5999,8 @@ commnent->comment
 commnents->comments
 commnetary->commentary
 commnication->communication
+commnities->communities
+commnity->community
 commnt->comment
 commnted->commented
 commnuative->commutative
@@ -10111,6 +10113,7 @@ disctionaries->dictionaries
 disctionary->dictionary
 discuassed->discussed
 discusion->discussion
+discusions->discussions
 discusson->discussion
 discussons->discussions
 discusting->disgusting
@@ -11810,6 +11813,12 @@ eventially->eventually
 eventuall->eventually
 eventualy->eventually
 evenually->eventually
+eveolution->evolution
+eveolutionary->evolutionary
+eveolve->evolve
+eveolved->evolved
+eveolves->evolves
+eveolving->evolving
 everage->average
 everaged->averaged
 everbody->everybody
@@ -17670,6 +17679,9 @@ limititer->limiter
 limititers->limiters
 limititing->limiting
 limitted->limited
+limitter->limiter
+limitting->limiting
+limitts->limits
 limk->link
 limted->limited
 limti->limit
@@ -24960,6 +24972,7 @@ resrouce->resource
 resrouced->resourced
 resrouces->resources
 resroucing->resourcing
+reSructuredText->reStructuredText
 resrved->reserved
 ressapee->recipe
 ressemblance->resemblance
@@ -25013,9 +25026,14 @@ restrcted->restricted
 restrcuture->restructure
 restriced->restricted
 restroing->restoring
+reStructuredTetx->reStructuredText
+reStructuredTxet->reStructuredText
+reStrucuredText->reStructuredText
 restuarant->restaurant
 restuarants->restaurants
+reStucturedText->reStructuredText
 restucturing->restructuring
+reStucuredText->reStructuredText
 resturant->restaurant
 resturants->restaurants
 resturaunt->restaurant
@@ -27602,7 +27620,12 @@ structue->structure
 structued->structured
 structues->structures
 structur->structure
+strucur->structure
 strucure->structure
+strucured->structured
+strucures->structures
+strucuring->structuring
+strucurs->structures
 strucutre->structure
 strucutred->structured
 strucutres->structures
@@ -28110,7 +28133,9 @@ suported->supported
 suporting->supporting
 suports->supports
 suportted->supported
+suposable->supposable
 supose->suppose
+suposeable->supposable
 suposed->supposed
 suposedly->supposedly
 suposes->supposes
@@ -28139,6 +28164,7 @@ supportes->supports
 supportet->supporter, supported,
 supportin->supporting
 supportted->supported
+supposeable->supposable
 supposeded->supposed
 supposedely->supposedly
 supposeds->supposed
@@ -31498,6 +31524,7 @@ weaponary->weaponry
 weas->was
 webage->webpage
 webaserver->web server, webserver,
+webbased->web-based
 webiste->website
 wedensday->Wednesday
 wednesdaay->Wednesday


### PR DESCRIPTION
From jupyter/jupyter#558

9 typos + 18 variants = 27 total

The original typos were:

    commnity
    concurent
    discusions
    eveolves
    limitted
    reStructuredText
    strucured
    suposed
    webbased