### PR TITLE
Move falsy and accreting to more appropriate files

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -497,7 +497,6 @@ accrdingly->accordingly
 accrediation->accreditation
 accredidation->accreditation
 accress->access
-accreting->accrediting
 accroding->according
 accrodingly->accordingly
 accronym->acronym
@@ -15330,7 +15329,6 @@ falshed->flashed
 falshes->flashes
 falshing->flashing
 falsly->falsely
-falsy->falsely, false,
 falt->fault
 falure->failure
 familar->familiar

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -21,6 +21,7 @@ dur->due
 endcode->encode
 errorstring->error string
 exitst->exits, exists,
+falsy->falsely, false,
 files'->file's
 gae->game, Gael, gale,
 hist->heist, his,

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -1,4 +1,5 @@
 ablet->able, tablet,
+accreting->accrediting
 afterwords->afterwards
 amination->animation, lamination,
 aminations->animations, laminations,


### PR DESCRIPTION
Closes #2444.

1. move `falsy` to `codespell_lib/data/dictionary_code.txt` 
2. move `accreting` to `codespell_lib/data/dictionary_rare.txt`