### PR TITLE
Add usesd->used correction.

### DIFF
--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -65,6 +65,6 @@ udate->update, date,
 udates->updates, dates,
 uint->unit
 uis->is, use,
-usesd->used
+usesd->used, uses,
 were'->we're
 whome->whom

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -65,5 +65,6 @@ udate->update, date,
 udates->updates, dates,
 uint->unit
 uis->is, use,
+usesd->used
 were'->we're
 whome->whom


### PR DESCRIPTION
See e.g.:

https://grep.app/search?q=usesd&words=true

Most are valid variables like `useSD` so i have put it into the code dictionary. But some of them are actual typos like e.g.:

> the file whose last modification time is usesd as the

or:

> Usesd for hardware stack checking