### PR TITLE
Skip comments and blanks in dictionary files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,12 @@ applied directly, but should instead be manually inspected. E.g.:
 
        clas->class, clash, disabled because of name clash in c++
 
+4. Comments and blanks
+
+   Lines starting with "#" and blank lines are ignored. This is intended for
+   custom dictionaries (specified with the ``-D`` flag), and is not used by the
+   dictionaries distributed with codespell itself.
+
 Development Setup
 -----------------
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -631,6 +631,8 @@ def build_dict(
 ) -> None:
     with open(filename, encoding="utf-8") as f:
         for line in f:
+            if re.search(r"^\s*#|^\s*$", line):
+                continue
             [key, data] = line.split("->")
             # TODO for now, convert both to lower. Someday we can maybe add
             # support for fixing caps.

--- a/example/dict.txt
+++ b/example/dict.txt
@@ -1,3 +1,6 @@
+# this is a commented out line, and should be ignored
+# the next line is blank, and should also be ignored:
+
 tis->this
 opem->open
 buring->burying, burning, burin, during,


### PR DESCRIPTION
This allows using comments and blank lines in dictionary files. My use case is that I have a file like the following:

```
# submit upstream
sceanrios->scenarios
eamcs->emacs
sccopes->scopes

# emacs specific
brunches->branches
ecmacs->emacs
ehsell->eshell
[...]
```