### PR TITLE
"Imbed" is a valid alternate form of "embed"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -16825,9 +16825,6 @@ imapcting->impacting
 imapcts->impacts
 imapge->image
 imbaress->embarrass
-imbed->embed
-imbedded->embedded
-imbedding->embedding
 imblance->imbalance
 imbrase->embrace
 imcoming->incoming


### PR DESCRIPTION
So remove suggested rewrites from the dictionary.

N.b. it is not clear from the README if the philosophy of this project
is to drive people to "preferred" spellings or to "correct" spellings.
If it is the latter, "imbed" and variants are valid (albeit less common)
alternates to "embed" - see for example
https://www.merriam-webster.com/dictionary/imbed