### PR TITLE
Add pre-commit config with flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    -   id: flake8
+


### PR DESCRIPTION
Add a short `.pre-commit-config.yaml` file for optionally running `flake8` locally via `pre-commit`, for convenience of running flake8 locally more easily.

pre-commit doesn't seem to support always using the 'latest' version:
https://pre-commit.com/#using-the-latest-version-for-a-repository
so I set this to use the current latest flake8 version. 

This could potentially become out of sync with the github action that runs flake8 on the CI side, which is using the whatever the 'latest' release is.
