### PR TITLE
Misspelling: entire

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11569,6 +11569,7 @@ enironments->environments
 enities->entities
 enitities->entities
 enitity->entity
+enitre->entire
 enity->entity
 enivornment->environment
 enivornments->environments


### PR DESCRIPTION
Typo initially found in docutils:
https://sourceforge.net/p/docutils/bugs/428/

https://github.com/search?q=enitre&type=code (11,517 hits)
https://searchcode.com/?q=enitre (218 hits)
https://grep.app/search?q=enitre (199 hits)