### PR TITLE
Add spelling fixes for derivative

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -56,7 +56,9 @@ degrates->degrades
 dependant->dependent
 derails->details
 dirivative->derivative
+dirivatives->derivatives
 dirivitive->derivative
+dirivitives->derivatives
 discontentment->discontent
 discreet->discrete
 discus->discuss

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -55,6 +55,8 @@ degrate->degrade
 degrates->degrades
 dependant->dependent
 derails->details
+dirivative->derivative
+dirivitive->derivative
 discontentment->discontent
 discreet->discrete
 discus->discuss


### PR DESCRIPTION
Added two rare misspellings of derivative (`dirivative` and `dirivitive`).