### PR TITLE
Add spelling corrections for (un)able.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32007,6 +32007,7 @@ un-complete->incomplete
 unabailable->unavailable
 unabale->unable
 unabel->unable
+unablet->unable
 unacceptible->unacceptable
 unaccesible->unaccessible
 unacknowleged->unacknowledged

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -1,3 +1,4 @@
+ablet->able, tablet,
 afterwords->afterwards
 amination->animation, lamination,
 aminations->animations, laminations,


### PR DESCRIPTION
See e.g.:
- https://grep.app/search?q=unablet&words=true
- https://github.com/greenbone/openvas-scanner/pull/1069

Note that `Ablet` seems to be a fish according to https://en.wiktionary.org/wiki/ablet so i have put it into the `dictionary_rare.txt`, hope this is correct like this.