### PR TITLE
move `warmup` to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -36612,7 +36612,6 @@ warining->warning
 warinings->warnings
 warks->works
 warlking->walking
-warmup->warm up, warm-up,
 warnibg->warning
 warnibgs->warnings
 warnig->warning

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -72,5 +72,6 @@ uint->unit
 uis->is, use,
 usesd->used, uses,
 wan->want
+warmup->warm up, warm-up,
 were'->we're
 whome->whom


### PR DESCRIPTION
I think `warmup->warm up` is valid for prose, but it seems common in code without being strictly mispelled: https://github.com/search?q=warmup&type=code

The [Java Microbenchmark Harness](https://github.com/openjdk/jmh), for example, has a `@Warmup` annotation: https://javadoc.io/doc/org.openjdk.jmh/jmh-core/latest/org/openjdk/jmh/annotations/Warmup.html