### PR TITLE
Change "circularly" to "circulary".

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -26,7 +26,7 @@ cant->can't
 chack->check, chalk, cheque,
 chancel->cancel
 chancels->cancels
-circularly->circular
+circulary->circular, circularly,
 commata->commas
 commend->comment, command,
 commends->comments, commands,


### PR DESCRIPTION
In `codespell_lib/data/dictionary_rare.txt`, one has: `circularly->circular`. However, the word "circularly" is not rare, and a mistake for "circular" is improbable (difference of 2 letters). I suspect that it is an error coming from commit d978da6e3143d2fee553e836a0b0ee46a68bd900 for the fix of issue #1193, where one previously had
```
circularly->circular, circularly,
```
while this should have been
```
circulary->circular, circularly,
```
as the adjective "circulary" exists (1913 Webster), but is rare and obsolete (the adjective "circular" is now used instead).