### PR TITLE
move fike to names dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13686,7 +13686,6 @@ fiels->feels, fields, files, phials,
 fiercly->fiercely
 fightings->fighting
 figurestyle->figurestyles
-fike->file
 filal->final
 fileds->fields
 fileld->field

--- a/codespell_lib/data/dictionary_names.txt
+++ b/codespell_lib/data/dictionary_names.txt
@@ -4,6 +4,7 @@ anny->any
 bae->base
 bridget->bridged, bridge,
 chang->change
+fike->file
 liszt->list
 que->queue
 sargent->sergeant, argent,


### PR DESCRIPTION
Hit a false-positive with this since Fike is an English surname: https://en.wikipedia.org/wiki/Fike