### PR TITLE
Prefer "converter" to "convertor"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9066,7 +9066,8 @@ covnerter->converter
 covnerters->converters
 covnertible->convertible
 covnerting->converting
-covnertor->convertor
+covnertor->converter
+covnertors->converters
 covnerts->converts
 covriance->covariance
 covriate->covariate

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -37,6 +37,8 @@ complier->compiler
 compliers->compilers
 confectionary->confectionery
 consequentially->consequently
+convertor->converter
+convertors->converters
 coo->coup
 copping->coping, copying, cropping,
 covert->convert


### PR DESCRIPTION
According to [this page](https://thecontentauthority.com/blog/convertor-vs-converter):

> For some, "convertor" is nothing but a vulgar misspelling, as there is no proper entry defining it as a word in any of the recognized, approved, and reliable thesaurus currently available.

So I think we should definitely prefer correcting to "converter" in the main dictionary. I also suggest adding "convertor->converter" to the rare one. Thanks.