### PR TITLE
Remove setup.py

### DIFF
--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python --version  # just to check
           pip install -U pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
-          pip install --upgrade chardet "setuptools!=47.2.0" docutils setuptools_scm[toml]
+          pip install --upgrade chardet "setuptools!=47.2.0" docutils setuptools_scm[toml] twine
           pip install aspell-python-py3
           pip install -e ".[dev]" # install the codespell dev packages
       - run: codespell --help

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ SORT_ARGS := -f -b
 
 DICTIONARIES := codespell_lib/data/dictionary*.txt
 
-PHONY := all check check-dictionaries sort-dictionaries trim-dictionaries check-dictionary sort-dictionary trim-dictionary check-manifest check-distutils flake8 pytest pypi clean
+PHONY := all check check-dictionaries sort-dictionaries trim-dictionaries check-dictionary sort-dictionary trim-dictionary check-manifest check-dist flake8 pytest pypi clean
 
 all: check-dictionaries codespell.1
 
-check: check-dictionaries check-manifest check-distutils flake8 pytest
+check: check-dictionaries check-manifest check-dist flake8 pytest
 
 check-dictionary: check-dictionaries
 sort-dictionary: sort-dictionaries
@@ -47,8 +47,11 @@ trim-dictionaries:
 check-manifest:
 	check-manifest --no-build-isolation
 
-check-distutils:
-	python setup.py check --restructuredtext --strict
+check-dist:
+	$(eval TMP := $(shell mktemp -d))
+	python -m build -o $(TMP)
+	twine check --strict $(TMP)/*
+	rm -rf $(TMP)
 
 flake8:
 	flake8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ cache:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python.exe -m pip install -U pip"
   - "pip install codecov chardet setuptools"
   - "pip install -e \".[dev]\"" # install the codespell dev packages
-  - "python setup.py develop"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ types = [
     "mypy",
     "pytest",
     "types-chardet",
-    "types-setuptools",
 ]
 
 [project.scripts]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-#! /usr/bin/env python
-
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup()


### PR DESCRIPTION
With pyproject.toml, setup.py becomes unnecessary. Future versions of setuptools (and Python packaging in general) will deprecate the file.

The command `setup.py check` was replaced by `twine check` which serves a similar role.

setuptools is still a dependency of the build, just doesn't require setup.py.

Fixes #2606