### PR TITLE
Move 'compliancy' into dictionary_rare.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -6410,7 +6410,6 @@ complette->complete
 complettly->completely
 complety->completely
 compliace->compliance
-compliancy->compliance
 complianse->compliance
 complied-in->compiled-in
 complience->compliance

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -29,6 +29,7 @@ circularly->circular
 commata->commas
 commend->comment, command,
 commends->comments, commands,
+compliancy->compliance
 complied->compiled
 complier->compiler
 compliers->compilers


### PR DESCRIPTION
This valid word has been removed in the past in #1107 based on #1062 but it was added again since then, ~~just removing it again.~~  moving into the rare dictionary.