### PR TITLE
More misspellings

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -15276,6 +15276,12 @@ gneral->general
 gnerally->generally
 gnerals->generals
 gnerate->generate
+gnerated->generated
+gnerates->generates
+gnerating->generating
+gneration->generation
+gnerations->generations
+gneric->generic
 gnorung->ignoring
 gobal->global
 godess->goddess
@@ -19285,6 +19291,7 @@ mechinism->mechanism
 mechnanism->mechanism
 mechnism->mechanism
 mechnisms->mechanisms
+meda->meta, medal,
 medacine->medicine
 medai->media
 medeival->medieval
@@ -25584,7 +25591,6 @@ relyably->reliably
 relyed->relied
 relyes->relies, realize, realise,
 relys->relies
-remainer->remainder
 remaines->remains
 remaing->remaining
 remainging->remaining
@@ -25975,6 +25981,7 @@ repetions->repetitions
 repetive->repetitive
 repid->rapid
 repitition->repetition
+repititions->repetitions
 replaca->replica, replace,
 replacability->replaceability
 replacable->replicable, replaceable,
@@ -28511,6 +28518,12 @@ speciying->specifying
 specktor->specter, spectre,
 spectauclar->spectacular
 spectaulars->spectaculars
+spectification->specification
+spectifications->specifications
+spectified->specified
+spectifies->specifies
+spectify->specify
+spectifying->specifying
 spects->aspects, expects, specs,
 spectular->spectacular
 spectularly->spectacularly

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -128,6 +128,8 @@ readd->re-add, read,
 readded->read
 ream->stream
 recuse->recurse
+remainer->remainder
+remainers->remainders
 retuned->returned
 retying->retrying
 revered->reversed


### PR DESCRIPTION
See https://github.com/wtclarke/spec2nii/pull/27.

Note that `remainer`/`remainers` can now be found in British dictionaries, in the context of the Brexit:
https://dictionary.cambridge.org/fr/dictionnaire/anglais/remainer
Should I move it to the _rare_ dictionary?