### PR TITLE
README: Document how to use pre-commit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,29 @@ config files.
 
 .. _tomli: https://pypi.org/project/tomli/
 
+`pre-commit <https://pre-commit.com/>`_ hook
+--------------------------------------------
+
+codespell also works with `pre-commit`, using
+
+.. code-block:: yaml
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+    - id: codespell
+    
+If one configures codespell using the `pyproject.toml` file instead use:
+
+.. code-block:: yaml
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+    - id: codespell
+      additional_dependencies:
+        - tomli
+
 Dictionary format
 -----------------
 


### PR DESCRIPTION
I came across codespell recently and decided to try to introduce it to my project (asdf-format/asdf#1267). While doing so I also wanted to setup codespell to work with the pre-commit, as this is used extensively by that project. However, I found that the documentation of how to use the pre-commit hook very lacking (in particular getting the hook to properly work with a `pyproject.toml` configuration). This PR attempts to better document how to set codespell up with pre-commit.