### PR TITLE
Add spelling corrections for vulnerab* variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -4611,6 +4611,9 @@ bulids->builds
 bulit->built
 bulle->bullet
 bulletted->bulleted
+bulnerabilities->vulnerabilities
+bulnerability->vulnerability
+bulnerable->vulnerable
 bult->built
 bult-in->built-in
 bultin->builtin


### PR DESCRIPTION
Happens a few times (probably because the `b` is next to the `v`):
- https://github.com/search?q=bulnerability&type=code
- https://grep.app/search?q=bulnerability