### PR TITLE
Resolve CoverageWarning when running tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,4 @@
 [run]
 branch = True
 source = codespell_lib
-include = */codespell_lib/*
 omit = */codespell_lib/tests/*


### PR DESCRIPTION
Appeared as:

    .../site-packages/coverage/inorout.py:472: CoverageWarning: --include is ignored because --source is set (include-ignored)
      self.warn("--include is ignored because --source is set", slug="include-ignored")