### PR TITLE
Add aspell as a dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
+    "aspell-python-py3",
     "check-manifest",
     "flake8",
     "pytest",


### PR DESCRIPTION
Required to run tests (`make check`) on my Ubuntu 22.04 machine.

The problem is that `aspell-python-py3` depends the `libaspell-dev`/`aspell-en` packages, not sure how portable the module is:
https://github.com/codespell-project/codespell/blob/b2866507b99bc802ec9bec9cb4fdc0708736c78f/.github/workflows/codespell-private.yml#L31-L38