### PR TITLE
Add connectec->connected

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7211,6 +7211,7 @@ connecotr->connector
 connecstatus->connectstatus
 connectd->connected
 connecte->connected
+connectec->connected
 connectet->connected
 connectibity->connectivity
 connectino->connection


### PR DESCRIPTION
I'm a bit torn here, as about 50% of the typos via grep.app are for when it's a SCALA (?) execution context connection variable, but the rest are this intended correction.

We could move to code, but then most of the typos are in code comments...