### PR TITLE
Move "MSDOS" to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22204,7 +22204,6 @@ msbuld->MSBuild
 msbulds->MSBuild's
 msbulid->MSBuild
 msbulids->MSBuild's
-MSDOS->MS-DOS
 mssing->missing
 msssge->message
 mthod->method

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -34,6 +34,7 @@ jupyter->Jupiter
 keyserver->key server
 lateset->latest
 movei->movie
+MSDOS->MS-DOS
 musl->must
 mut->must, mutt, moot,
 nmake->make


### PR DESCRIPTION
I'm getting a _ton_ of false positives for the MSDOS correction, such as:

```
-#ifdef MSDOS
-#include "msdos.h"
+#ifdef MS-DOS
+#include "ms-dos.h"
```

I suggest moving it to the code dictionary. Thanks.