### PR TITLE
Fix build_exclude_hashes fails: UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2244: character maps to <undefined>

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -460,7 +460,7 @@ def parse_ignore_words_option(ignore_words_option):
 
 
 def build_exclude_hashes(filename, exclude_lines):
-    with codecs.open(filename, 'r') as f:
+    with codecs.open(filename, mode='r', encoding='utf-8') as f:
         for line in f:
             exclude_lines.add(line)
 


### PR DESCRIPTION
On Win11 I always get

codespell................................................................Failed
- hook id: codespell
- exit code: 1

Traceback (most recent call last):
  File "C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64\lib\runpy.py", line 197, in _run_module_as_main return _run_code(code, main_globals, None, File "C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64\lib\runpy.py", line 87, in _run_code exec(code, run_globals) File "C:\Users\Joerg.WORLDWARTWEB\.cache\pre-commit\repox5gyvwwr\py_env-python3\Scripts\codespell.EXE\__main__.py", line 7, in <module> File "C:\Users\Joerg.WORLDWARTWEB\.cache\pre-commit\repox5gyvwwr\py_env-python3\lib\site-packages\codespell_lib\_codespell.py", line 747, in _script_main return main(*sys.argv[1:]) File "C:\Users\Joerg.WORLDWARTWEB\.cache\pre-commit\repox5gyvwwr\py_env-python3\lib\site-packages\codespell_lib\_codespell.py", line 862, in main build_exclude_hashes(options.exclude_file, exclude_lines) File "C:\Users\Joerg.WORLDWARTWEB\.cache\pre-commit\repox5gyvwwr\py_env-python3\lib\site-packages\codespell_lib\_codespell.py", line 443, in build_exclude_hashes for line in f: File "C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64\lib\encodings\cp1252.py", line 23, in decode return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2244: character maps to <undefined>

The proposed change fixes this for me