### PR TITLE
Move uis->is, use, to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18197,9 +18197,9 @@ measue->measure
 measued->measured
 measuer->measurer
 measues->measures
-measuing->measuring
 measuement->measurement
 measuements->measurements
+measuing->measuring
 measurd->measured, measure,
 measuremenet->measurement
 measuremenets->measurements

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18195,10 +18195,10 @@ mear->wear, mere, mare,
 mearly->merely, nearly,
 measue->measure
 measued->measured
-measuer->measurer
-measues->measures
 measuement->measurement
 measuements->measurements
+measuer->measurer
+measues->measures
 measuing->measuring
 measurd->measured, measure,
 measuremenet->measurement

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -29913,7 +29913,6 @@ uggly->ugly
 ugglyness->ugliness
 uglyness->ugliness
 uique->unique
-uis->is, use,
 uise->use
 uisng->using
 uite->suite, unite,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18193,6 +18193,13 @@ meaninless->meaningless
 meaninng->meaning
 mear->wear, mere, mare,
 mearly->merely, nearly,
+measue->measure
+measued->measured
+measuer->measurer
+measues->measures
+measuing->measuring
+measuement->measurement
+measuements->measurements
 measurd->measured, measure,
 measuremenet->measurement
 measuremenets->measurements

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -48,5 +48,6 @@ todays->today's
 udate->update, date,
 udates->updates, dates,
 uint->unit
+uis->is, use,
 were'->we're
 whome->whom


### PR DESCRIPTION
Given it would be the correct way to refer to more than one user interface.

This arises from  #1829

