### PR TITLE
Capitalize all suggested fixes

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -528,7 +528,7 @@ def ask_for_word_fix(line, wrongword, misspelling, interactivity):
         # we ask the user which word to use
 
         r = ''
-        opt = list(map(lambda x: x.strip(), misspelling.data.split(',')))
+        opt = [w.strip() for w in misspelling.data.split(',')]
         while not r:
             print("%s Choose an option (blank for none): " % line, end='')
             for i in range(len(opt)):

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -495,7 +495,7 @@ def is_text_file(filename):
 
 def fix_case(word, fixword):
     if word == word.capitalize():
-        return fixword.capitalize()
+        return ', '.join(w.strip().capitalize() for w in fixword.split(','))
     elif word == word.upper():
         return fixword.upper()
     # they are both lower case

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -393,13 +393,14 @@ def test_case_handling(tmpdir, capsys):
         assert f.read().decode('utf-8') == 'this has an ASCII error'
 
 
-def test_case_handling_in_fixes(tmpdir, capsys):
-    """Test that the case of fixes is similar to the mispelled word."""
+def _helper_test_case_handling_in_fixes(tmpdir, capsys, reason):
     d = str(tmpdir)
-    with open(op.join(d, 'dictionary_with_reason.txt'), 'w') as f:
-        fix = 'adopter, adaptor'
-        reason = 'these are different words!'
-        f.write(f'adoptor->{fix}, {reason}\n')
+
+    with open(op.join(d, 'dictionary.txt'), 'w') as f:
+        if reason:
+            f.write('adoptor->adopter, adaptor, reason\n')
+        else:
+            f.write('adoptor->adopter, adaptor,\n')
     dictionary_name = f.name
 
     # the mispelled word is entirely lowercase
@@ -408,6 +409,9 @@ def test_case_handling_in_fixes(tmpdir, capsys):
     code, stdout, _ = cs.main('-D', dictionary_name, f.name, std=True)
     # all suggested fixes must be lowercase too
     assert 'adopter, adaptor' in stdout
+    # the reason, if any, must not be modified
+    if reason:
+        assert 'reason' in stdout
 
     # the mispelled word is capitalized
     with open(op.join(d, 'bad.txt'), 'w') as f:
@@ -415,8 +419,9 @@ def test_case_handling_in_fixes(tmpdir, capsys):
     code, stdout, _ = cs.main('-D', dictionary_name, f.name, std=True)
     # all suggested fixes must be capitalized too
     assert 'Adopter, Adaptor' in stdout
-    # the reason, however, must not be modified
-    assert reason in stdout
+    # the reason, if any, must not be modified
+    if reason:
+        assert 'reason' in stdout
 
     # the mispelled word is entirely uppercase
     with open(op.join(d, 'bad.txt'), 'w') as f:
@@ -424,8 +429,9 @@ def test_case_handling_in_fixes(tmpdir, capsys):
     code, stdout, _ = cs.main('-D', dictionary_name, f.name, std=True)
     # all suggested fixes must be uppercase too
     assert 'ADOPTER, ADAPTOR' in stdout
-    # the reason, however, must not be modified
-    assert reason in stdout
+    # the reason, if any, must not be modified
+    if reason:
+        assert 'reason' in stdout
 
     # the mispelled word mixes lowercase and uppercase
     with open(op.join(d, 'bad.txt'), 'w') as f:
@@ -433,8 +439,15 @@ def test_case_handling_in_fixes(tmpdir, capsys):
     code, stdout, _ = cs.main('-D', dictionary_name, f.name, std=True)
     # all suggested fixes should be lowercase
     assert 'adopter, adaptor' in stdout
-    # the reason, however, must not be modified
-    assert reason in stdout
+    # the reason, if any, must not be modified
+    if reason:
+        assert 'reason' in stdout
+
+
+def test_case_handling_in_fixes(tmpdir, capsys):
+    """Test that the case of fixes is similar to the mispelled word."""
+    _helper_test_case_handling_in_fixes(tmpdir, capsys, reason=False)
+    _helper_test_case_handling_in_fixes(tmpdir, capsys, reason=True)
 
 
 def test_context(tmpdir, capsys):


### PR DESCRIPTION
When a wrong word is capitalized, capitalize all the suggested fixes, instead of only the first fix.

Also modify similar code, for consistency.

Fixes #2222.