### PR TITLE
Add isort to project

### DIFF
--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,0 +1,12 @@
+name: isort
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: isort/isort-action@v1.0.0

--- a/codespell_lib/__init__.py
+++ b/codespell_lib/__init__.py
@@ -1,2 +1,2 @@
-from ._codespell import main, _script_main  # noqa
+from ._codespell import _script_main, main  # noqa
 from ._version import __version__  # noqa

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -3,14 +3,14 @@ import inspect
 import os
 import os.path as op
 import re
-from shutil import copyfile
 import subprocess
 import sys
+from shutil import copyfile
 
 import pytest
 
 import codespell_lib as cs_
-from codespell_lib._codespell import uri_regex_def, EX_USAGE, EX_OK, EX_DATAERR
+from codespell_lib._codespell import EX_DATAERR, EX_OK, EX_USAGE, uri_regex_def
 
 
 def test_constants():

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -1,13 +1,12 @@
 import glob
-import os.path as op
 import os
+import os.path as op
 import re
 import warnings
 
 import pytest
 
-from codespell_lib._codespell import _builtin_dictionaries
-from codespell_lib._codespell import supported_languages
+from codespell_lib._codespell import _builtin_dictionaries, supported_languages
 
 spellers = dict()
 


### PR DESCRIPTION
isort is a utility to sort Python imports alphabetically, and automatically separate into sections and by type. This will provide a consistent import style from contributors. As well, by using a tool, a contributor doesn't need to think about or anticipate the project's preferred style, just let the tool handle it.

Run isort GitHub action as part of CI.