### PR TITLE
Capitalize LessTif

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20031,7 +20031,7 @@ lerans->learns
 lern->learn, lean,
 lerned->learned, learnt, leaned,
 lerning->learning, leaning,
-lesstiff->lesstif
+lesstiff->LessTif
 letgitimate->legitimate
 letmost->leftmost
 leutenant->lieutenant


### PR DESCRIPTION
This PR changes the replacement word from lesstif to LessTif as in https://en.wikipedia.org/wiki/LessTif

As discussed in PR #2470.