### PR TITLE
Implement inline ignores

### DIFF
--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -54,7 +54,7 @@ jobs:
       # tomli should not be required for the next two steps (and make sure it's not)
       - run: pip uninstall -yq tomli
         if: ${{ matrix.no-toml == 'no-toml' }}
-      - run: codespell --check-filenames --skip="./.git/*,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
+      - run: codespell --check-filenames --skip="./.git/*,./.pytest_cache/*,./junit-results.xml,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
       # this file has an error
       - run: "! codespell codespell_lib/tests/test_basic.py"
 

--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -54,7 +54,7 @@ jobs:
       # tomli should not be required for the next two steps (and make sure it's not)
       - run: pip uninstall -yq tomli
         if: ${{ matrix.no-toml == 'no-toml' }}
-      - run: codespell --check-filenames --skip="./.git/*,./.pytest_cache/*,./junit-results.xml,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
+      - run: codespell --check-filenames --skip="./.git/*,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
       # this file has an error
       - run: "! codespell codespell_lib/tests/test_basic.py"
 

--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -54,7 +54,7 @@ jobs:
       # tomli should not be required for the next two steps (and make sure it's not)
       - run: pip uninstall -yq tomli
         if: ${{ matrix.no-toml == 'no-toml' }}
-      - run: codespell --check-filenames --skip="./.git/*,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
+      - run: codespell --check-filenames --skip="./.git/*,./.pytest_cache/*,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
       # this file has an error
       - run: "! codespell codespell_lib/tests/test_basic.py"
 

--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -54,7 +54,7 @@ jobs:
       # tomli should not be required for the next two steps (and make sure it's not)
       - run: pip uninstall -yq tomli
         if: ${{ matrix.no-toml == 'no-toml' }}
-      - run: codespell --check-filenames --skip="./.git/*,./.pytest_cache/*,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
+      - run: codespell --check-filenames --skip="./.git/*,./.pytest_cache/*,./junit-results.xml,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
       # this file has an error
       - run: "! codespell codespell_lib/tests/test_basic.py"
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -56,7 +56,7 @@ uri_regex_def = (
 # alternative misspellings and fixes.
 alt_chars = (("'", "’"),)  # noqa: RUF001
 inline_ignore_regex = re.compile(
-    r"([^\w\s]) codespell:ignore(\s(?P<words>[\w,]*))?(\s+\1|$)"
+    r"[^\w\s]\s?codespell:ignore\b(\s+(?P<words>[\w,]*))?"
 )
 USAGE = """
 \t%prog [OPTIONS] [file1 file2 ... fileN]

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -55,9 +55,7 @@ uri_regex_def = (
 # Pass all misspellings through this translation table to generate
 # alternative misspellings and fixes.
 alt_chars = (("'", "’"),)  # noqa: RUF001
-inline_ignore_regex = re.compile(
-    r"[^\w\s]\s?codespell:ignore\b(\s+(?P<words>[\w,]*))?"
-)
+inline_ignore_regex = re.compile(r"[^\w\s]\s?codespell:ignore\b(\s+(?P<words>[\w,]*))?")
 USAGE = """
 \t%prog [OPTIONS] [file1 file2 ... fileN]
 """

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -56,7 +56,8 @@ uri_regex_def = (
 # alternative misspellings and fixes.
 alt_chars = (("'", "’"),)  # noqa: RUF001
 inline_ignore_regex = re.compile(
-    r"[^\w\s] codespell:ignore(?:(?:\s|$)([\w,]*))")
+    r"([^\w\s]) codespell:ignore(\s(?P<words>[\w,]*))?(\s+\1|$)"
+)
 USAGE = """
 \t%prog [OPTIONS] [file1 file2 ... fileN]
 """
@@ -980,7 +981,7 @@ def parse_file(
         match = inline_ignore_regex.search(line)
         if match:
             extra_words_to_ignore = set(
-                filter(None, (match.group(1) or "").split(","))
+                filter(None, (match.group("words") or "").split(","))
             )
             if not extra_words_to_ignore:
                 continue

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -391,43 +391,58 @@ def test_ignore_word_list(
     assert cs.main("-Labandonned,someword", "-Labilty", tmp_path) == 1
 
 
-@pytest.mark.parametrize('content, expected_error_count', [
-    # recommended form
-    ('abandonned abondon abilty  # codespell:ignore abondon', 2),
-    ('abandonned abondon abilty  // codespell:ignore abondon,abilty', 1),
-    ('abandonned abondon abilty  /* codespell:ignore abandonned,abondon,abilty', 0),  # noqa: E501
-    # ignore unused ignore
-    ('abandonned abondon abilty  # codespell:ignore nomenklatur', 3),
-    # wildcard form
-    ('abandonned abondon abilty  # codespell:ignore ', 0),
-    ('abandonned abondon abilty  # codespell:ignore', 0),
-    ('abandonned abondon abilty  # codespell:ignore\n', 0),
-    ('abandonned abondon abilty  # codespell:ignore\r\n', 0),
-    ('abandonned abondon abilty  # codespell:ignore  # noqa: E501\n', 0),
-    ('abandonned abondon abilty  # codespell:ignore # noqa: E501\n', 0),
-    ('abandonned abondon abilty  # codespell:ignore# noqa: E501\n', 0),
-    ('abandonned abondon abilty  # codespell:ignore, noqa: E501\n', 0),
-    ('abandonned abondon abilty  #codespell:ignore\n', 0),
-    # ignore these for safety
-    ('abandonned abondon abilty  # codespell:ignorenoqa: E501\n', 3),
-    ('abandonned abondon abilty  codespell:ignore\n', 3),
-    ('abandonned abondon abilty codespell:ignore\n', 3),
-    # showcase different comment markers
-    ("abandonned abondon abilty ' codespell:ignore\n", 0),
-    ('abandonned abondon abilty " codespell:ignore\n', 0),
-    ('abandonned abondon abilty ;; codespell:ignore\n', 0),
-    ('abandonned abondon abilty /* codespell:ignore */\n', 0),
-    # prose examples
-    ('You could also use line based igore ( codespell:ignore ) to igore ', 0),
-    ('You could also use line based igore (codespell:ignore) to igore ', 0),
-    ('You could also use line based igore (codespell:ignore igore) to igore ', 0),  # noqa: E501
-    ('You could also use line based igore (codespell:ignore igare) to igore ', 2),  # noqa: E501
-])
+@pytest.mark.parametrize(
+    'content, expected_error_count',
+    [
+        # recommended form
+        ('abandonned abondon abilty  # codespell:ignore abondon', 2),
+        ('abandonned abondon abilty  // codespell:ignore abondon,abilty', 1),
+        (
+            'abandonned abondon abilty  /* codespell:ignore abandonned,abondon,abilty',
+            0,
+        ),  # noqa: E501
+        # ignore unused ignore
+        ('abandonned abondon abilty  # codespell:ignore nomenklatur', 3),
+        # wildcard form
+        ('abandonned abondon abilty  # codespell:ignore ', 0),
+        ('abandonned abondon abilty  # codespell:ignore', 0),
+        ('abandonned abondon abilty  # codespell:ignore\n', 0),
+        ('abandonned abondon abilty  # codespell:ignore\r\n', 0),
+        ('abandonned abondon abilty  # codespell:ignore  # noqa: E501\n', 0),
+        ('abandonned abondon abilty  # codespell:ignore # noqa: E501\n', 0),
+        ('abandonned abondon abilty  # codespell:ignore# noqa: E501\n', 0),
+        ('abandonned abondon abilty  # codespell:ignore, noqa: E501\n', 0),
+        ('abandonned abondon abilty  #codespell:ignore\n', 0),
+        # ignore these for safety
+        ('abandonned abondon abilty  # codespell:ignorenoqa: E501\n', 3),
+        ('abandonned abondon abilty  codespell:ignore\n', 3),
+        ('abandonned abondon abilty codespell:ignore\n', 3),
+        # showcase different comment markers
+        ("abandonned abondon abilty ' codespell:ignore\n", 0),
+        ('abandonned abondon abilty " codespell:ignore\n', 0),
+        ('abandonned abondon abilty ;; codespell:ignore\n', 0),
+        ('abandonned abondon abilty /* codespell:ignore */\n', 0),
+        # prose examples
+        (
+            'You could also use line based igore ( codespell:ignore ) to igore ',
+            0,
+        ),
+        ('You could also use line based igore (codespell:ignore) to igore ', 0),
+        (
+            'You could also use line based igore (codespell:ignore igore) to igore ',
+            0,
+        ),  # noqa: E501
+        (
+            'You could also use line based igore (codespell:ignore igare) to igore ',
+            2,
+        ),  # noqa: E501
+    ],
+)
 def test_inline_ignores(
     tmpdir: pytest.TempPathFactory,
     capsys: pytest.CaptureFixture[str],
     content: str,
-    expected_error_count: int
+    expected_error_count: int,
 ) -> None:
     d = str(tmpdir)
     with open(op.join(d, 'bad.txt'), 'w') as f:

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -396,6 +396,8 @@ def test_ignore_word_list(
     ('abandonned abondon abilty  # codespell:ignore abondon', 2),
     ('abandonned abondon abilty  // codespell:ignore abondon,abilty', 1),
     ('abandonned abondon abilty  /* codespell:ignore abandonned,abondon,abilty', 0),  # noqa: E501
+    # ignore unused ignore
+    ('abandonned abondon abilty  # codespell:ignore nomenklatur', 3),
     # wildcard form
     ('abandonned abondon abilty  # codespell:ignore ', 0),
     ('abandonned abondon abilty  # codespell:ignore', 0),

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -417,6 +417,8 @@ def test_ignore_word_list(
         ("abandonned abondon abilty  # codespell:ignorenoqa: E501\n", 3),
         ("abandonned abondon abilty  codespell:ignore\n", 3),
         ("abandonned abondon abilty codespell:ignore\n", 3),
+        # ignore these as they aren't valid
+        ("abandonned abondon abilty  # codespell:igore\n", 3),
         # showcase different comment markers
         ("abandonned abondon abilty ' codespell:ignore\n", 0),
         ('abandonned abondon abilty " codespell:ignore\n', 0),

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -392,48 +392,48 @@ def test_ignore_word_list(
 
 
 @pytest.mark.parametrize(
-    'content, expected_error_count',
+    "content, expected_error_count",
     [
         # recommended form
-        ('abandonned abondon abilty  # codespell:ignore abondon', 2),
-        ('abandonned abondon abilty  // codespell:ignore abondon,abilty', 1),
+        ("abandonned abondon abilty  # codespell:ignore abondon", 2),
+        ("abandonned abondon abilty  // codespell:ignore abondon,abilty", 1),
         (
-            'abandonned abondon abilty  /* codespell:ignore abandonned,abondon,abilty',
+            "abandonned abondon abilty  /* codespell:ignore abandonned,abondon,abilty",
             0,
         ),  # noqa: E501
         # ignore unused ignore
-        ('abandonned abondon abilty  # codespell:ignore nomenklatur', 3),
+        ("abandonned abondon abilty  # codespell:ignore nomenklatur", 3),
         # wildcard form
-        ('abandonned abondon abilty  # codespell:ignore ', 0),
-        ('abandonned abondon abilty  # codespell:ignore', 0),
-        ('abandonned abondon abilty  # codespell:ignore\n', 0),
-        ('abandonned abondon abilty  # codespell:ignore\r\n', 0),
-        ('abandonned abondon abilty  # codespell:ignore  # noqa: E501\n', 0),
-        ('abandonned abondon abilty  # codespell:ignore # noqa: E501\n', 0),
-        ('abandonned abondon abilty  # codespell:ignore# noqa: E501\n', 0),
-        ('abandonned abondon abilty  # codespell:ignore, noqa: E501\n', 0),
-        ('abandonned abondon abilty  #codespell:ignore\n', 0),
+        ("abandonned abondon abilty  # codespell:ignore ", 0),
+        ("abandonned abondon abilty  # codespell:ignore", 0),
+        ("abandonned abondon abilty  # codespell:ignore\n", 0),
+        ("abandonned abondon abilty  # codespell:ignore\r\n", 0),
+        ("abandonned abondon abilty  # codespell:ignore  # noqa: E501\n", 0),
+        ("abandonned abondon abilty  # codespell:ignore # noqa: E501\n", 0),
+        ("abandonned abondon abilty  # codespell:ignore# noqa: E501\n", 0),
+        ("abandonned abondon abilty  # codespell:ignore, noqa: E501\n", 0),
+        ("abandonned abondon abilty  #codespell:ignore\n", 0),
         # ignore these for safety
-        ('abandonned abondon abilty  # codespell:ignorenoqa: E501\n', 3),
-        ('abandonned abondon abilty  codespell:ignore\n', 3),
-        ('abandonned abondon abilty codespell:ignore\n', 3),
+        ("abandonned abondon abilty  # codespell:ignorenoqa: E501\n", 3),
+        ("abandonned abondon abilty  codespell:ignore\n", 3),
+        ("abandonned abondon abilty codespell:ignore\n", 3),
         # showcase different comment markers
         ("abandonned abondon abilty ' codespell:ignore\n", 0),
         ('abandonned abondon abilty " codespell:ignore\n', 0),
-        ('abandonned abondon abilty ;; codespell:ignore\n', 0),
-        ('abandonned abondon abilty /* codespell:ignore */\n', 0),
+        ("abandonned abondon abilty ;; codespell:ignore\n", 0),
+        ("abandonned abondon abilty /* codespell:ignore */\n", 0),
         # prose examples
         (
-            'You could also use line based igore ( codespell:ignore ) to igore ',
+            "You could also use line based igore ( codespell:ignore ) to igore ",
             0,
         ),
-        ('You could also use line based igore (codespell:ignore) to igore ', 0),
+        ("You could also use line based igore (codespell:ignore) to igore ", 0),
         (
-            'You could also use line based igore (codespell:ignore igore) to igore ',
+            "You could also use line based igore (codespell:ignore igore) to igore ",
             0,
         ),  # noqa: E501
         (
-            'You could also use line based igore (codespell:ignore igare) to igore ',
+            "You could also use line based igore (codespell:ignore igare) to igore ",
             2,
         ),  # noqa: E501
     ],
@@ -445,7 +445,7 @@ def test_inline_ignores(
     expected_error_count: int,
 ) -> None:
     d = str(tmpdir)
-    with open(op.join(d, 'bad.txt'), 'w') as f:
+    with open(op.join(d, "bad.txt"), "w") as f:
         f.write(content)
     assert cs.main(d) == expected_error_count
 

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -418,7 +418,7 @@ def test_ignore_word_list(
         ("abandonned abondon abilty  codespell:ignore\n", 3),
         ("abandonned abondon abilty codespell:ignore\n", 3),
         # ignore these as they aren't valid
-        ("abandonned abondon abilty  # codespell:igore\n", 3),
+        ("abandonned abondon abilty  # codespell:igore\n", 4),
         # showcase different comment markers
         ("abandonned abondon abilty ' codespell:ignore\n", 0),
         ('abandonned abondon abilty " codespell:ignore\n', 0),

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -417,6 +417,9 @@ def test_ignore_word_list(
     ("abandonned abondon abilty ' codespell:ignore\n", 0),
     ('abandonned abondon abilty " codespell:ignore\n', 0),
     ('abandonned abondon abilty ;; codespell:ignore\n', 0),
+    ('abandonned abondon abilty /* codespell:ignore */\n', 0),
+    # avoid false positive
+    ('You could also use line based igore ( codespell:ignore ) to igore ', 2),
 ])
 def test_inline_ignores(
     tmpdir: pytest.TempPathFactory,

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -402,6 +402,7 @@ def test_ignore_word_list(
     ('abandonned abondon abilty  # codespell:ignore ', 0),
     ('abandonned abondon abilty  # codespell:ignore', 0),
     ('abandonned abondon abilty  # codespell:ignore\n', 0),
+    ('abandonned abondon abilty  # codespell:ignore\r\n', 0),
     ('abandonned abondon abilty  # codespell:ignore  # noqa: E501\n', 0),
     ('abandonned abondon abilty  # codespell:ignore # noqa: E501\n', 0),
     # ignore these for safety

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -405,12 +405,11 @@ def test_ignore_word_list(
     ('abandonned abondon abilty  # codespell:ignore\r\n', 0),
     ('abandonned abondon abilty  # codespell:ignore  # noqa: E501\n', 0),
     ('abandonned abondon abilty  # codespell:ignore # noqa: E501\n', 0),
+    ('abandonned abondon abilty  # codespell:ignore# noqa: E501\n', 0),
+    ('abandonned abondon abilty  # codespell:ignore, noqa: E501\n', 0),
+    ('abandonned abondon abilty  #codespell:ignore\n', 0),
     # ignore these for safety
-    ('abandonned abondon abilty  # codespell:ignore# noqa: E501\n', 3),
-    ('abandonned abondon abilty  # codespell:ignore, noqa: E501\n', 3),
-    ('abandonned abondon abilty  # codespell:ignore/noqa: E501\n', 3),
     ('abandonned abondon abilty  # codespell:ignorenoqa: E501\n', 3),
-    ('abandonned abondon abilty  #codespell:ignore\n', 3),
     ('abandonned abondon abilty  codespell:ignore\n', 3),
     ('abandonned abondon abilty codespell:ignore\n', 3),
     # showcase different comment markers
@@ -418,8 +417,11 @@ def test_ignore_word_list(
     ('abandonned abondon abilty " codespell:ignore\n', 0),
     ('abandonned abondon abilty ;; codespell:ignore\n', 0),
     ('abandonned abondon abilty /* codespell:ignore */\n', 0),
-    # avoid false positive
-    ('You could also use line based igore ( codespell:ignore ) to igore ', 2),
+    # prose examples
+    ('You could also use line based igore ( codespell:ignore ) to igore ', 0),
+    ('You could also use line based igore (codespell:ignore) to igore ', 0),
+    ('You could also use line based igore (codespell:ignore igore) to igore ', 0),  # noqa: E501
+    ('You could also use line based igore (codespell:ignore igare) to igore ', 2),  # noqa: E501
 ])
 def test_inline_ignores(
     tmpdir: pytest.TempPathFactory,

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -392,7 +392,7 @@ def test_ignore_word_list(
 
 
 @pytest.mark.parametrize(
-    "content, expected_error_count",
+    ("content", "expected_error_count"),
     [
         # recommended form
         ("abandonned abondon abilty  # codespell:ignore abondon", 2),
@@ -400,7 +400,7 @@ def test_ignore_word_list(
         (
             "abandonned abondon abilty  /* codespell:ignore abandonned,abondon,abilty",
             0,
-        ),  # noqa: E501
+        ),
         # ignore unused ignore
         ("abandonned abondon abilty  # codespell:ignore nomenklatur", 3),
         # wildcard form
@@ -431,11 +431,11 @@ def test_ignore_word_list(
         (
             "You could also use line based igore (codespell:ignore igore) to igore ",
             0,
-        ),  # noqa: E501
+        ),
         (
             "You could also use line based igore (codespell:ignore igare) to igore ",
             2,
-        ),  # noqa: E501
+        ),
     ],
 )
 def test_inline_ignores(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,4 +171,4 @@ allow-magic-value-types = ["bytes", "int", "str",]
 max-args = 13
 max-branches = 49
 max-returns = 11
-max-statements = 200
+max-statements = 119

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,4 +171,4 @@ allow-magic-value-types = ["bytes", "int", "str",]
 max-args = 13
 max-branches = 49
 max-returns = 11
-max-statements = 113
+max-statements = 200


### PR DESCRIPTION
Fixes #1212

Following @rob-miller's suggestion implement inline ignore hints.

E.g.

```
crate  // codespell:ignore crate
abandonned abondon abilty  # codespell:ignore abondon,abilty
abandonned abondon abilty  # codespell:ignore  # to ignore all
```