### PR TITLE
Add corrections from secdev/scapy#3302

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -6640,6 +6640,7 @@ configuations->configurations
 configue->configure
 configued->configured
 configuerd->configured
+configuered->configured
 configues->configures
 configuraion->configuration
 configuraiton->configuration
@@ -15923,6 +15924,7 @@ indecies->indices
 indefinate->indefinite
 indefinately->indefinitely
 indefineable->undefinable
+indefinetly->indefinitely
 indefinitiley->indefinitely
 indefinitively->indefinitely
 indefinitly->indefinitely
@@ -25049,6 +25051,7 @@ resue->reuse, rescue,
 resued->reused, rescued,
 resul->result
 resuling->resulting
+resullt->result
 resulotion->resolution
 resulsets->resultsets
 resultion->resolution
@@ -31597,6 +31600,7 @@ whihc->which
 whihch->which
 whike->while
 whilest->whilst
+whill->will
 whiltelist->whitelist
 whiltelisted->whitelisted
 whiltelisting->whitelisting

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -19,6 +19,7 @@ gae->game, Gael, gale,
 iam->I am, aim,
 iff->if
 ith->with
+Jupyther->Jupyter
 keyserver->key server
 lateset->latest
 movei->movie


### PR DESCRIPTION
5 typos from [secdev/scapy#3302](https://github.com/secdev/scapy/pull/3302).

I wasn't sure where `"Jupyther"` belongs; I added it to `dictionary_code.txt`.