### PR TITLE
Catch all cases of missing pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,12 @@ flake8:
 	flake8
 
 pytest:
-	pytest codespell_lib
+	@if command -v pytest > /dev/null; then \
+		pytest codespell_lib; \
+	else \
+		echo "Test dependencies not present, install using 'pip install -e \".[dev]\"'"; \
+		exit 1; \
+	fi
 
 clean:
 	rm -rf codespell.1


### PR DESCRIPTION
Use `python3`/`pytest-3` instead of `python`/`pytest`.

Fixes #2567.