### PR TITLE
Add spelling correction for float and variants.

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -59,6 +59,8 @@ fallowed->followed
 fallowing->following
 fallows->follows
 fave->save
+floaw->flow, float,
+floaws->flows, floats,
 florescent->fluorescent
 followings->following
 forewarded->forwarded


### PR DESCRIPTION
See e.g.:

https://grep.app/search?q=floaw

Not sure about other variants, any additional suggestions are welcome.