### PR TITLE
Add packat(s)->packet(s)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20806,6 +20806,7 @@ packaeges->packages
 packaegs->packages
 packag->package
 packaing->packaging
+packats->packets
 packe->packed, packet,
 packege->package
 packge->package

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -26,6 +26,7 @@ mut->must, mutt, moot,
 nto->not
 objext->object
 od->of
+packat->packet
 process'->process's
 protecten->protection
 reday->ready


### PR DESCRIPTION
See e.g.:

https://grep.app/search?q=packat&words=true
https://grep.app/search?q=packats&words=true

Note that `packAt` (pack at) might be a valid code variable (there are various hits at the first link) so decided to put it into the code dictionary. Please let me know if you disagree with this.