### PR TITLE
Normalize code block indicators in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,15 +42,15 @@ The ``-w`` flag will actually implement the changes recommended by codespell. No
 
     codespell -I FILE, --ignore-words=FILE
 
-The ``-I`` flag can be used for a list of certain words to allow that are in the codespell dictionaries. The format of the file is one word per line. Invoke using: ``codespell -I path/to/file.txt`` to execute codespell referencing said list of allowed words. **Important note:** The list passed to ``-I`` is case-sensitive based on how it is listed in the codespell dictionaries. ::
+The ``-I`` flag can be used for a list of certain words to allow that are in the codespell dictionaries. The format of the file is one word per line. Invoke using: ``codespell -I path/to/file.txt`` to execute codespell referencing said list of allowed words. **Important note:** The list passed to ``-I`` is case-sensitive based on how it is listed in the codespell dictionaries.::
 
     codespell -L word1,word2,word3,word4
 
-The ``-L`` flag can be used to allow certain words that are comma-separated placed immediately after it.  **Important note:** The list passed to ``-L`` is case-sensitive based on how it is listed in the codespell dictionaries. ::
+The ``-L`` flag can be used to allow certain words that are comma-separated placed immediately after it.  **Important note:** The list passed to ``-L`` is case-sensitive based on how it is listed in the codespell dictionaries.::
 
     codespell -x FILE, --exclude-file=FILE
 
-Ignore whole lines that match those in ``FILE``.  The lines in ``FILE`` should match the to-be-excluded lines exactly.
+Ignore whole lines that match those in ``FILE``.  The lines in ``FILE`` should match the to-be-excluded lines exactly.::
 
     codespell -S, --skip=
 
@@ -66,7 +66,7 @@ Useful commands::
     codespell -d -q 3 --skip="*.po,*.ts,./src/3rdParty,./src/Test"
 
 List all typos found except translation files and some directories.
-Display them without terminal colors and with a quiet level of 3. ::
+Display them without terminal colors and with a quiet level of 3.::
 
     codespell -i 3 -w
 
@@ -214,7 +214,7 @@ To stay current with codespell developments it is possible to build codespell fr
 
 **Important Notes:**
 
-* Sometimes installing via ``pip`` will complain about permissions. If this is the case then run with ::
+* Sometimes installing via ``pip`` will complain about permissions. If this is the case then run with::
 
     pip install --user --upgrade git+https://github.com/codespell-project/codespell.git
 
@@ -224,7 +224,7 @@ To stay current with codespell developments it is possible to build codespell fr
 Updating the dictionaries
 -------------------------
 
-In the scenario where the user prefers not to follow the development version of codespell yet still opts to benefit from the frequently updated dictionary files, we recommend running a simple set of commands to achieve this ::
+In the scenario where the user prefers not to follow the development version of codespell yet still opts to benefit from the frequently updated dictionary files, we recommend running a simple set of commands to achieve this::
 
     wget https://raw.githubusercontent.com/codespell-project/codespell/master/codespell_lib/data/dictionary.txt
     codespell -D dictionary.txt

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,9 @@ Python 3.7 or above.
 Installation
 ------------
 
-You can use ``pip`` to install codespell with e.g.::
+You can use ``pip`` to install codespell with e.g.:
+
+.. code-block:: sh
 
     pip install codespell
 
@@ -36,31 +38,31 @@ For more in depth info please check usage with ``codespell -h``.
 
 Some noteworthy flags:
 
-::
+.. code-block:: sh
 
     codespell -w, --write-changes
 
 The ``-w`` flag will actually implement the changes recommended by codespell. Not running with ``-w`` flag is the same as with doing a dry run. It is recommended to run this with the ``-i`` or ``--interactive`` flag.
 
-::
+.. code-block:: sh
 
     codespell -I FILE, --ignore-words=FILE
 
 The ``-I`` flag can be used for a list of certain words to allow that are in the codespell dictionaries. The format of the file is one word per line. Invoke using: ``codespell -I path/to/file.txt`` to execute codespell referencing said list of allowed words. **Important note:** The list passed to ``-I`` is case-sensitive based on how it is listed in the codespell dictionaries.
 
-::
+.. code-block:: sh
 
     codespell -L word1,word2,word3,word4
 
 The ``-L`` flag can be used to allow certain words that are comma-separated placed immediately after it.  **Important note:** The list passed to ``-L`` is case-sensitive based on how it is listed in the codespell dictionaries.
 
-::
+.. code-block:: sh
 
     codespell -x FILE, --exclude-file=FILE
 
 Ignore whole lines that match those in ``FILE``.  The lines in ``FILE`` should match the to-be-excluded lines exactly.
 
-::
+.. code-block:: sh
 
     codespell -S, --skip=
 
@@ -73,14 +75,14 @@ Comma-separated list of files to skip. It accepts globs as well.  Examples:
 
 Useful commands:
 
-::
+.. code-block:: sh
 
     codespell -d -q 3 --skip="*.po,*.ts,./src/3rdParty,./src/Test"
 
 List all typos found except translation files and some directories.
 Display them without terminal colors and with a quiet level of 3.
 
-::
+.. code-block:: sh
 
     codespell -i 3 -w
 
@@ -92,7 +94,9 @@ after applying them in projects like Linux Kernel, EFL, oFono among others.
 You can provide your own version of the dictionary, but patches for
 new/different entries are very welcome.
 
-Want to know if a word you're proposing exists in codespell already? It is possible to test a word against the current set dictionaries that exist in ``codespell_lib/data/dictionary*.txt`` via::
+Want to know if a word you're proposing exists in codespell already? It is possible to test a word against the current set dictionaries that exist in ``codespell_lib/data/dictionary*.txt`` via:
+
+.. code-block:: sh
 
     echo "word" | codespell -
     echo "1stword,2ndword" | codespell -
@@ -107,7 +111,9 @@ Command line options can also be specified in a config file.
 When running ``codespell``, it will check in the current directory for a file
 named ``setup.cfg`` or ``.codespellrc`` (or a file specified via ``--config``),
 containing an entry named ``[codespell]``. Each command line argument can
-be specified in this file (without the preceding dashes), for example::
+be specified in this file (without the preceding dashes), for example:
+
+.. code-block:: ini
 
     [codespell]
     skip = *.po,*.ts,./src/3rdParty,./src/Test
@@ -117,14 +123,18 @@ be specified in this file (without the preceding dashes), for example::
 Codespell will also check in the current directory for a ``pyproject.toml``
 (or a path can be specified via ``--toml <filename>``) file, and the
 ``[tool.codespell]`` entry will be used as long as the tomli_ package
-is installed, for example::
+is installed, for example:
+
+.. code-block:: toml
 
     [tool.codespell]
     skip = '*.po,*.ts,./src/3rdParty,./src/Test'
     count = ''
     quiet-level = 3
 
-These are both equivalent to running::
+These are both equivalent to running:
+
+.. code-block:: sh
 
     codespell --quiet-level 3 --count --skip "*.po,*.ts,./src/3rdParty,./src/Test"
 
@@ -181,15 +191,21 @@ applied directly, but should instead be manually inspected. E.g.:
 Development Setup
 -----------------
 
-As suggested in the `Python Packaging User Guide`_, ensure ``pip``, ``setuptools``, and ``wheel`` are up to date before installing from source. Specifically you will need recent versions of ``setuptools`` and ``setuptools_scm``::
+As suggested in the `Python Packaging User Guide`_, ensure ``pip``, ``setuptools``, and ``wheel`` are up to date before installing from source. Specifically you will need recent versions of ``setuptools`` and ``setuptools_scm``:
+
+.. code-block:: sh
 
     pip install --upgrade pip setuptools setuptools_scm wheel
 
-You can install required dependencies for development by running the following within a checkout of the codespell source::
+You can install required dependencies for development by running the following within a checkout of the codespell source:
+
+.. code-block:: sh
 
        pip install -e ".[dev]"
 
-To run tests against the codebase run::
+To run tests against the codebase run:
+
+.. code-block:: sh
 
        make check
 
@@ -204,11 +220,15 @@ If you have a suggested typo that you'd like to see merged please follow these s
 
 2. Choose the correct dictionary file to add your typo to. See `codespell --help` for explanations of the different dictionaries.
 
-3. Sort the dictionaries. This is done by invoking (in the top level directory of ``codespell/``)::
+3. Sort the dictionaries. This is done by invoking (in the top level directory of ``codespell/``):
+
+   .. code-block:: sh
 
        make check-dictionaries
 
-   If the make script finds that you need to sort a dictionary, please then run::
+   If the make script finds that you need to sort a dictionary, please then run:
+
+   .. code-block:: sh
 
        make sort-dictionaries
 
@@ -222,15 +242,19 @@ If you have a suggested typo that you'd like to see merged please follow these s
 Updating
 --------
 
-To stay current with codespell developments it is possible to build codespell from GitHub via::
+To stay current with codespell developments it is possible to build codespell from GitHub via:
+
+.. code-block:: sh
 
     pip install --upgrade git+https://github.com/codespell-project/codespell.git
 
 **Important Notes:**
 
-* Sometimes installing via ``pip`` will complain about permissions. If this is the case then run with::
+* Sometimes installing via ``pip`` will complain about permissions. If this is the case then run with:
 
-    pip install --user --upgrade git+https://github.com/codespell-project/codespell.git
+  .. code-block:: sh
+
+      pip install --user --upgrade git+https://github.com/codespell-project/codespell.git
 
 * It has been reported that after installing from ``pip``, codespell can't be located. Please check the $PATH variable to see if ``~/.local/bin`` is present. If it isn't then add it to your path.
 * If you decide to install via ``pip`` then be sure to remove any previously installed versions of codespell (via your platform's preferred app manager).
@@ -238,7 +262,9 @@ To stay current with codespell developments it is possible to build codespell fr
 Updating the dictionaries
 -------------------------
 
-In the scenario where the user prefers not to follow the development version of codespell yet still opts to benefit from the frequently updated dictionary files, we recommend running a simple set of commands to achieve this::
+In the scenario where the user prefers not to follow the development version of codespell yet still opts to benefit from the frequently updated dictionary files, we recommend running a simple set of commands to achieve this:
+
+.. code-block:: sh
 
     wget https://raw.githubusercontent.com/codespell-project/codespell/master/codespell_lib/data/dictionary.txt
     codespell -D dictionary.txt

--- a/README.rst
+++ b/README.rst
@@ -34,23 +34,33 @@ Usage
 
 For more in depth info please check usage with ``codespell -h``.
 
-Some noteworthy flags::
+Some noteworthy flags:
+
+::
 
     codespell -w, --write-changes
 
-The ``-w`` flag will actually implement the changes recommended by codespell. Not running with ``-w`` flag is the same as with doing a dry run. It is recommended to run this with the ``-i`` or ``--interactive`` flag.::
+The ``-w`` flag will actually implement the changes recommended by codespell. Not running with ``-w`` flag is the same as with doing a dry run. It is recommended to run this with the ``-i`` or ``--interactive`` flag.
+
+::
 
     codespell -I FILE, --ignore-words=FILE
 
-The ``-I`` flag can be used for a list of certain words to allow that are in the codespell dictionaries. The format of the file is one word per line. Invoke using: ``codespell -I path/to/file.txt`` to execute codespell referencing said list of allowed words. **Important note:** The list passed to ``-I`` is case-sensitive based on how it is listed in the codespell dictionaries.::
+The ``-I`` flag can be used for a list of certain words to allow that are in the codespell dictionaries. The format of the file is one word per line. Invoke using: ``codespell -I path/to/file.txt`` to execute codespell referencing said list of allowed words. **Important note:** The list passed to ``-I`` is case-sensitive based on how it is listed in the codespell dictionaries.
+
+::
 
     codespell -L word1,word2,word3,word4
 
-The ``-L`` flag can be used to allow certain words that are comma-separated placed immediately after it.  **Important note:** The list passed to ``-L`` is case-sensitive based on how it is listed in the codespell dictionaries.::
+The ``-L`` flag can be used to allow certain words that are comma-separated placed immediately after it.  **Important note:** The list passed to ``-L`` is case-sensitive based on how it is listed in the codespell dictionaries.
+
+::
 
     codespell -x FILE, --exclude-file=FILE
 
-Ignore whole lines that match those in ``FILE``.  The lines in ``FILE`` should match the to-be-excluded lines exactly.::
+Ignore whole lines that match those in ``FILE``.  The lines in ``FILE`` should match the to-be-excluded lines exactly.
+
+::
 
     codespell -S, --skip=
 
@@ -61,12 +71,16 @@ Comma-separated list of files to skip. It accepts globs as well.  Examples:
 * to skip directories, invoke ``codespell --skip="./src/3rd-Party,./src/Test"``
 
 
-Useful commands::
+Useful commands:
+
+::
 
     codespell -d -q 3 --skip="*.po,*.ts,./src/3rdParty,./src/Test"
 
 List all typos found except translation files and some directories.
-Display them without terminal colors and with a quiet level of 3.::
+Display them without terminal colors and with a quiet level of 3.
+
+::
 
     codespell -i 3 -w
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pytest-dependency",
+    "Pygments",
     "tomli"
 ]
 hard-encoding-detection = [


### PR DESCRIPTION
- Remove space before the two colons, since most instances of the syntax used this format
- Add missing `::` before the code block for the `-S`/`--skip` option
