### PR TITLE
Add constrainst to dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8023,6 +8023,7 @@ constracted->constructed
 constractor->constructor
 constractors->constructors
 constraing->constraining, constraint,
+constrainst->constraint, constraints,
 constrainted->constrained
 constraintes->constraints
 constrainting->constraining

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8024,6 +8024,7 @@ constractor->constructor
 constractors->constructors
 constraing->constraining, constraint,
 constrainst->constraint, constraints,
+constrainsts->constraints
 constrainted->constrained
 constraintes->constraints
 constrainting->constraining


### PR DESCRIPTION
This seems to be a common mistake: https://github.com/search?q=constrainst&type=code