### PR TITLE
remove "on-path attacker" as replacement for "man-in-the-middle" (the proposed term is unusual replacement for a standard term that is entirely fine)

### DIFF
--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -1,7 +1,6 @@
 blacklist->blocklist
 blacklists->blocklists
 blueish->bluish
-man-in-the-middle->on-path attacker
 master->primary, leader, active, writer, coordinator, parent, manager, main,
 masters->primaries, leaders, actives, writers, coordinators, parents, managers,
 slave->secondary, follower, standby, replica, reader, worker, helper, subordinate, subsystem,


### PR DESCRIPTION
In this case:

- while https://tools.ietf.org/id/draft-knodel-terminology-00.html cited in justification for this change claims "It is not a standard term, not as clear as its alternative “on-path attacker”, and should therefore be avoided." it seems not true to me. 
- I am likely actually from group that is trying to be "protected" so I feel relatively OK with declaring that it seems weird to me (though there could be more complicated explanation  for that replacement that would nullify this and claim that also here I am from group not supposed to comment)
 
Maybe it is preferred among people known to author of the cited text or in a highly technical academic writing, it is not popular in general, it is not standard at all in general use. I encountered it here for the first time in my life despite being interested in computer security and related topics. (though I am not an expert)
 
For example there is not even a Wikipedia redirect as of 2021-11-11 - see https://en.wikipedia.org/w/index.php?search=on-path+attacker It may be worth creating for people confused by this term and looking for an explanation, if that term is actually being used. [man-in-the-middle](https://en.wikipedia.org/w/index.php?title=Man-in-the-middle&action=history) redirect exists since 2005.

Term "man-in-the-middle" is actually clear, communicates well and is actually case of an useful metaphor.

"Terminology, Power and Oppressive Language" mentions https://www.orwellfoundation.com/the-orwell-foundation/orwell/essays-and-other-works/politics-and-the-english-language/ as part of justification but I have no idea which part of this text is supposed to encourage not using well fitting and explanatory terms such as "man-in-the-middle". 

Both are metaphors, similar in terms of being abstract ("on-path attacker" seems worse here?), no significant difference in length and so on.

Though it is nice to read someone complain about the same things that make me irritated decades later :)

> Many political words are similarly abused. The word Fascism has now no meaning except in so far as it signifies ‘something not desirable’. The words democracy, socialism, freedom, patriotic, realistic, justice, have each of them several different meanings which cannot be reconciled with one another. In the case of a word like democracy, not only is there no agreed definition, but the attempt to make one is resisted from all sides.

----------------------------------------

Also, this rule would replace "man-in-the-middle attack" by "on-path attacker attack" (not that "on-path attack" would be substantially better and explaining well)

-----------------------------------------

BTW, what kind of political problem is with term "blueish"? Or is it this one single non-political replacement there? ( and it is about https://english.stackexchange.com/questions/18824/why-are-blueish-and-bluish-both-considered-correct-spellings )