### PR TITLE
 Most of `MANIFEST.in` is obsolete, get rid of it

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,12 +1,7 @@
-include codespell_lib/__init__.py
-recursive-include codespell_lib *.py
-include codespell_lib/data/dictionary*.txt
-include codespell_lib/data/linux-kernel.exclude
-include COPYING
 exclude *.yml *.yaml
 exclude .coveragerc
 exclude .git-blame-ignore-revs
-exclude example example/* snap snap/* tools tools/*
+exclude example example/* snap snap/*
 exclude Makefile
 exclude codespell.1.include
 exclude pyproject-codespell.precommit-toml

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ SORT_ARGS := -f -b
 
 DICTIONARIES := codespell_lib/data/dictionary*.txt
 
-PHONY := all check check-dictionaries sort-dictionaries trim-dictionaries check-dictionary sort-dictionary trim-dictionary check-manifest check-dist flake8 pytest pypi clean
+PHONY := all check check-dictionaries sort-dictionaries trim-dictionaries check-dictionary sort-dictionary trim-dictionary check-dist flake8 pytest pypi clean
 
 all: check-dictionaries codespell.1
 
-check: check-dictionaries check-manifest check-dist flake8 pytest
+check: check-dictionaries check-dist flake8 pytest
 
 check-dictionary: check-dictionaries
 sort-dictionary: sort-dictionaries
@@ -43,9 +43,6 @@ trim-dictionaries:
 	@for dictionary in ${DICTIONARIES}; do \
 		sed -E -i.bak -e 's/^[[:space:]]+//; s/[[:space:]]+$$//; /^$$/d' $$dictionary && rm $$dictionary.bak; \
 	done
-
-check-manifest:
-	check-manifest --no-build-isolation
 
 check-dist:
 	$(eval TMP := $(shell mktemp -d))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
+    "build",
     "flake8",
     "flake8-pyproject",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "check-manifest",
     "flake8",
     "flake8-pyproject",
     "pytest",
@@ -90,9 +89,6 @@ expand-star-imports = true
 [tool.bandit]
 skip = "B101,B404,B603"
 recursive = true
-
-[tool.check-manifest]
-ignore = ["codespell_lib/_version.py"]
 
 # TODO: reintegrate codespell configuration after updating test cases
 #[tool.codespell]


### PR DESCRIPTION
`MANIFEST.in` is useful to **exclude** files, but not to **include** files any more according to [pypa /setuptools_scm](https://github.com/pypa/setuptools_scm):
> Additionally `setuptools_scm` provides setuptools with a list of files that are managed by the SCM (i.e. it automatically adds all of the SCM-managed files to the sdist). Unwanted files must be excluded by discarding them via `MANIFEST.in`.

As far as I can see, `check-manifest` is not `setuptools_scm`-aware and obsolete, it insists files such as `COPYING` are added to `MANIFEST.in`:
```
$ check-manifest --no-build-isolation
lists of files in version control and sdist do not match!
missing from VCS:
  codespell_lib/_version.py
missing from sdist:
  COPYING
suggested MANIFEST.in rules:
  include COPYING
$ 
```

Finally, add `build` to the dev dependencies to fix issue caused by #2626, which added `python -m build` without adding build as dependency to `pyproject.toml`.

Re-opens #2620 after changing branch name.