### PR TITLE
Move deque->dequeue to code because of C++'s double-ended queue

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9629,7 +9629,6 @@ depricate->deprecate
 depricated->deprecated
 depricates->deprecates
 depricating->deprecating
-deque->dequeue
 dequed->dequeued
 dequeing->dequeuing
 deques->dequeues

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -11,6 +11,7 @@ cmo->com
 copyable->copiable
 creat->create, crate,
 define'd->defined
+deque->dequeue
 dof->of, doff,
 dont->don't
 dosclose->disclose


### PR DESCRIPTION
 (std::deque)

Off the back of #2262

CC @vikivivi and @luzpaz 