### PR TITLE
Move "acount" to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -665,7 +665,6 @@ acordingly->accordingly
 acordinng->according
 acorss->across
 acorting->according
-acount->account
 acounts->accounts
 acquaintence->acquaintance
 acquaintences->acquaintances

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -1,3 +1,4 @@
+acount->account
 agrv->argv
 alloced->allocated
 amin->main


### PR DESCRIPTION
I have code using `acount` as a variable name. Please consider moving that correction to the code dictionary. Thanks.