### PR TITLE
Add 'satus' to dictionary, suggesting typo of 'status'.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25522,6 +25522,7 @@ sattellite->satellite
 sattellites->satellites
 satuaday->Saturday
 satuadays->Saturdays
+satus->status
 saught->sought
 sav->save
 savees->saves


### PR DESCRIPTION
Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>