### PR TITLE
move `outputof` to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22031,7 +22031,6 @@ outpust->output, outputs,
 outpusts->outputs
 outputed->outputted
 outputing->outputting
-outputof->output-of
 outrside->outside, other side,
 outselves->ourselves
 outter->outer

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -35,7 +35,7 @@ nmake->make
 nto->not
 objext->object
 od->of
-outputof->output of,output-of
+outputof->output of, output-of
 packat->packet
 process'->process's
 protecten->protection, protected,

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -35,6 +35,7 @@ nmake->make
 nto->not
 objext->object
 od->of
+outputof->output-of
 packat->packet
 process'->process's
 protecten->protection, protected,

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -35,7 +35,7 @@ nmake->make
 nto->not
 objext->object
 od->of
-outputof->output of, output-of
+outputof->output of, output-of,
 packat->packet
 process'->process's
 protecten->protection, protected,

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -35,7 +35,7 @@ nmake->make
 nto->not
 objext->object
 od->of
-outputof->output-of
+outputof->output of,output-of
 packat->packet
 process'->process's
 protecten->protection, protected,


### PR DESCRIPTION
avoid false positives from https://github.com/premake/premake-4.x/wiki/os.outputof

I am also a bit surprised that the correction is `output-of` (with a dash) 🤨 