### PR TITLE
Move sudo-like command name "doas" to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12156,7 +12156,6 @@ doalog->dialog
 doamin->domain, dopamine,
 doamine->dopamine, domain,
 doamins->domains
-doas->does
 doasn't->doesn't
 doble->double
 dobled->doubled

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -14,6 +14,7 @@ copyable->copiable
 creat->create, crate,
 define'd->defined
 deque->dequeue
+doas->does, do as,
 dof->of, doff,
 dont->don't
 dosclose->disclose


### PR DESCRIPTION
Please consider not correcting "doas", as that is the command name used for the OpenBSD `sudo` replacement.

Source: https://man.openbsd.org/doas