### PR TITLE
Add spelling correction for protect and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -23492,7 +23492,11 @@ presumaby->presumably
 presumebly->presumably
 presumely->presumably
 presumibly->presumably
+pretect->protect
+pretected->protected
+pretecting->protecting
 pretection->protection
+pretects->protects
 pretendend->pretended
 pretty-printter->pretty-printer
 preveiw->preview


### PR DESCRIPTION
Not that much hits but these should be typos:

https://grep.app/search?q=pretected