### PR TITLE
Move "spawnve" to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -31456,7 +31456,6 @@ spaw->spawn
 spawed->spawned
 spawing->spawning
 spawining->spawning
-spawnve->spawn
 spaws->spawns
 spcae->space
 spcaed->spaced

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -53,6 +53,7 @@ seeked->sought
 sinc->sync, sink, since,
 sincs->syncs, sinks, since,
 snd->send, and, sound,
+spawnve->spawn
 stdio->studio
 stdios->studios
 stoll->still


### PR DESCRIPTION
On MS-Windows, apparently `spawnve` or `_spawnve` is a commonly used C function, so I suggest we move it to the code dictionary.

Source: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/spawnve?view=msvc-170