### PR TITLE
Include chardet in dev dependencies

### DIFF
--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python --version  # just to check
           pip install -U pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
-          pip install --upgrade chardet "setuptools!=47.2.0" docutils setuptools_scm[toml] twine
+          pip install --upgrade "setuptools!=47.2.0" docutils setuptools_scm[toml] twine
           pip install aspell-python-py3
           pip install -e ".[dev]" # install the codespell dev packages
       - run: codespell --help

--- a/.github/workflows/codespell-windows.yml
+++ b/.github/workflows/codespell-windows.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           python --version
           pip install -U pip
-          pip install chardet setuptools
+          pip install setuptools
           pip install -e .[dev]
       - run: codespell --help
       - run: codespell --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
     "build",
+    "chardet",
     "flake8",
     "flake8-pyproject",
     "pytest",


### PR DESCRIPTION
[Per `README`](https://github.com/codespell-project/codespell#development-setup), you should run `pip install -e ".[dev]"` to install dependencies required for development but currently `dev` does not include `chardet` which is required for running one of the unit tests.

I also went ahead and removed the direct installation of the `chardet` dep since it's now installed by `dev` extra which both CI setups use.