### PR TITLE
Document required setuptools version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,10 @@ applied directly, but should instead be manually inspected. E.g.:
 Development Setup
 -----------------
 
+As suggested in the `Python Packaging User Guide`_, ensure ``pip``, ``setuptools``, and ``wheel`` are up to date before installing from source. Specifically you will need recent versions of ``setuptools`` and ``setuptools_scm``::
+
+    pin install --upgrade pip setuptools setuptools_scm wheel
+
 You can install required dependencies for development by running the following within a checkout of the codespell source::
 
        pip install -e ".[dev]"
@@ -177,6 +181,8 @@ You can install required dependencies for development by running the following w
 To run tests against the codebase run::
 
        make check
+
+.. _Python Packaging User Guide: https://packaging.python.org/en/latest/tutorials/installing-packages/#requirements-for-installing-packages
 
 Sending Pull Requests
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ homepage = "https://github.com/codespell-project/codespell"
 repository = "https://github.com/codespell-project/codespell"
 
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
+requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Building from source requires recent versions of some packages:
* `setuptools>=64`
* `setuptools_scm[tomli]>=6.2`

Addresses caveats discussed in #2523.

Fixes #2532
Fixes #2547