### PR TITLE
Change existence test for dictionary file

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -819,7 +819,7 @@ def main(*args):
                     parser.print_help()
                     return EX_USAGE
         else:
-            if not os.path.isfile(dictionary):
+            if not os.path.exists(dictionary) or os.path.isdir(dictionary):
                 print("ERROR: cannot find dictionary file: %s" % dictionary,
                       file=sys.stderr)
                 parser.print_help()


### PR DESCRIPTION
I was trying to define a single new dictionary entry on the fly from the command line using [shell process substitution](http://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html#Process-Substitution) (_one of my favorite lesser-known tricks in the shell!_):

```
$ find . -type f | xargs codespell -D <(echo 'privliged->privileged')
ERROR: cannot find dictionary file: /dev/fd/63
...
```

This commonly happens when `os.path.isfile()` is used to test for a regular file as `main()` of `_codespell.py` does:
```
        else:
            if not os.path.isfile(dictionary):
                print("ERROR: cannot find dictionary file: %s" % dictionary,
                      file=sys.stderr)
                parser.print_help()
                return EX_USAGE
            use_dictionaries.append(dictionary)
```

I'm suggesting a change to primarily use `not os.path.exists(dictionary)` for the test.  I also added `or os.path.isdir(dictionary)` since directories are are common.

Please let me know if you want me to follow any pattern or policy in this PR or change.  I will be happy to make changes to conform to your process.