### PR TITLE
Migrate metadata from setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,56 @@
+[metadata]
+name = codespell
+version = attr: codespell_lib.__version__
+maintainer = Lucas De Marchi
+maintainer_email = lucas.de.marchi@gmail.com
+license = GPL v2
+description = Codespell
+url = https://github.com/codespell-project/codespell/
+download_url = https://github.com/codespell-project/codespell/
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+classifiers =
+    Intended Audience :: Developers
+    License :: OSI Approved
+    Programming Language :: Python
+    Topic :: Software Development
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Operating System :: Unix
+    Operating System :: MacOS
+platforms = any
+
+[options]
+packages =
+    codespell_lib
+    codespell_lib.tests
+    codespell_lib.data
+zip_safe = False
+include_package_data = True
+python_requires = >=3.7
+
+[options.entry_points]
+console_scripts = codespell = codespell_lib:_script_main
+
+# TODO: toml will need to be updated when 3.11 comes out as it's a
+# CPython module there
+
+[options.extras_require]
+dev =
+    check-manifest
+    flake8
+    pytest
+    pytest-cov
+    pytest-dependency
+    tomli
+hard-encoding-detection = chardet
+toml = tomli
+
+[options.package_data]
+codespell_lib =
+    data/dictionary*.txt
+    data/linux-kernel.exclude
+
 [tool:pytest]
 addopts = --cov=codespell_lib -rs --cov-report= --tb=short
 

--- a/setup.py
+++ b/setup.py
@@ -1,69 +1,12 @@
 #! /usr/bin/env python
 
-# adapted from mne-python
-
+import contextlib
 import os
 
 from setuptools import setup
 
-from codespell_lib import __version__
-
-DISTNAME = 'codespell'
-DESCRIPTION = """Codespell"""
-MAINTAINER = 'Lucas De Marchi'
-MAINTAINER_EMAIL = 'lucas.de.marchi@gmail.com'
-URL = 'https://github.com/codespell-project/codespell/'
-LICENSE = 'GPL v2'
-DOWNLOAD_URL = 'https://github.com/codespell-project/codespell/'
-with open('README.rst', 'r') as f:
-    LONG_DESCRIPTION = f.read()
-
 if __name__ == "__main__":
-    if os.path.exists('MANIFEST'):
+    with contextlib.suppress(FileNotFoundError):
         os.remove('MANIFEST')
 
-    setup(name=DISTNAME,
-          maintainer=MAINTAINER,
-          include_package_data=True,
-          maintainer_email=MAINTAINER_EMAIL,
-          description=DESCRIPTION,
-          license=LICENSE,
-          url=URL,
-          version=__version__,
-          download_url=DOWNLOAD_URL,
-          long_description=LONG_DESCRIPTION,
-          long_description_content_type='text/x-rst',
-          zip_safe=False,
-          classifiers=['Intended Audience :: Developers',
-                       'License :: OSI Approved',
-                       'Programming Language :: Python',
-                       'Topic :: Software Development',
-                       'Operating System :: Microsoft :: Windows',
-                       'Operating System :: POSIX',
-                       'Operating System :: Unix',
-                       'Operating System :: MacOS'],
-          platforms='any',
-          python_requires='>=3.7',
-          packages=[
-              'codespell_lib',
-              'codespell_lib.tests',
-              'codespell_lib.data',
-          ],
-          package_data={'codespell_lib': [
-              os.path.join('data', 'dictionary*.txt'),
-              os.path.join('data', 'linux-kernel.exclude'),
-          ]},
-          entry_points={
-              'console_scripts': [
-                  'codespell = codespell_lib:_script_main'
-              ],
-          },
-          # TODO: toml will need to be updated when 3.11 comes out as it's a
-          # CPython module there
-          extras_require={
-              "dev": ["check-manifest", "flake8", "pytest", "pytest-cov",
-                      "pytest-dependency", "tomli"],
-              "hard-encoding-detection": ["chardet"],
-              "toml": ["tomli"],
-          }
-          )
+    setup()


### PR DESCRIPTION
This pull request was created using https://pypi.org/project/setuptools-py2cfg plus manual modifications.

https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use
> We recommend users expose as much as possible configuration in a more declarative way via the [pyproject.toml](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html) or [setup.cfg](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html), and keep the setup.py minimal with only the dynamic parts (or even omit it completely if applicable).