### PR TITLE
Remove unused attribute Misspelling.fixword

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -540,7 +540,6 @@ def ask_for_word_fix(line, wrongword, misspelling, interactivity):
 
         if r == 'N':
             misspelling.fix = False
-            misspelling.fixword = ''
 
     elif (interactivity & 2) and not misspelling.reason:
         # if it is not disabled, i.e. it just has more than one possible fix,


### PR DESCRIPTION
Unused since 1f6deb0da37f282bec67ca4eec214bf48e0209dd.

Discovered using mypy https://mypy.readthedocs.io/