### PR TITLE
Misspelling of sufficient, sufficiently

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32653,11 +32653,17 @@ sufficated->suffocated
 sufficates->suffocates
 sufficating->suffocating
 suffication->suffocation
+sufficency->sufficiency
 sufficent->sufficient
 sufficently->sufficiently
+sufficiancy->sufficiency
 sufficiant->sufficient
+sufficiantly->sufficiently
 sufficiennt->sufficient
 sufficienntly->sufficiently
+suffiency->sufficiency
+suffient->sufficient
+suffiently->sufficiently
 suffisticated->sophisticated
 suficate->suffocate
 suficated->suffocated


### PR DESCRIPTION
* https://github.com/search?q=sufficency&type=code  1206
* https://github.com/search?q=sufficiancy&type=code  104
* https://github.com/search?q=sufficiant&type=code  24618
* https://github.com/search?q=sufficiantly&type=code  844
* https://github.com/search?q=suffiency&type=code  666
* https://github.com/search?q=suffient&type=code  286066
* https://github.com/search?q=suffiently&type=code  35388