### PR TITLE
Do not use len(SEQUENCE) to determine if a sequence is empty

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -782,7 +782,7 @@ def main(*args):
     options, parser, used_cfg_files = parse_options(args)
 
     # Report used config files
-    if len(used_cfg_files) > 0:
+    if used_cfg_files:
         print('Used config files:')
     for ifile, cfg_file in enumerate(used_cfg_files, start=1):
         print('    %i: %s' % (ifile, cfg_file))


### PR DESCRIPTION
From DeepSource.io:
[Built-in function `len` used as condition PYL-C1802](https://deepsource.io/directory/analyzers/rust/issues/PYL-C1802)

> Using the `len` function to check if a sequence is empty is not idiomatic and can be less performant than checking the truthiness of the object.
> 
> `len` doesn't know the context in which it is called, so if computing the length means traversing the entire sequence, it must; it doesn't know that the result is just being compared to 0. Computing the boolean value can stop after it sees the first element, regardless of how long the sequence actually is.

Addresses https://github.com/codespell-project/codespell/pull/2552#discussion_r1004721881.