### PR TITLE
Correct "3rt" to "3rd"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2,6 +2,7 @@
 2rd->2nd
 2st->2nd
 3nd->3rd
+3rt->3rd
 3st->3rd
 4rd->4th
 a-diaerers->a-diaereses


### PR DESCRIPTION
Here's a quick one found here: https://github.com/jwiegley/use-package-examples

GitHub code search reveals that the mistake is somewhat common: https://github.com/search?q=3rt