### PR TITLE
Don't print config files by default

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -132,6 +132,7 @@ class QuietLevels:
     DISABLED_FIXES = 4
     NON_AUTOMATIC_FIXES = 8
     FIXES = 16
+    CONFIG_FILES = 32
 
 
 class GlobMatch:
@@ -475,7 +476,7 @@ def parse_options(
         "--quiet-level",
         action="store",
         type=int,
-        default=2,
+        default=34,
         help="bitmask that allows suppressing messages:\n"
         "- 0: print all messages.\n"
         "- 1: disable warnings about wrong encoding.\n"
@@ -483,6 +484,7 @@ def parse_options(
         "- 4: omit warnings about automatic fixes that were disabled in the dictionary.\n"  # noqa: E501
         "- 8: don't print anything for non-automatic fixes.\n"  # noqa: E501
         "- 16: don't print the list of fixed files.\n"
+        "- 32: don't print configuration files.\n"
         "As usual with bitmasks, these levels can be "
         "combined; e.g. use 3 for levels 1+2, 7 for "
         "1+2+4, 23 for 1+2+4+16, etc. "
@@ -994,10 +996,11 @@ def main(*args: str) -> int:
     options, parser, used_cfg_files = parse_options(args)
 
     # Report used config files
-    if len(used_cfg_files) > 0:
-        print("Used config files:")
-    for ifile, cfg_file in enumerate(used_cfg_files, start=1):
-        print("    %i: %s" % (ifile, cfg_file))
+    if not options.quiet_level & QuietLevels.CONFIG_FILES:
+        if len(used_cfg_files) > 0:
+            print("Used config files:")
+        for ifile, cfg_file in enumerate(used_cfg_files, start=1):
+            print("    %i: %s" % (ifile, cfg_file))
 
     if options.regex and options.write_changes:
         print(

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1017,6 +1017,35 @@ def test_uri_regex_def() -> None:
         assert not uri_regex.findall(boilerplate % uri), uri
 
 
+def test_quiet_option_32(
+    tmp_path: Path,
+    tmpdir: pytest.TempPathFactory,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    d = tmp_path / "files"
+    d.mkdir()
+    conf = str(tmp_path / "setup.cfg")
+    with open(conf, "w") as f:
+        # It must contain a "codespell" section.
+        f.write("[codespell]\n")
+    args = ("--config", conf)
+
+    # Config files should NOT be in output.
+    result = cs.main(str(d), *args, "--quiet-level=32", std=True)
+    assert isinstance(result, tuple)
+    code, stdout, _ = result
+    assert code == 0
+    assert "Used config files:" not in stdout
+
+    # Config files SHOULD be in output.
+    result = cs.main(str(d), *args, "--quiet-level=2", std=True)
+    assert isinstance(result, tuple)
+    code, stdout, _ = result
+    assert code == 0
+    assert "Used config files:" in stdout
+    assert "setup.cfg" in stdout
+
+
 @pytest.mark.parametrize("kind", ("toml", "cfg"))
 def test_config_toml(
     tmp_path: Path,


### PR DESCRIPTION
I find the default output to be to verbose when using the `--config` flag. There is no need for me to see that configuration file printed out on every invocation. I suggest hiding that behind a new `--debug` flag.

Thanks.