### PR TITLE
typos found in iperf

### DIFF
--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -64,6 +64,8 @@ shouldnot->should not, shouldn't,
 sinc->sync, sink, since,
 sincs->syncs, sinks, since,
 snd->send, and, sound,
+sockt->socket
+sockts->sockets
 spawnve->spawn
 stdio->studio
 stdios->studios


### PR DESCRIPTION
See https://github.com/esnet/iperf/pull/1350.