### PR TITLE
Don't correct "crate" since it is used by Rust

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -42,7 +42,6 @@ copping->coping, copying, cropping,
 covert->convert
 crasher->crash
 crashers->crashes
-crate->create
 crated->created
 creche->crèche
 cristal->crystal


### PR DESCRIPTION
Please consider not correcting "crate"->"create", as Rust uses crates.

Source: https://crates.io/