### PR TITLE
Fix unfortunate typo generated by old sphinx-doc

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -26230,6 +26230,7 @@ sharloton->charlatan
 sharraid->charade
 sharraids->charades
 shashes->slashes
+shat->that
 shatow->château
 shbang->shebang
 sheat->sheath, sheet, cheat,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -26230,7 +26230,6 @@ sharloton->charlatan
 sharraid->charade
 sharraids->charades
 shashes->slashes
-shat->that, shit,
 shatow->château
 shbang->shebang
 sheat->sheath, sheet, cheat,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -26230,7 +26230,7 @@ sharloton->charlatan
 sharraid->charade
 sharraids->charades
 shashes->slashes
-shat->that
+shat->that, shit,
 shatow->château
 shbang->shebang
 sheat->sheath, sheet, cheat,

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -133,6 +133,7 @@ sate->state
 sates->states
 savable->saveable
 setts->sets
+shat->that, shit,
 sightly->slightly
 simplication->simplification
 singe->single


### PR DESCRIPTION
A lot of repositories contain this typo which was introduced by a bug in
a sphinx-doc template which has since been fixed but the legacy remains.

Examples:
* https://github.com/mozillazg/python-pinyin/pull/196
* https://github.com/lambdalisue/django-permission/pull/84
* https://github.com/philippbosch/django-geoposition/pull/113
* https://github.com/revsys/django-test-plus/pull/117
* https://github.com/danjac/pyramid_storage/pull/38
* https://github.com/tetframework/Tonnikala/pull/7
* https://github.com/duerrp/pyexperiment/pull/2