### PR TITLE
Move `hist` from rare to code

### DIFF
--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -18,6 +18,7 @@ errorstring->error string
 exitst->exits, exists,
 files'->file's
 gae->game, Gael, gale,
+hist->heist, his,
 iam->I am, aim,
 iff->if
 ith->with

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -75,7 +75,6 @@ guerillas->guerrillas
 hart->heart, harm,
 heterogenous->heterogeneous
 hided->hidden, hid,
-hist->heist, his,
 hove->have, hover, love,
 impassible->impassable
 implicity->implicitly


### PR DESCRIPTION
The rationale is that while `hist` is a [valid exclamation](https://www.lexico.com/definition/hist), it is foremost the widely used [`matplotlib.pyplot.hist`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.hist.html) function, used by almost all scientific Python software that require visualization.

Fixes #2185.