### PR TITLE
Harden GitHub CI configuration

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,10 +3,13 @@ name: black
 on:
   - push
   - pull_request
+permissions: {}
 
 jobs:
   black:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: psf/black@stable

--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -7,6 +7,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
 on: [push, pull_request]
+permissions: {}
 jobs:
   test:
     env:
@@ -25,6 +26,8 @@ jobs:
     name: Python ${{ matrix.python-version }} test
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@v4
         with:
@@ -53,6 +56,8 @@ jobs:
         with:
           python-version: 3.x
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Install general dependencies
         run: pip install -U pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
       - name: Install codespell dependencies
@@ -68,6 +73,8 @@ jobs:
         with:
           python-version: 3.x
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Install codespell dependencies
         run: pip install -e ".[dev]"
       - name: Flake8 with annotations

--- a/.github/workflows/codespell-windows.yml
+++ b/.github/workflows/codespell-windows.yml
@@ -2,12 +2,15 @@ name: Test Codespell Windows
 on:
   - push
   - pull_request
+permissions: {}
 jobs:
   test-windows:
     name: Test Windows
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,12 +3,15 @@
 # https://github.com/codespell-project/codespell
 name: codespell
 on: [push, pull_request]
+permissions: {}
 jobs:
   codespell:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -4,9 +4,13 @@ on:
   - push
   - pull_request
 
+permissions: {}
+
 jobs:
   isort:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: isort/isort-action@v1

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -4,11 +4,15 @@ on:
   - push
   - pull_request
 
+permissions: {}
+
 jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup python
         uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
This reduces the attack surface for GitHub actions by restricting the defaults. I'm not sure how practical or important these attacks are currently, but it seems like there's no reason not to do this for the tests, linters and spell checkers that are currently used.

See here for more:
https://docs.github.com/en/actions/security-guides/
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
https://github.com/actions/checkout#checkout-v3