### PR TITLE
PEP 517

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ recursive-include codespell_lib *.py
 include codespell_lib/data/dictionary*.txt
 include codespell_lib/data/linux-kernel.exclude
 include COPYING
-include bin/codespell
 exclude *.yml *.yaml
 exclude .coveragerc
 exclude .git-blame-ignore-revs

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ check-dictionary: check-dictionaries
 sort-dictionary: sort-dictionaries
 trim-dictionary: trim-dictionaries
 
-codespell.1: codespell.1.include bin/codespell Makefile
-	PYTHONPATH=. help2man ./bin/codespell --include codespell.1.include --no-info --output codespell.1
+codespell.1: codespell.1.include Makefile
+	PYTHONPATH=. help2man codespell --include codespell.1.include --no-info --output codespell.1
 	sed -i '/\.SS \"Usage/,+2d' codespell.1
 
 check-dictionaries:

--- a/bin/codespell
+++ b/bin/codespell
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-
-import sys
-
-if __name__ == '__main__':
-    import codespell_lib
-    sys.exit(codespell_lib.main(*sys.argv[1:]))


### PR DESCRIPTION
No need to provide `bin/codespell`, it will be generated by this entry point specification:
https://github.com/codespell-project/codespell/blob/1302d7974fb12ae2d723376e81e9b2f1e5c7a5bd/pyproject.toml#L50-L51

For the reviewers: not sure at this point if we need to adapt this:
https://github.com/codespell-project/codespell/blob/1302d7974fb12ae2d723376e81e9b2f1e5c7a5bd/Makefile#L15-L17


Fixes #2592.