### PR TITLE
Replace #1950: Typos from marvin.cs.uidaho.edu: A

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1854,21 +1854,36 @@ ambulence->ambulance
 ambulences->ambulances
 amdgput->amdgpu
 amealearate->ameliorate
+amealearated->ameliorated
+amealearates->ameliorates
+amealearating->ameliorating
 amealearative->ameliorative
 amealearator->ameliorator
 amealiarate->ameliorate
+amealiarated->ameliorated
+amealiarates->ameliorates
+amealiarating->ameliorating
 amealiarative->ameliorative
 amealiarator->ameliorator
 ameba->amoebae
 amebae->amoebae
 amebas->amoebae
 ameelarate->ameliorate
+ameelarated->ameliorated
+ameelarates->ameliorates
+ameelarating->ameliorating
 ameelarative->ameliorative
 ameelarator->ameliorator
 ameeliarate->ameliorate
+ameeliarated->ameliorated
+ameeliarates->ameliorates
+ameeliarating->ameliorating
 ameeliarative->ameliorative
 ameeliarator->ameliorator
 amelearate->ameliorate
+amelearated->ameliorated
+amelearates->ameliorates
+amelearating->ameliorating
 amelearative->ameliorative
 amelearator->ameliorator
 amendement->amendment
@@ -1876,6 +1891,11 @@ amendmant->amendment
 amened->amended, amend,
 Amercia->America
 amerliorate->ameliorate
+amerliorated->ameliorated
+amerliorates->ameliorates
+amerliorating->ameliorating
+amerliorative->ameliorative
+amerliorator->ameliorator
 amgle->angle
 amgles->angles
 amiguous->ambiguous
@@ -1983,11 +2003,16 @@ analzyes->analyzes
 analzying->analyzing
 ananlog->analog
 anarchim->anarchism
-anarchistm->anarchism
+anarchistm->anarchism, anarchist,
+anarchit->anarchist
+anarchits->anarchists
+anarkist->anarchist
 anarkistic->anarchistic
 anarkists->anarchists
 anarquism->anarchism
 anarquist->anarchist
+anarquistic->anarchistic
+anarquists->anarchists
 anaylse->analyse
 anaylsed->analysed
 anaylser->analyser
@@ -2036,7 +2061,10 @@ androind->android
 androinds->androids
 andthe->and the
 ane->and
+aneel->anneal
+aneeled->annealed
 aneeling->annealing
+aneels->anneals
 anevironment->environment
 anevironments->environments
 angluar->angular
@@ -2138,6 +2166,7 @@ annonomus->anonymous
 annonomusally->anonymously
 annonomusly->anonymously
 annonymous->anonymous
+annonymously->anonymously
 annotaion->annotation
 annotaions->annotations
 annoted->annotated
@@ -2196,6 +2225,7 @@ anounce->announce
 anounced->announced
 anouncement->announcement
 anount->amount
+anoy->annoy
 anoyed->annoyed
 anoying->annoying
 anoymous->anonymous
@@ -2242,8 +2272,8 @@ anthropolgy->anthropology
 antialialised->antialiased
 antialising->antialiasing
 antiapartheid->anti-apartheid
-anticdote->anecdote
-anticdotes->anecdotes
+anticdote->anecdote, antidote,
+anticdotes->anecdotes, antidotes,
 anticpate->anticipate
 antripanewer->entrepreneur
 antripanewers->entrepreneurs
@@ -2257,6 +2287,7 @@ anull->annul
 anulled->annulled
 anulling->annulling
 anulls->annulled
+anuls->annulls
 anumber->a number
 anurism->aneurysm
 anuwhere->anywhere
@@ -3203,6 +3234,9 @@ asscoitaed->associated
 assebly->assembly
 assebmly->assembly
 assemalate->assimilate
+assemalated->assimilated
+assemalates->assimilates
+assemalating->assimilating
 assembe->assemble
 assembed->assembled
 assembeld->assembled
@@ -3224,6 +3258,9 @@ assesments->assessments
 assessmant->assessment
 assessmants->assessments
 assfalt->asphalt
+assfalted->asphalted
+assfalting->asphalting
+assfalts->asphalts
 assgin->assign
 assgined->assigned
 assgining->assigning

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1824,10 +1824,24 @@ amacing->amazing
 amacingly->amazingly
 amalgomated->amalgamated
 amatuer->amateur
+amatur->amateur
 amature->armature, amateur,
+amaturs->amateurs
 amazaing->amazing
+ambadexterous->ambidextrous
+ambadexterouseness->ambidextrousness
+ambadexterously->ambidextrously
+ambadexterousness->ambidextrousness
+ambadextrous->ambidextrous
+ambadextrouseness->ambidextrousness
+ambadextrously->ambidextrously
+ambadextrousness->ambidextrousness
 ambedded->embedded
 ambibuity->ambiguity
+ambidexterous->ambidextrous
+ambidexterouseness->ambidextrousness
+ambidexterously->ambidextrously
+ambidexterousness->ambidextrousness
 ambien->ambient
 ambigious->ambiguous
 ambigous->ambiguous
@@ -1839,6 +1853,22 @@ ambuguity->ambiguity
 ambulence->ambulance
 ambulences->ambulances
 amdgput->amdgpu
+amealearate->ameliorate
+amealearative->ameliorative
+amealearator->ameliorator
+amealiarate->ameliorate
+amealiarative->ameliorative
+amealiarator->ameliorator
+ameba->amoeba
+ameelarate->ameliorate
+ameelarative->ameliorative
+ameelarator->ameliorator
+ameeliarate->ameliorate
+ameeliarative->ameliorative
+ameeliarator->ameliorator
+amelearate->ameliorate
+amelearative->ameliorative
+amelearator->ameliorator
 amendement->amendment
 amendmant->amendment
 amened->amended, amend,
@@ -1874,8 +1904,14 @@ amout->amount
 amoutn->amount
 amoutns->amounts
 amouts->amounts
+ampatheater->amphitheater
+ampatheaters->amphitheaters
 amperstands->ampersands
 amphasis->emphasis
+amphatheater->amphitheater
+amphatheaters->amphitheaters
+ampitheater->amphitheater
+ampitheaters->amphitheaters
 amplifer->amplifier
 amplifyer->amplifier
 amplitud->amplitude
@@ -1926,6 +1962,8 @@ analyer->analyser, analyzer,
 analyers->analysers, analyzers,
 analyes->analyses, analyzes, analyse, analyze,
 analyis->analysis
+analyist->analyst
+analyists->analysts
 analysator->analyser
 analysies->analyses, analysis,
 analysus->analysis
@@ -1944,6 +1982,8 @@ analzying->analyzing
 ananlog->analog
 anarchim->anarchism
 anarchistm->anarchism
+anarkistic->anarchistic
+anarkists->anarchists
 anarquism->anarchism
 anarquist->anarchist
 anaylse->analyse
@@ -1971,6 +2011,7 @@ ancesetors->ancestors
 ancester->ancestor
 ancesteres->ancestors
 ancesters->ancestors
+ancestoral->ancestral
 ancestore->ancestor
 ancestores->ancestors
 ancestory->ancestry
@@ -1993,11 +2034,29 @@ androind->android
 androinds->androids
 andthe->and the
 ane->and
+aneeling->annealing
 anevironment->environment
 anevironments->environments
 angluar->angular
+angshios->anxious
+angshiosly->anxiously
+angshiosness->anxiousness
+angshis->anxious
+angshisly->anxiously
+angshisness->anxiousness
+angshiuos->anxious
+angshiuosly->anxiously
+angshiuosness->anxiousness
+angshus->anxious
+angshusly->anxiously
+angshusness->anxiousness
 anguluar->angular
+angziety->anxiety
 anhoter->another
+anialate->annihilate
+anialated->annihilated
+anialates->annihilates
+anialating->annihilating
 anid->and
 anihilation->annihilation
 animaing->animating
@@ -2016,6 +2075,7 @@ animeted->animated
 animetion->animation
 animetions->animations
 animets->animates
+animonee->anemone
 animore->anymore
 aninate->animate
 anination->animation
@@ -2029,11 +2089,27 @@ anitrez->antirez
 aniversary->anniversary
 aniway->anyway
 aniwhere->anywhere
+anjanew->ingenue
+ankshios->anxious
+ankshiosly->anxiously
+ankshiosness->anxiousness
+ankshis->anxious
+ankshisly->anxiously
+ankshisness->anxiousness
+ankshiuos->anxious
+ankshiuosly->anxiously
+ankshiuosness->anxiousness
+ankshus->anxious
+ankshusly->anxiously
+ankshusness->anxiousness
 anlge->angle
 anly->only, any,
 anlysis->analysis
 anlyzing->analyzing
 anme->name, anime,
+annaverseries->anniversaries
+annaversery->anniversary
+annaverserys->anniversaries
 annay->annoy, any,
 annayed->annoyed
 annaying->annoying
@@ -2056,6 +2132,9 @@ annoncement->announcement
 annoncements->announcements
 annonces->announces
 annoncing->announcing
+annonomus->anonymous
+annonomusally->anonymously
+annonomusly->anonymously
 annonymous->anonymous
 annotaion->annotation
 annotaions->annotations
@@ -2073,6 +2152,8 @@ announcments->announcements
 announed->announced
 announement->announcement
 announements->announcements
+annoyence->annoyance
+annoyences->annoyances
 annoymous->anonymous
 annoyying->annoying
 annualy->annually
@@ -2082,10 +2163,14 @@ anoher->another
 anohter->another
 anologon->analogon
 anomally->anomaly
+anomolee->anomaly
 anomolies->anomalies
 anomolous->anomalous
 anomoly->anomaly
 anonimity->anonymity
+anonimus->anonymous
+anonimusally->anonymously
+anonimusly->anonymously
 anononymous->anonymous
 anonther->another
 anonymouse->anonymous
@@ -2109,11 +2194,25 @@ anounce->announce
 anounced->announced
 anouncement->announcement
 anount->amount
+anoyed->annoyed
 anoying->annoying
 anoymous->anonymous
+anoys->annoys
+anpatheater->amphitheater
+anpatheaters->amphitheaters
+anphatheater->amphitheater
+anphatheaters->amphitheaters
+anphibian->amphibian
+anphibians->amphibians
+anphitheater->amphitheater
+anphitheaters->amphitheaters
+anpitheater->amphitheater
+anpitheaters->amphitheaters
 anroid->android
 ansalisation->nasalisation
 ansalization->nasalization
+ansamble->ensemble
+ansambles->ensembles
 anser->answer
 ansester->ancestor
 ansesters->ancestors
@@ -2141,21 +2240,38 @@ anthropolgy->anthropology
 antialialised->antialiased
 antialising->antialiasing
 antiapartheid->anti-apartheid
+anticdote->anecdote
+anticdotes->anecdotes
 anticpate->anticipate
+antripanewer->entrepreneur
+antripanewers->entrepreneurs
 antry->entry
 antyhing->anything
 anual->annual
 anually->annually
+anuled->annulled
+anuling->annulling
+anull->annul
 anulled->annulled
+anulling->annulling
+anulls->annulled
 anumber->a number
+anurism->aneurysm
 anuwhere->anywhere
 anway->anyway
 anways->anyway
+anwee->ennui
 anwhere->anywhere
 anwser->answer
 anwsered->answered
 anwsering->answering
 anwsers->answers
+anxios->anxious
+anxiosly->anxiously
+anxiosness->anxiousness
+anxiuos->anxious
+anxiuosly->anxiously
+anxiuosness->anxiousness
 anyawy->anyway
 anyhing->anything
 anyhting->anything
@@ -2193,9 +2309,16 @@ apach->apache
 apapted->adapted
 aparant->apparent
 aparantly->apparently
+aparatus->apparatus
+aparatuses->apparatuses
 aparent->apparent
 aparently->apparently
 aparment->apartment
+apartide->apartheid
+apaul->appall
+apauled->appalled
+apauling->appalling
+apauls->appalls
 apdated->updated
 apeal->appeal
 apealed->appealed
@@ -2220,12 +2343,15 @@ aperure->aperture
 aperures->apertures
 apeture->aperture
 apetures->apertures
+apihelion->aphelion
+apihelions->aphelions
 apilogue->epilogue
 aplha->alpha
 aplication->application
 aplications->applications
 aplied->applied
 aplies->applies
+aplikay->appliqué
 aplitude->amplitude, aptitude,
 apllicatin->application
 apllicatins->applications
@@ -2238,14 +2364,19 @@ apllying->applying
 aply->apply
 aplyed->applied
 aplying->applying
+apocraful->apocryphal
 apointed->appointed
 apointing->appointing
 apointment->appointment
 apoints->appoints
 apolegetic->apologetic
 apolegetics->apologetics
+apollstree->upholstery
 apon->upon, apron,
 aportionable->apportionable
+apostrafes->apostrophes
+apostrafies->apostrophes
+apostrafy->apostrophe
 apostrophie->apostrophe
 apostrophies->apostrophes
 appar->appear
@@ -2261,6 +2392,9 @@ appars->appears
 appart->apart
 appartment->apartment
 appartments->apartments
+appathetic->apathetic
+appature->aperture
+appatures->apertures
 appealling->appealing, appalling,
 appearaing->appearing
 appearantly->apparently
@@ -2543,6 +2677,7 @@ apreciating->appreciating
 apreciation->appreciation
 apreciative->appreciative
 aprehensive->apprehensive
+apresheation->appreciation
 apreteate->appreciate
 apreteated->appreciated
 apreteating->appreciating
@@ -2579,6 +2714,7 @@ aprroximates->approximates
 aprroximation->approximation
 aprroximations->approximations
 aprtment->apartment
+apyoon->uppugn
 aqain->again
 aqcuire->acquire
 aqcuired->acquired
@@ -2590,7 +2726,12 @@ aquaintance->acquaintance
 aquainted->acquainted
 aquainting->acquainting
 aquaints->acquaints
+aqueus->aqueous
 aquiantance->acquaintance
+aquiess->acquiesce
+aquiessed->acquiesced
+aquiesses->acquiesces
+aquiessing->acquiescing
 aquire->acquire
 aquired->acquired
 aquires->acquires
@@ -2600,6 +2741,8 @@ aquisitions->acquisitions
 aquit->acquit
 aquitted->acquitted
 aquries->acquires, equerries,
+aracnid->arachnid
+aracnids->arachnids
 arameters->parameters
 aranged->arranged
 arangement->arrangement
@@ -2764,6 +2907,8 @@ arcives->archives
 arciving->archiving
 arcticle->article
 Ardiuno->Arduino
+ardvark->aardvark
+ardvarks->aardvarks
 are'nt->aren't
 aready->already
 areea->area
@@ -2835,11 +2980,19 @@ aritst->artist
 arival->arrival
 arive->arrive
 arlready->already
+armagedon->armageddon
+armagedons->armageddons
 armamant->armament
 armistace->armistice
+armistis->armistice
+armistises->armistices
 armonic->harmonic
+armorment->armament
+armorments->armaments
 arn't->aren't
 arne't->aren't
+aroara->aurora
+aroaras->auroras
 arogant->arrogant
 arogent->arrogant
 aronud->around
@@ -2906,6 +3059,8 @@ arrengements->arrangements
 arrity->arity, parity,
 arriveis->arrives
 arrivial->arrival
+arro->arrow
+arros->arrows
 arround->around
 arrray->array
 arrrays->arrays
@@ -2917,7 +3072,9 @@ arry->array, carry,
 arrya->array
 arryas->arrays
 arrys->arrays
+arsnic->arsenic
 artcile->article
+artic->arctic
 articaft->artifact
 articafts->artifacts
 artical->article
@@ -3019,6 +3176,7 @@ asociated->associated
 asolute->absolute
 asorbed->absorbed
 aspected->expected
+aspestus->asbestos
 asphyxation->asphyxiation
 assasin->assassin
 assasinate->assassinate
@@ -3036,6 +3194,7 @@ asscociated->associated
 asscoitaed->associated
 assebly->assembly
 assebmly->assembly
+assemalate->assimilate
 assembe->assemble
 assembed->assembled
 assembeld->assembled
@@ -3056,6 +3215,7 @@ assesment->assessment
 assesments->assessments
 assessmant->assessment
 assessmants->assessments
+assfalt->asphalt
 assgin->assign
 assgined->assigned
 assgining->assigning
@@ -3114,6 +3274,8 @@ assigntment->assignment
 assihnment->assignment
 assihnments->assignments
 assime->assume
+assimtote->asymptote
+assimtotes->asymptotes
 assined->assigned
 assing->assign
 assinged->assigned
@@ -3145,6 +3307,7 @@ assistent->assistant
 assit->assist
 assitant->assistant
 assition->assertion
+assma->asthma
 assmbler->assembler
 assmeble->assemble
 assmebler->assembler
@@ -3303,6 +3466,8 @@ assymtote->asymptote
 assymtotes->asymptotes
 assymtotic->asymptotic
 assymtotically->asymptotically
+astarisk->asterisk
+astarisks->asterisks
 asterices->asterisks
 asteriks->asterisk, asterisks,
 asteriod->asteroid
@@ -3316,12 +3481,18 @@ asthetically->aesthetically
 asthetics->aesthetics
 astiimate->estimate
 astiimation->estimation
+astrix->asterisk
+astrixes->asterisks
+astrixs->asterisks
+astroid->asteroid
 asume->assume
 asumed->assumed
 asumes->assumes
 asuming->assuming
 asumption->assumption
+asumtotic->asymptotic
 asure->assure
+aswage->assuage
 aswell->as well
 asychronize->asynchronize
 asychronized->asynchronized
@@ -3381,6 +3552,8 @@ atended->attended
 atendee->attendee
 atends->attends
 atention->attention
+aternies->attorneys
+aterny->attorney
 atheistical->atheistic
 athenean->Athenian
 atheneans->Athenians
@@ -3488,6 +3661,7 @@ attitide->attitude
 attmept->attempt
 attmpt->attempt
 attnetion->attention
+attornies->attorneys
 attosencond->attosecond
 attosenconds->attoseconds
 attrbiute->attribute
@@ -3599,6 +3773,10 @@ auot->auto
 auotmatic->automatic
 auromated->automated
 aussian->Gaussian, Russian, Austrian,
+austair->austere
+austeer->austere
+austensible->ostensible
+austensibly->ostensibly
 austrailia->Australia
 austrailian->Australian
 Australien->Australian
@@ -3967,6 +4145,8 @@ autosae->autosave
 autosavegs->autosaves
 autosaveperodical->autosaveperiodical
 autosence->autosense
+autotorium->auditorium
+autotoriums->auditoriums
 autum->autumn
 auxialiary->auxiliary
 auxilaries->auxiliaries
@@ -3982,6 +4162,8 @@ auxilliaries->auxiliaries
 auxilliary->auxiliary
 auxiluary->auxiliary
 auxliliary->auxiliary
+avacado->avocado
+avacados->avocados
 avaiable->available
 avaialable->available
 avaialbale->available
@@ -4133,6 +4315,9 @@ aysnc->async
 aything->anything
 ayway->anyway, away,
 ayways->always
+azma->asthma
+azmith->azimuth
+azmiths->azimuths
 baase->base, abase,
 bable->babel, table, bible,
 bacause->because

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -326,6 +326,7 @@ accepeted->accepted
 acceppt->accept
 acceptence->acceptance
 acceptible->acceptable
+acceptibly->acceptably
 acceptted->accepted
 acces->access
 accesed->accessed
@@ -358,6 +359,7 @@ accessiiblity->accessibility
 accessile->accessible
 accessintg->accessing
 accessisble->accessible
+accessment->assessment
 accessoire->accessory
 accessoires->accessories, accessorise,
 accessoirez->accessorize, accessories,
@@ -517,6 +519,7 @@ accss->access
 accssible->accessible
 accssor->accessor
 acctual->actual
+accually->actually
 accuarcy->accuracy
 accuarte->accurate
 accuartely->accurately
@@ -579,6 +582,7 @@ acessible->accessible
 acessing->accessing
 acessor->accessor
 acessors->accessors, accessor,
+acheeve->achieve
 acheive->achieve
 acheived->achieved
 acheivement->achievement
@@ -667,6 +671,8 @@ acomplishments->accomplishments
 acontiguous->a contiguous
 acoording->according
 acoordingly->accordingly
+acoostic->acoustic
+acordian->accordion
 acording->according
 acordingly->accordingly
 acordinng->according
@@ -676,9 +682,11 @@ acount->account
 acounts->accounts
 acquaintence->acquaintance
 acquaintences->acquaintances
+acqueus->aqueous
 acquiantence->acquaintance
 acquiantences->acquaintances
 acquiesence->acquiescence
+acquiess->acquiesce
 acquisiton->acquisition
 acquisitons->acquisitions
 acquited->acquitted
@@ -693,8 +701,10 @@ acqusitions->acquisitions
 acrage->acreage
 acroos->across
 acrosss->across
+acrost->across
 acrue->accrue
 acrued->accrued
+acryllic->acrylic
 acses->cases, access,
 acssume->assume
 acssumed->assumed
@@ -703,6 +713,7 @@ actally->actually
 actaly->actually
 actaul->actual
 actaully->actually
+acter->actor
 actial->actual
 actially->actually
 actialy->actually
@@ -785,6 +796,7 @@ acustommed->accustomed
 acutal->actual
 acutally->actually
 acutual->actual
+adament->adamant
 adapated->adapted
 adapater->adapter
 adapaters->adapters
@@ -804,6 +816,7 @@ adaptibe->adaptive
 adaptove->adaptive, adoptive,
 adaquate->adequate
 adaquately->adequately
+adaquit->adequate
 adatper->adapter
 adatpers->adapters
 adavance->advance
@@ -922,9 +935,11 @@ adevnturer->adventurer
 adevnturers->adventurers
 adevntures->adventures
 adevnturing->adventuring
+adew->adieu
 adge->edge, badge, adage,
 adges->edges, badges, adages,
 adhearing->adhering
+adheasive->adhesive
 adherance->adherence
 adiacent->adjacent
 adiditon->addition
@@ -940,16 +955,20 @@ adivsories->advisories
 adivsoriy->advisory, advisories,
 adivsoriyes->advisories
 adivsory->advisory
+adjacancy->adjacency
 adjacentcy->adjacency, adjacence,
 adjacentsy->adjacency
 adjactend->adjacent
 adjancent->adjacent
+adjasant->adjacent
 adjascent->adjacent
 adjasence->adjacence
 adjasencies->adjacencies
 adjasensy->adjacency
 adjasent->adjacent
 adjast->adjust
+adjatate->agitate
+adjative->adjective
 adjcence->adjacence
 adjcencies->adjacencies
 adjcent->adjacent
@@ -1041,6 +1060,7 @@ advaned->advanced
 advantagous->advantageous
 advanved->advanced
 adventages->advantages
+adventagous->advantageous
 adventrous->adventurous
 adverised->advertised
 advertice->advertise
@@ -1080,6 +1100,7 @@ afetr->after
 affact->affect, effect,
 affecfted->affected
 affekt->affect, effect,
+afficianado->aficionado
 afficianados->aficionados
 afficionado->aficionado
 afficionados->aficionados
@@ -1128,6 +1149,7 @@ agant->agent
 agants->agents, against,
 aggaravates->aggravates
 aggegate->aggregate
+aggenst->against
 aggessive->aggressive
 aggessively->aggressively
 agggregate->aggregate
@@ -1152,6 +1174,7 @@ aggresive->aggressive
 aggresively->aggressively
 aggrevate->aggravate
 aggrgate->aggregate
+aggrivate->aggravate
 agian->again
 agianst->against
 agin->again
@@ -1161,6 +1184,7 @@ aglorithm->algorithm
 aglorithms->algorithms
 agorithm->algorithm
 agrain->again
+agrandize->aggrandize
 agravate->aggravate
 agre->agree
 agred->agreed
@@ -1200,6 +1224,7 @@ ahere->here, adhere,
 ahev->have
 ahlpa->alpha
 ahlpas->alphas
+ahmond->almond
 ahppen->happen
 ahve->have
 aicraft->aircraft
@@ -1823,6 +1848,7 @@ alyways->always
 amacing->amazing
 amacingly->amazingly
 amalgomated->amalgamated
+amalgum->amalgam
 amatuer->amateur
 amatur->amateur
 amature->armature, amateur,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1859,7 +1859,9 @@ amealearator->ameliorator
 amealiarate->ameliorate
 amealiarative->ameliorative
 amealiarator->ameliorator
-ameba->amoeba
+ameba->amoebae
+amebae->amoebae
+amebas->amoebae
 ameelarate->ameliorate
 ameelarative->ameliorative
 ameelarator->ameliorator
@@ -2352,6 +2354,7 @@ aplications->applications
 aplied->applied
 aplies->applies
 aplikay->appliqué
+aplikays->appliqués
 aplitude->amplitude, aptitude,
 apllicatin->application
 apllicatins->applications
@@ -2485,6 +2488,8 @@ applide->applied
 applie->apply, applied,
 applikation->application
 applikations->applications
+applikay->appliqué
+applikays->appliqués
 appling->applying, appalling,
 appllied->applied
 applly->apply
@@ -2714,7 +2719,10 @@ aprroximates->approximates
 aprroximation->approximation
 aprroximations->approximations
 aprtment->apartment
-apyoon->uppugn
+apyoon->oppugn
+apyooned->oppugned
+apyooning->oppugning
+apyoons->oppugns
 aqain->again
 aqcuire->acquire
 aqcuired->acquired
@@ -3469,6 +3477,7 @@ assymtotically->asymptotically
 astarisk->asterisk
 astarisks->asterisks
 asterices->asterisks
+asterik->asterisk
 asteriks->asterisk, asterisks,
 asteriod->asteroid
 astethic->aesthetic

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -360,6 +360,7 @@ accessile->accessible
 accessintg->accessing
 accessisble->accessible
 accessment->assessment
+accessments->assessments
 accessoire->accessory
 accessoires->accessories, accessorise,
 accessoirez->accessorize, accessories,
@@ -583,6 +584,11 @@ acessing->accessing
 acessor->accessor
 acessors->accessors, accessor,
 acheeve->achieve
+acheeved->achieved
+acheevement->achievement
+acheevements->achievements
+acheeves->achieves
+acheeving->achieving
 acheive->achieve
 acheived->achieved
 acheivement->achievement
@@ -673,9 +679,12 @@ acoording->according
 acoordingly->accordingly
 acoostic->acoustic
 acordian->accordion
+acordians->accordions
 acording->according
 acordingly->accordingly
 acordinng->according
+acordion->accordion
+acordions->accordions
 acorss->across
 acorting->according
 acount->account
@@ -687,6 +696,9 @@ acquiantence->acquaintance
 acquiantences->acquaintances
 acquiesence->acquiescence
 acquiess->acquiesce
+acquiessed->acquiesced
+acquiesses->acquiesces
+acquiessing->acquiescing
 acquisiton->acquisition
 acquisitons->acquisitions
 acquited->acquitted
@@ -713,7 +725,6 @@ actally->actually
 actaly->actually
 actaul->actual
 actaully->actually
-acter->actor
 actial->actual
 actially->actually
 actialy->actually
@@ -797,6 +808,7 @@ acutal->actual
 acutally->actually
 acutual->actual
 adament->adamant
+adamently->adamantly
 adapated->adapted
 adapater->adapter
 adapaters->adapters
@@ -817,6 +829,7 @@ adaptove->adaptive, adoptive,
 adaquate->adequate
 adaquately->adequately
 adaquit->adequate
+adaquitly->adequately
 adatper->adapter
 adatpers->adapters
 adavance->advance
@@ -940,6 +953,7 @@ adge->edge, badge, adage,
 adges->edges, badges, adages,
 adhearing->adhering
 adheasive->adhesive
+adheasives->adhesives
 adherance->adherence
 adiacent->adjacent
 adiditon->addition
@@ -961,13 +975,18 @@ adjacentsy->adjacency
 adjactend->adjacent
 adjancent->adjacent
 adjasant->adjacent
+adjasantly->adjacently
 adjascent->adjacent
+adjascently->adjacently
 adjasence->adjacence
 adjasencies->adjacencies
 adjasensy->adjacency
 adjasent->adjacent
 adjast->adjust
 adjatate->agitate
+adjatated->agitated
+adjatates->agitates
+adjatating->agitating
 adjative->adjective
 adjcence->adjacence
 adjcencies->adjacencies
@@ -1061,6 +1080,7 @@ advantagous->advantageous
 advanved->advanced
 adventages->advantages
 adventagous->advantageous
+adventagously->advantageously
 adventrous->adventurous
 adverised->advertised
 advertice->advertise
@@ -1175,6 +1195,9 @@ aggresively->aggressively
 aggrevate->aggravate
 aggrgate->aggregate
 aggrivate->aggravate
+aggrivated->aggravated
+aggrivates->aggravates
+aggrivating->aggravating
 agian->again
 agianst->against
 agin->again
@@ -1185,6 +1208,9 @@ aglorithms->algorithms
 agorithm->algorithm
 agrain->again
 agrandize->aggrandize
+agrandized->aggrandized
+agrandizes->aggrandizes
+agrandizing->aggrandizing
 agravate->aggravate
 agre->agree
 agred->agreed
@@ -1225,6 +1251,7 @@ ahev->have
 ahlpa->alpha
 ahlpas->alphas
 ahmond->almond
+ahmonds->almonds
 ahppen->happen
 ahve->have
 aicraft->aircraft
@@ -1849,7 +1876,9 @@ amacing->amazing
 amacingly->amazingly
 amalgomated->amalgamated
 amalgum->amalgam
+amalgums->amalgams
 amatuer->amateur
+amatuers->amateurs
 amatur->amateur
 amature->armature, amateur,
 amaturs->amateurs

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -11,6 +11,9 @@ analyser->analyzer
 analysers->analyzers
 analysing->analyzing
 apologise->apologize
+apologised->apologized
+apologises->apologizes
+apologising->apologizing
 armour->armor
 artefact->artifact
 artefacts->artifacts

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -1,5 +1,7 @@
 ablet->able, tablet,
 accreting->accrediting
+acter->actor
+acters->actors
 afterwords->afterwards
 amination->animation, lamination,
 aminations->animations, laminations,


### PR DESCRIPTION
This replaces PR #1950. I took care of the comments from the code review, and also added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html