### PR TITLE
Move "upto" to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -36075,7 +36075,6 @@ uptadeable->updatable
 uptdate->update
 uptim->uptime
 uptions->options
-upto->up to
 uptodate->up-to-date
 uptodateness->up-to-dateness
 uptream->upstream

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -71,6 +71,7 @@ udate->update, date,
 udates->updates, dates,
 uint->unit
 uis->is, use,
+upto->up to
 usesd->used, uses,
 wan->want
 warmup->warm up, warm-up,


### PR DESCRIPTION
This moves "upto" to the code dictionary, as it is often used in Common Lisp or Emacs Lisp code with the `loop` macro.

Source: https://lispcookbook.github.io/cl-cookbook/iteration.html