### PR TITLE
Improve flag discoverability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,21 +39,37 @@ For more in depth info please check usage with ``codespell -h``.
 
 Some noteworthy flags::
 
+
+Write Changes
+^^^^^^^^^^^^^
+
     codespell -w, --write-changes
 
 The ``-w`` flag will actually implement the changes recommended by codespell. Not running with ``-w`` flag is the same as with doing a dry run. It is recommended to run this with the ``-i`` or ``--interactive`` flag.::
+
+Ignore Words
+^^^^^^^^^^^^
 
     codespell -I FILE, --ignore-words=FILE
 
 The ``-I`` flag can be used for a list of certain words to allow that are in the codespell dictionaries. The format of the file is one word per line. Invoke using: ``codespell -I path/to/file.txt`` to execute codespell referencing said list of allowed words. **Important note:** The list passed to ``-I`` is case-sensitive based on how it is listed in the codespell dictionaries. ::
 
-    codespell -L word1,word2,word3,word4
+Ignore Word List
+^^^^^^^^^^^^^^^^
+
+    codespell -L word1,word2,word3,word4, --ignore-words-list word1,word2,word3,word4
 
 The ``-L`` flag can be used to allow certain words that are comma-separated placed immediately after it.  **Important note:** The list passed to ``-L`` is case-sensitive based on how it is listed in the codespell dictionaries. ::
+
+Exclude File
+^^^^^^^^^^^^
 
     codespell -x FILE, --exclude-file=FILE
 
 Ignore whole lines that match those in ``FILE``.  The lines in ``FILE`` should match the to-be-excluded lines exactly.
+
+Skip
+^^^^
 
     codespell -S, --skip=
 
@@ -63,17 +79,26 @@ Comma-separated list of files to skip. It accepts globs as well.  Examples:
 
 * to skip directories, invoke ``codespell --skip="./src/3rd-Party,./src/Test"``
 
+Useful commands
+---------------
 
-Useful commands::
+Typos not in translations
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
     codespell -d -q 3 --skip="*.po,*.ts,./src/3rdParty,./src/Test"
 
 List all typos found except translation files and some directories.
 Display them without terminal colors and with a quiet level of 3. ::
 
+Interactive and save changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
     codespell -i 3 -w
 
 Run interactive mode level 3 and write changes to file.
+
+Notes
+-----
 
 We ship a collection of dictionaries that are an improved version of the one available
 `on Wikipedia <https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines>`_


### PR DESCRIPTION
I'm trying to figure out how to use `-I` and `-L` and it'd be helpful if the flags were easier to get to/link to in the readme.

(I still don't understand how the flags work, but that's a different story.)