### PR TITLE
Use major version @v1 of isort GitHub Action

### DIFF
--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: isort/isort-action@v1.0.0
+      - uses: isort/isort-action@v1


### PR DESCRIPTION
Amend 50106dd

The major version tag for this GitHub Action has just been created:
	https://github.com/isort/isort-action/issues/61