### PR TITLE
Add spelling correction for place

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25130,6 +25130,12 @@ playright->playwright
 playwrite->playwright
 playwrites->playwrights
 plcae->place
+plcaebo->placebo
+plcaed->placed
+plcaeholder->placeholder
+plcaeholders->placeholders
+plcaement->placement
+plcaements->placements
 plcaes->places
 pleaase->please
 pleace->please, place,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25129,6 +25129,8 @@ playgropund->playground
 playright->playwright
 playwrite->playwright
 playwrites->playwrights
+plcae->place
+plcaes->places
 pleaase->please
 pleace->please, place,
 pleacing->placing


### PR DESCRIPTION
Spelling correction for `plcae` which appears many times:
* https://github.com/search?q=plcae&type=code
* https://github.com/search?q=plcaes&type=code