### PR TITLE
Add dosclosure->disclosure

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10804,6 +10804,10 @@ dorder->order, disorder,
 dordered->ordered
 dorment->dormant
 dorp->drop
+dosclosed->disclosed
+doscloses->discloses
+dosclosing->disclosing
+dosclosure->disclosure
 dosen't->doesn't
 dosen->dozen, dose, doesn,
 dosen;t->doesn't

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10808,6 +10808,7 @@ dosclosed->disclosed
 doscloses->discloses
 dosclosing->disclosing
 dosclosure->disclosure
+dosclosures->disclosures
 dosen't->doesn't
 dosen->dozen, dose, doesn,
 dosen;t->doesn't

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -10,6 +10,7 @@ copyable->copiable
 define'd->defined
 dof->of, doff,
 dont->don't
+dosclose->disclose
 dur->due
 endcode->encode
 errorstring->error string


### PR DESCRIPTION
See e.g.:

https://github.com/search?q=Dosclosure&type=Code

Probably originating from `o` being near to `i`.

`dosclose` was added the code dictionary because it might be related to closing something related to DOS.