### PR TITLE
'analyses' is the plural of 'analysis'

### DIFF
--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -9,7 +9,6 @@ analyse->analyze
 analysed->analyzed
 analyser->analyzer
 analysers->analyzers
-analyses->analyzes
 analysing->analyzing
 artefact->artifact
 artefacts->artifacts


### PR DESCRIPTION
As the title states, 'analyses' is the correct plural of 'analysis' in American English. As such, it shouldn't get flagged.

Unfortunately, this does mean that it won't flag usage of 'to analyze' in the third person, but I'm not sure how much can be done about that.