### PR TITLE
Improve the definition of the "rare" builtin dictionary

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -54,7 +54,7 @@ _builtin_dictionaries = (
     # realistic for obscure words
     ('clear', 'for unambiguous errors', '',
         False, None, supported_languages_en, None),
-    ('rare', 'for rare but valid words', '_rare',
+    ('rare', 'for rare (but valid) words which are likely to be errors', '_rare',  # noqa: E501
         None, None, None, None),
     ('informal', 'for making informal words more formal', '_informal',
         True, True, supported_languages_en, supported_languages_en),


### PR DESCRIPTION
For an end user who is not familiar with the inner details of the script, the meaning of the old definition was ambiguous. It wasn't
clear whether using this dictionary flags the rare words as errors (false positives) or on the contrary does not flag these rare words
(false negatives).

I do reckon the leading `for` was consistent with the rest of the definitions, but cannot suggest a good definition starting with `for`.