### PR TITLE
Flush stdout when asking word fix

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -693,8 +693,7 @@ def ask_for_word_fix(
         r = ""
         fixword = fix_case(wrongword, misspelling.data)
         while not r:
-            print(f"{line}\t{wrongword} ==> {fixword} (Y/n) ", end="",
-                  flush=True)
+            print(f"{line}\t{wrongword} ==> {fixword} (Y/n) ", end="", flush=True)
             r = sys.stdin.readline().strip().upper()
             if not r:
                 r = "Y"
@@ -716,8 +715,7 @@ def ask_for_word_fix(
             for i, o in enumerate(opt):
                 fixword = fix_case(wrongword, o)
                 print(" %d) %s" % (i, fixword), end="")
-            print(": ", end="")
-            sys.stdout.flush()
+            print(": ", end="", flush=True)
 
             n = sys.stdin.readline().strip()
             if not n:

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -693,8 +693,8 @@ def ask_for_word_fix(
         r = ""
         fixword = fix_case(wrongword, misspelling.data)
         while not r:
-            print(f"{line}\t{wrongword} ==> {fixword} (Y/n) ", end="")
-            sys.stdout.flush()
+            print(f"{line}\t{wrongword} ==> {fixword} (Y/n) ", end="",
+                  flush=True)
             r = sys.stdin.readline().strip().upper()
             if not r:
                 r = "Y"

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -694,6 +694,7 @@ def ask_for_word_fix(
         fixword = fix_case(wrongword, misspelling.data)
         while not r:
             print(f"{line}\t{wrongword} ==> {fixword} (Y/n) ", end="")
+            sys.stdout.flush()
             r = sys.stdin.readline().strip().upper()
             if not r:
                 r = "Y"


### PR DESCRIPTION
In some cases the prompt for word fix does not appears (e.g. when ran in `tox >= 4`). This PR solves this issue.