### PR TITLE
move creat to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8036,7 +8036,6 @@ creaed->created
 creaeted->created
 creasoat->creosote
 creastor->creator
-creat->create
 creatation->creation
 createa->create
 createable->creatable

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -7,7 +7,7 @@ clas->class
 cloneable->clonable
 cmo->com
 copyable->copiable
-creat->crate, create,
+creat->create, crate,
 define'd->defined
 dof->of, doff,
 dont->don't

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -7,6 +7,7 @@ clas->class
 cloneable->clonable
 cmo->com
 copyable->copiable
+creat->crate, create,
 define'd->defined
 dof->of, doff,
 dont->don't

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -199,6 +199,7 @@ allowed_dups = {
     ('dictionary.txt', 'dictionary_names.txt'),
     ('dictionary.txt', 'dictionary_rare.txt'),
     ('dictionary.txt', 'dictionary_usage.txt'),
+    ('dictionary_code.txt', 'dictionary_rare.txt'),
     ('dictionary_rare.txt', 'dictionary_usage.txt'),
 }
 


### PR DESCRIPTION
`creat(2)` is a Linux syscall. Also add crate as a possible correction.

Resolves #2120 