### PR TITLE
Add entries to the inclusive language dictionary

### DIFF
--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -3,9 +3,13 @@ blacklists->blocklists
 blueish->bluish
 man-hour->person-hour
 man-hours->person-hours
-man-in-the-middle->on-path attacker
+man-in-the-middle->on-path attacker, interceptor, intermediary
 master->primary, leader, active, writer, coordinator, parent, manager, main,
 masters->primaries, leaders, actives, writers, coordinators, parents, managers,
+sanity-check->test, verification
+sanity-checks->tests, verifications
+sanity-test->test, verification
+sanity-tests->tests, verifications
 segregation->separation, segmentation
 segregations->separations, segmentations
 slave->secondary, follower, standby, replica, reader, worker, helper, subordinate, subsystem,

--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -1,9 +1,13 @@
 blacklist->blocklist
 blacklists->blocklists
 blueish->bluish
+man-hour->person-hour
+man-hours->person-hours
 man-in-the-middle->on-path attacker
 master->primary, leader, active, writer, coordinator, parent, manager, main,
 masters->primaries, leaders, actives, writers, coordinators, parents, managers,
+segregation->separation, segmentation
+segregations->separations, segmentations
 slave->secondary, follower, standby, replica, reader, worker, helper, subordinate, subsystem,
 slaves->secondaries, followers, standbys, replicas, readers, workers, helpers, subordinates,
 whitelist->allowlist, permitlist,

--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -1,11 +1,20 @@
+black-hat->malicious actor, attacker
+blackhat->malicious actor, attacker
 blacklist->blocklist
 blacklists->blocklists
 blueish->bluish
-man-hour->person-hour
-man-hours->person-hours
-man-in-the-middle->on-path attacker, interceptor, intermediary
+cripples->slows down, hinders, obstructs
+crippling->attenuating, incapacitating
+dummy-value->placeholder value
+girlfriend-test->mom-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test
+man-hour->staff hour, volunteer hour, hour of effort, person-hour
+man-hours->staff hours, volunteer hours, hours of effort, person-hours
+man-in-the-middle->on-path attacker, interceptor, intermediary, machine-in-the-middle, person-in-the-middle
+manned->crewed, staffed, monitored, human operated
 master->primary, leader, active, writer, coordinator, parent, manager, main,
 masters->primaries, leaders, actives, writers, coordinators, parents, managers,
+middleman->intermediary, broker
+mom-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test
 sanity-check->test, verification
 sanity-checks->tests, verifications
 sanity-test->test, verification

--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -6,7 +6,7 @@ blueish->bluish
 cripples->slows down, hinders, obstructs
 crippling->attenuating, incapacitating
 dummy-value->placeholder value
-girlfriend-test->mom-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test
+girlfriend-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test
 man-hour->staff hour, volunteer hour, hour of effort, person-hour
 man-hours->staff hours, volunteer hours, hours of effort, person-hours
 man-in-the-middle->on-path attacker, interceptor, intermediary, machine-in-the-middle, person-in-the-middle

--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -1,26 +1,26 @@
-black-hat->malicious actor, attacker
-blackhat->malicious actor, attacker
+black-hat->malicious actor, attacker,
+blackhat->malicious actor, attacker,
 blacklist->blocklist
 blacklists->blocklists
 blueish->bluish
-cripples->slows down, hinders, obstructs
-crippling->attenuating, incapacitating
+cripples->slows down, hinders, obstructs,
+crippling->attenuating, incapacitating,
 dummy-value->placeholder value
-girlfriend-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test
-man-hour->staff hour, volunteer hour, hour of effort, person-hour
-man-hours->staff hours, volunteer hours, hours of effort, person-hours
-man-in-the-middle->on-path attacker, interceptor, intermediary, machine-in-the-middle, person-in-the-middle
-manned->crewed, staffed, monitored, human operated
+girlfriend-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test,
+man-hour->staff hour, volunteer hour, hour of effort, person-hour,
+man-hours->staff hours, volunteer hours, hours of effort, person-hours,
+man-in-the-middle->on-path attacker, interceptor, intermediary, machine-in-the-middle, person-in-the-middle,
+manned->crewed, staffed, monitored, human operated,
 master->primary, leader, active, writer, coordinator, parent, manager, main,
 masters->primaries, leaders, actives, writers, coordinators, parents, managers,
-middleman->intermediary, broker
-mom-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test
-sanity-check->test, verification
-sanity-checks->tests, verifications
-sanity-test->test, verification
-sanity-tests->tests, verifications
-segregation->separation, segmentation
-segregations->separations, segmentations
+middleman->intermediary, broker,
+mom-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test,
+sanity-check->test, verification,
+sanity-checks->tests, verifications,
+sanity-test->test, verification,
+sanity-tests->tests, verifications,
+segregation->separation, segmentation,
+segregations->separations, segmentations,
 slave->secondary, follower, standby, replica, reader, worker, helper, subordinate, subsystem,
 slaves->secondaries, followers, standbys, replicas, readers, workers, helpers, subordinates,
 whitelist->allowlist, permitlist,


### PR DESCRIPTION
This PR adds entries to the `usage` inclusive language dictionary.

References:
- https://github.com/IBM/IBMInclusiveITLanguage
- https://inclusivenaming.org/word-lists/

cc: @madhens @lex-joy