### PR TITLE
Rehabilitate extraversion

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -15331,9 +15331,6 @@ extrator->extractor
 extrators->extractors
 extrats->extracts
 extravagent->extravagant
-extraversion->extroversion
-extravert->extrovert
-extraverts->extroverts
 extraxt->extract
 extraxted->extracted
 extraxting->extracting


### PR DESCRIPTION
Extr**a**version is commonly used in scholar articles.

One could argue that extr**o**version is mostly American and extr**a**version mostly British, but it's not as simple as that, since extr**a**version is commonly used in American scholar articles.

For a more detailed explanation, see for example [The Difference between ExtrAversion and ExtrOversion](https://blogs.scientificamerican.com/beautiful-minds/the-difference-between-extraversion-and-extroversion/).

Dictionary entries:
* [APA Dictionary of Psychology](https://dictionary.apa.org/extraversion)
* [Oxford Learner's Dictionary](https://www.oxfordlearnersdictionaries.com/definition/english/extraversion)
* [Merriam-Webster](https://www.merriam-webster.com/dictionary/extraversion)
* [Collins](https://www.collinsdictionary.com/dictionary/english/extraversion)
* [Macmillan](https://www.macmillandictionary.com/dictionary/british/extraversion)