### PR TITLE
Add spelling corrections for second(s).

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27504,18 +27504,22 @@ seciton->section
 secitons->sections
 secne->scene
 secod->second
+secods->seconds
 seconadry->secondary
 seconcary->secondary
 secondaray->secondary
 seconday->secondary
 secondy->secondly, secondary,
 seconf->second
+seconfs->seconds
 seconly->secondly
+secons->second, seconds,
 secont->second
 secontary->secondary
 secontly->secondly
 seconts->seconds
 secord->second
+secords->seconds
 secotr->sector
 secound->second
 secoundary->secondary
@@ -27553,6 +27557,7 @@ secuencing->sequencing
 secuirty->security
 secuity->security
 secund->second
+secunds->seconds
 securiy->security
 securiyt->security
 securly->securely


### PR DESCRIPTION
See e.g.: for the new `secons` typo.

https://grep.app/search?q=secons&words=true

For other variants i have added the `s` variants where missing.