### PR TITLE
Add spelling correction

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -24395,6 +24395,7 @@ pararaph->paragraph
 parareter->parameter
 parargaph->paragraph
 parargaphs->paragraphs
+pararmeter->parameter
 pararmeters->parameters
 parastic->parasitic
 parastics->parasitics


### PR DESCRIPTION
Missing singular form for `pararmeter` which appears many times: https://github.com/search?q=pararmeter&type=code