### PR TITLE
Add uncler->unclear, uncle, uncles,

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32169,6 +32169,7 @@ unchaneged->unchanged
 unchangable->unchangeable
 uncheked->unchecked
 unchenged->unchanged
+uncler->unclear, uncle, uncles,
 uncognized->unrecognized
 uncoment->uncomment
 uncomented->uncommented


### PR DESCRIPTION
See e.g.:
- https://github.com/search?q=%22uncler%22&type=issues (most are "real" typos)
- https://github.com/search?q=%22uncler%22&type=code (various code hits)
- https://grep.app/search?q=uncler&words=true (not much hits)

I'm just not sure if we should put it into the "code" dictionary instead because of e.g. the `uncleR` package of `R`?