### PR TITLE
nore could also be note

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20148,7 +20148,7 @@ noramalizes->normalizes
 noramalizing->normalizing
 noramals->normals
 noraml->normal
-nore->nor, more,
+nore->nor, note, more,
 norhern->northern
 norifications->notifications
 normailzation->normalization


### PR DESCRIPTION
seen in the wild: "nore this method is not thread-safe"