### PR TITLE
Add shell completion by shtab

### DIFF
--- a/codespell_lib/_shtab.py
+++ b/codespell_lib/_shtab.py
@@ -1,0 +1,8 @@
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(parser, *args, **kwargs):
+    from argparse import Action
+    Action.complete = None
+    return parser

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,6 @@ if __name__ == "__main__":
               "dev": ["check-manifest", "flake8", "pytest", "pytest-cov",
                       "pytest-dependency"],
               "hard-encoding-detection": ["chardet"],
+              "shtab": ["completion"],
           }
           )


### PR DESCRIPTION

Because bug of shtab <https://github.com/iterative/shtab/issues/91>, I 
temporarily fix it in my fork and sent a PR to shtab. A fixed version:

```zsh
❯ codespell --print-completion zsh|tee /usr/share/zsh/site-functions/_codespell
#compdef codespell

# AUTOMATCALLY GENERATED by `shtab`


_shtab_codespell_commands() {
  local _commands=(
    
  )
  _describe 'codespell commands' _commands
}

_shtab_codespell_options=(
  "(- : *)"{-h,--help}"[show this help message and exit]"
  "(- : *)--print-completion[print shell completion script]:print_completion:(bash zsh tcsh)"
  "(- : *)--version[show program\'s version number and exit]"
  {-d,--disable-colors}"[disable colors, even when printing to terminal (always set for Windows)]"
  {-c,--enable-colors}"[enable colors, even when not printing to terminal]"
  {-w,--write-changes}"[write changes in place if possible]"
  "*"{-D,--dictionary}"[custom dictionary file that contains spelling corrections. If this flag is not specified or equals \"-\" then the default dictionary is used. This option can be specified multiple times.]:dictionary:"
  "--builtin[comma-separated list of builtin dictionaries to include (when \"-D -\" or no \"-D\" is passed). Current options are\:
- clear\: for unambiguous errors
- rare\: for rare (but valid) words that are likely to be errors
- informal\: for making informal words more formal
- usage\: for replacing phrasing with recommended terms
- code\: for words from code and\/or mathematics that are likely to be typos in other contexts (such as uint)
- names\: for valid proper names that might be typos
- en-GB_to_en-US\: for corrections from en-GB to en-US
The default is \%(default)r.]:builtin:((clear\:for unambiguous errors rare\:for rare (but valid) words that are likely to be errors informal\:for making informal words more formal usage\:for replacing phrasing with recommended terms code\:for words from code and/or mathematics that are likely to be typos in other contexts (such as uint) names\:for valid proper names that might be typos en-GB_to_en-US\:for corrections from en-GB to en-US))"
  "--ignore-regex[regular expression that is used to find patterns to ignore by treating as whitespace. When writing regular expressions, consider ensuring there are boundary non-word chars, e.g., \"\\bmatch\\b\". Defaults to empty\/disabled.]:ignore_regex:"
  "*"{-I,--ignore-words}"[file that contains words that will be ignored by codespell. File must contain 1 word per line. Words are case sensitive based on how they are written in the dictionary file]:ignore_words:_files"
  "*"{-L,--ignore-words-list}"[comma separated list of words to be ignored by codespell. Words are case sensitive based on how they are written in the dictionary file]:ignore_words_list:"
  "*--uri-ignore-words-list[comma separated list of words to be ignored by codespell in URIs and emails only. Words are case sensitive based on how they are written in the dictionary file. If set to \"\*\", all misspelling in URIs and emails will be ignored.]:uri_ignore_words_list:"
  {-r,--regex}"[regular expression that is used to find words. By default any alphanumeric character, the underscore, the hyphen, and the apostrophe is used to build words. This option cannot be specified together with --write-changes.]:regex:"
  "--uri-regex[regular expression that is used to find URIs and emails. A default expression is provided.]:uri_regex:"
  {-s,--summary}"[print summary of fixes]"
  "--count[print the number of errors as the last line of stderr]"
  "*"{-S,--skip}"[comma-separated list of files to skip. It accepts globs as well. E.g.\: if you want codespell to skip .eps and .txt files, you\'d give \"\*.eps,\*.txt\" to this option.]:skip:"
  {-x,--exclude-file}"[ignore whole lines that match those in the file FILE. The lines in FILE should match the to-be-excluded lines exactly]:exclude_file:_files"
  {-i,--interactive}"[set interactive mode when writing changes\:
- 0\: no interactivity.
- 1\: ask for confirmation.
- 2\: ask user to choose one fix when more than one is available.
- 3\: both 1 and 2]:interactive:((0\:no interactivity. 1\:ask for confirmation. 2\:ask user to choose one fix when more than one is available. 3\:both 1 and 2))"
  {-q,--quiet-level}"[bitmask that allows suppressing messages\:
- 0\: print all messages.
- 1\: disable warnings about wrong encoding.
- 2\: disable warnings about binary files.
- 4\: omit warnings about automatic fixes that were disabled in the dictionary.
- 8\: don\'t print anything for non-automatic fixes.
- 16\: don\'t print the list of fixed files.
As usual with bitmasks, these levels can be combined\; e.g. use 3 for levels 1\+2, 7 for 1\+2\+4, 23 for 1\+2\+4\+16, etc. The default mask is \%(default)s.]:quiet_level:((0\:print all messages. 1\:disable warnings about wrong encoding. 2\:disable warnings about binary files. 3\: 4\:omit warnings about automatic fixes that were disabled in the dictionary. 5\: 6\: 7\: 8\:don't print anything for non-automatic fixes. 9\: 10\: 11\: 12\: 13\: 14\: 15\: 16\:don't print the list of fixed files. 17\: 18\: 19\: 20\: 21\: 22\: 23\: 24\: 25\: 26\: 27\: 28\: 29\: 30\: 31\:))"
  {-e,--hard-encoding-detection}"[use chardet to detect the encoding of each file. This can slow down codespell, but is more reliable in detecting encodings other than utf-8, iso8859-1, and ascii.]"
  {-f,--check-filenames}"[check file names as well]"
  {-H,--check-hidden}"[check hidden files and directories (those starting with \".\") as well.]"
  {-A,--after-context}"[print LINES of trailing context]:after_context:"
  {-B,--before-context}"[print LINES of leading context]:before_context:"
  {-C,--context}"[print LINES of surrounding context]:context:"
  "--config[path to config file.]:config:_files"
  "(*)::files or directories to check:_files"
)


_shtab_codespell() {
  local context state line curcontext="$curcontext"

  if ((${_shtab_codespell_options[(I)'(-)*']} + ${_shtab_codespell_options[(I)'(*)']} == 0)); then
    _shtab_codespell_options+=(': :_shtab_codespell_commands' '*::: :->codespell')
  fi
  _arguments -C $_shtab_codespell_options

  case $state in
    codespell)
      words=($line[1] "${words[@]}")
      (( CURRENT += 1 ))
      curcontext="${curcontext%:*:*}:_shtab_codespell-$line[1]:"
      case $line[1] in
        
      esac
  esac
}



typeset -A opt_args
_shtab_codespell "$@"
```