### PR TITLE
Mispelling: latest could be last

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -17777,7 +17777,7 @@ largst->largest
 larrry->larry
 laso->also, lasso,
 lastes->latest
-lastest->latest
+lastest->latest, last,
 lastr->last
 lates->later, latest,
 latets->latest


### PR DESCRIPTION
I think it happens from time to time, see for example:
https://github.com/martijnvanbrummelen/nwipe/pull/351/commits/b2c22d5