### PR TITLE
Remove anomalous duplicates

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -34227,11 +34227,5 @@ __attribyte__->__attribute__
 __cpluspus->__cplusplus
 __cpusplus->__cplusplus
 évaluate->evaluate
-сontain->contain
-сontained->contained
-сontainer->container
-сontainers->containers
-сontaining->containing
 сontainor->container
 сontainors->containers
-сontains->contains


### PR DESCRIPTION
For some reason tests are missing these and `make sort-dictionaries` is malfunctioning as well. 
