### PR TITLE
DOC: Better docs

### DIFF
--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -2,6 +2,7 @@
 # For general usage in your repo, see the example in codespell.yml
 # https://github.com/codespell-project/codespell
 name: codespell Private Actions
+# Cancel an action on a given PR once a new commit is pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -1,8 +1,8 @@
 # GitHub Action to check our dictionary, this should only be used by the codespell project itself
 # For general usage in your repo, see the example in codespell.yml
 # https://github.com/codespell-project/codespell
+# Concurrency cancels an action on a given PR once a new commit is pushed
 name: codespell Private Actions
-# Cancel an action on a given PR once a new commit is pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ This is equivalent to running::
 
     codespell --quiet-level 3 --count --skip "*.po,*.ts,./src/3rdParty,./src/Test"
 
-Now codespell also support ``pyproject.toml``::
+Now codespell also support ``pyproject.toml`` via the ``--toml pyproject.toml`` argument::
 
     [tool.codespell]
     skip = '*.po,*.ts,./src/3rdParty,./src/Test'

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ This is equivalent to running::
 Any options specified in the command line will *override* options from the
 config files.
 
-.. _tomli:: https://pypi.org/project/tomli/
+.. _tomli: https://pypi.org/project/tomli/
 
 Dictionary format
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -103,19 +103,24 @@ be specified in this file (without the preceding dashes), for example::
     count =
     quiet-level = 3
 
-This is equivalent to running::
-
-    codespell --quiet-level 3 --count --skip "*.po,*.ts,./src/3rdParty,./src/Test"
-
-Now codespell also support ``pyproject.toml`` via the ``--toml pyproject.toml`` argument::
+Codespell will also check in the current directory for a ``pyproject.toml``
+(or a path can be specified via ``--toml <filename>``) file, and the
+``[tool.codespell]`` entry will be used as long as the tomli_ package
+is installed, for example::
 
     [tool.codespell]
     skip = '*.po,*.ts,./src/3rdParty,./src/Test'
     count = ''
     quiet-level = 3
 
+This is equivalent to running::
+
+    codespell --quiet-level 3 --count --skip "*.po,*.ts,./src/3rdParty,./src/Test"
+
 Any options specified in the command line will *override* options from the
-config file.
+config files.
+
+.. _tomli:: https://pypi.org/project/tomli/
 
 Dictionary format
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ is installed, for example::
     count = ''
     quiet-level = 3
 
-This is equivalent to running::
+These are both equivalent to running::
 
     codespell --quiet-level 3 --count --skip "*.po,*.ts,./src/3rdParty,./src/Test"
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -407,14 +407,22 @@ def parse_options(args):
     config = configparser.ConfigParser()
 
     # Read toml before other config files.
+    toml_files_errors = list()
+    if os.path.isfile('pyproject.toml'):
+        toml_files_errors.append(('pyproject.toml', False))
     if options.toml:
+        toml_files_errors.append((options.toml, True))
+    for toml_file, raise_error in toml_files_errors:
         try:
             import tomli
         except Exception as exc:
-            raise ImportError(
-                f'tomli is required to read pyproject.toml but could not be '
-                f'imported, got: {exc}') from None
-        with open(options.toml, 'rb') as f:
+            if raise_error:
+                raise ImportError(
+                    f'tomli is required to read pyproject.toml but could not be '
+                    f'imported, got: {exc}') from None
+            else:
+                continue
+        with open(toml_file, 'rb') as f:
             data = tomli.load(f).get('tool', {})
         config.read_dict(data)
     config.read(cfg_files)

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -418,8 +418,8 @@ def parse_options(args):
         except Exception as exc:
             if raise_error:
                 raise ImportError(
-                    f'tomli is required to read pyproject.toml but could not be '
-                    f'imported, got: {exc}') from None
+                    f'tomli is required to read pyproject.toml but could not '
+                    f'be imported, got: {exc}') from None
             else:
                 continue
         with open(toml_file, 'rb') as f:

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -808,7 +808,7 @@ def test_config_toml(tmp_path, capsys, kind):
     assert 'bad.txt' in stdout
 
     if kind == 'cfg':
-        conffile = str(tmp_path / 'config.cfg')
+        conffile = str(tmp_path / 'setup.cfg')
         args = ('--config', conffile)
         with open(conffile, 'w') as f:
             f.write("""\
@@ -830,6 +830,16 @@ count = false
 
     # Should pass when skipping bad.txt
     code, stdout, _ = cs.main(str(d), *args, count=True, std=True)
+    assert code == 0
+    assert 'bad.txt' not in stdout
+
+    # And both should automatically work if they're in cwd
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        code, stdout, _ = cs.main(str(d), count=True, std=True)
+    finally:
+        os.chdir(cwd)
     assert code == 0
     assert 'bad.txt' not in stdout
 


### PR DESCRIPTION
@peternewman this should address some of your comments at least

Feel free to open a PR where, if `pyproject.toml` is detected in `cwd`, it tries to use it. But I don't think it should raise an error or print anything (because doing either could mess up existing workflows).