### PR TITLE
doucmentation is documentation

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10851,7 +10851,7 @@ doublely->doubly
 doubletquote->doublequote
 doucment->document
 doucmentated->documented
-doucmentation->documenting
+doucmentation->documentation
 doucmented->documented
 doucmenter->documenter
 doucmenters->documenters


### PR DESCRIPTION
I cannot imagine a typo where doucmentation is used instead of documenting. Probably a typo while entering this entry in the dictionary!

See https://github.com/UbuntuForums/system-info/pull/2.