### PR TITLE
MAINT: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# The purpose of this file is to trigger review requests when PRs touch
+# particular files. Those reviews are not mandatory, however it's often useful
+# to have an expert pinged who is interested in only one part of codespell and
+# doesn't follow general development.
+#
+# Note that only GitHub handles (whether individuals or teams) with commit
+# rights should be added to this file.
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# for more details about how CODEOWNERS works.
+
+# Each line is a file pattern followed by one or more owners.
+
+# Copy-paste-adapted from SciPy
+
+# Administrata and CIs
+*.toml  @larsoner
+*.yml  @larsoner
+*.rst  @larsoner
+*.cfg  @larsoner
+coverage*  @larsoner
+.github/*  @larsoner
+Makefile  @larsoner
+
+# Python code
+codespell_lib/*.py  @larsoner
+
+# Dictionaries
+# codepell_lib/data/*.txt  @luzpaz


### PR DESCRIPTION
To facilitate review, we can have a CODEOWNERS file that allows maintainers to be auto-tagged for review. I've added myself here. I propose we merge this, then @luzpaz @peternewman you can open PRs to add yourself wherever you want.