### PR TITLE
alwys->always

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1653,6 +1653,7 @@ alwasys->always
 alwauys->always
 alway->always
 alwyas->always
+alwys->always
 alyways->always
 amacing->amazing
 amacingly->amazingly


### PR DESCRIPTION
A misspelling seen in the wild.