### PR TITLE
Handle bad globs passed to if --skip/-S

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -898,7 +898,15 @@ def main(*args):
 
     file_opener = FileOpener(options.hard_encoding_detection,
                              options.quiet_level)
+
     glob_match = GlobMatch(options.skip)
+    try:
+        glob_match.match("/random/path")  # does not need a real path
+    except re.error:
+        print("ERROR: --skip/-S has been fed an invalid glob, "
+              "try escaping special characters",
+              file=sys.stderr)
+        return EX_USAGE
 
     bad_count = 0
     for filename in options.files:


### PR DESCRIPTION
Fixes #2145.

The downside is that we catch the `re.error` exception when `glob_match` is actually used. We cannot tell which exact glob fails because `glob_match` is initialized with a **list** of globs:
https://github.com/codespell-project/codespell/blob/0ee668811694e2f6a0df4612ffc4e9d4e447b04d/codespell_lib/_codespell.py#L864

The alternative would be to run `fnmatch.fnmatch()` on each item in `options.skip`, before creating a global `GlobMatch` for all items. We will suppose that the global `GlobMatch` instance cannot fail if none of the simple `fnmatch.fnmatch()` calls fails.