### PR TITLE
Read config file without interpolation

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -402,7 +402,7 @@ def parse_options(args):
     cfg_files = ['setup.cfg', '.codespellrc']
     if options.config:
         cfg_files.append(options.config)
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
 
     # Read toml before other config files.
     toml_files_errors = list()


### PR DESCRIPTION
Some config files use interpolation, some do not:
https://docs.python.org/3/library/configparser.html#interpolation-of-values

Config files might contain occurrences of `%` that should not be interpolated. When attempting to interpolate them, `ConfigParser` crashes with:
```
	ValueError: invalid interpolation syntax
```

Therefore, we decide to disable interpolation, to avoid crashes. We do not expect interpolation in the `[codespell]` section, so it shouldn't be a problem in practice.

Alternatively, we could read with interpolation (which interpolation scheme by the way?), and in the case of a ValueError exception, retry without interpolation. However, since we do not expect interpolation in the `[codespell]` section, I believe the current solution is simpler, faster, to the point.

Fixes #2544.