### PR TITLE
Add "token" as alternative for "toke"

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -176,7 +176,7 @@ theses->these, thesis,
 thur->their
 tittle->title
 tittles->title
-toke->took
+toke->token, took,
 tread->thread, treat,
 trough->through
 unknow->unknown


### PR DESCRIPTION
I found "token" as a typo for "toke" in the Emacs codebase. I suggest adding it.