### PR TITLE
Add spelling correction for double and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11264,6 +11264,9 @@ doubeleclicked->double-clicked
 doubeleclicks->double-clicks
 doubely->doubly
 doubes->doubles
+doublde->double
+doublded->doubled
+doubldes->doubles
 doubleclick->double-click
 doublely->doubly
 doubletquote->doublequote


### PR DESCRIPTION
Doesn't happen that much:
- https://github.com/search?q=Doublded&type=commits (Only the specific `doublded`)
- https://github.com/search?q=Doublde (All)
- https://grep.app/search?q=Doublde

But as i had done the `Doublded` typo on my own a few days ago just submitting it as a suggestion.