### PR TITLE
Typos from marvin.cs.uidaho.edu: C

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5713,12 +5713,23 @@ calulation->calculation
 calulations->calculations
 caluse->clause, callus, callous,
 Cambrige->Cambridge
+cameleon->chameleon
+cameleons->chameleons
 camelion->chameleon
+camelions->chameleons
 camoflage->camouflage
+camoflaged->camouflaged
+camoflages->camouflages
+camoflaging->camouflaging
 camoflague->camouflage
+camoflagued->camouflaged
+camoflagues->camouflages
+camoflaguing->camouflaging
 campagin->campaign
+campagins->campaigns
 campain->campaign
 campaing->campaign
+campaings->campaigns
 campains->campaigns
 camparing->comparing
 can;t->can't
@@ -6180,8 +6191,8 @@ censible->sensible
 censibly->sensibly
 censur->censor, censure,
 centain->certain
-centenal->sentinel
-centenals->sentinels
+centenal->sentinel, centennial,
+centenals->sentinels, centennials,
 cententenial->centennial
 centerd->centered
 centerfuge->centrifuge
@@ -7314,8 +7325,8 @@ cofrimations->confirmations
 cofrimed->confirmed
 cofriming->confirming
 cofrims->confirms
-cogniscent->cognizant
-cognizent->cognizant
+cogniscent->cognizant, cognisant,
+cognizent->cognizant, cognisant,
 cohabitating->cohabiting
 coherance->coherence
 coherancy->coherency
@@ -10038,7 +10049,7 @@ credists->credits
 creditted->credited
 creedence->credence
 cresent->crescent
-cresh->creche
+cresh->crèche
 cresits->credits
 cretae->create
 cretaed->created

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5450,6 +5450,8 @@ bytetream->bytestream
 bytetreams->bytestreams
 cabint->cabinet
 cabints->cabinets
+cabnet->cabinet
+cabnets->cabinets
 cacahe->cache
 cacahes->caches
 cace->cache
@@ -5459,6 +5461,7 @@ cacheed->cached
 cacheing->caching
 cachline->cacheline
 cachse->cache, caches,
+cachup->catchup
 cacl->calc
 caclate->calculate
 cacluate->calculate
@@ -5479,6 +5482,8 @@ caclulates->calculates
 caclulating->calculating
 caclulation->calculation
 caclulations->calculations
+cacoon->cocoon
+cacoons->cocoons
 caculate->calculate
 caculated->calculated
 caculater->calculator
@@ -5491,6 +5496,15 @@ cacuses->caucuses
 cadidate->candidate
 caefully->carefully
 Caesarian->Caesarean
+caese->cease
+caesed->ceased
+caeseing->ceasing
+caeses->ceases
+caf->calf
+cafay->cafe
+cafays->cafes
+cafine->caffeine
+cafs->calves
 cahacter->character
 cahacters->characters
 cahange->change
@@ -5615,12 +5629,15 @@ calcutate->calculate
 calcutated->calculated
 calcutates->calculates
 calcutating->calculating
+caldesack->cul-de-sac
 caleed->called
 caleee->callee
 calees->callees
 calenday->calendar
 caler->caller
 calescing->coalescing
+calfes->calves
+calfs->calves
 caliased->aliased
 calibraiton->calibration
 calibraitons->calibrations
@@ -5652,8 +5669,11 @@ callibrating->calibrating
 callibration->calibration
 callibrations->calibrations
 callibri->calibri
+calliflower->cauliflower
+calliflowers->cauliflowers
 callig->calling
 callint->calling
+callis->callus
 callled->called
 calllee->callee
 calllers->callers
@@ -5693,6 +5713,7 @@ calulation->calculation
 calulations->calculations
 caluse->clause, callus, callous,
 Cambrige->Cambridge
+camelion->chameleon
 camoflage->camouflage
 camoflague->camouflage
 campagin->campaign
@@ -5701,6 +5722,16 @@ campaing->campaign
 campains->campaigns
 camparing->comparing
 can;t->can't
+canabel->cannibal
+canabels->cannibals
+canabelyse->cannibalise
+canabelysed->cannibalised
+canabelyses->cannibalises
+canabelysing->cannibalising
+canabelyze->cannibalize
+canabelyzed->cannibalized
+canabelyzes->cannibalizes
+canabelyzing->cannibalizing
 canadan->canadian
 canbe->can be
 cancelaltion->cancellation
@@ -5726,6 +5757,8 @@ candinate->candidate
 candinates->candidates
 canditate->candidate
 canditates->candidates
+canew->canoe
+canews->canoes
 cange->change
 canged->changed
 canges->changes
@@ -5734,6 +5767,16 @@ canidate->candidate
 canidates->candidates
 cann't->can't
 cann->can
+cannabile->cannibal
+cannabiles->cannibals
+cannabilyse->cannibalise
+cannabilysed->cannibalised
+cannabilyses->cannibalises
+cannabilysing->cannibalising
+cannabilyze->cannibalize
+cannabilyzed->cannibalized
+cannabilyzes->cannibalizes
+cannabilyzing->cannibalizing
 cannister->canister
 cannisters->canisters
 cannnot->cannot
@@ -5769,7 +5812,10 @@ cantain->contain
 cantained->contained
 cantaining->containing
 cantains->contains
+cantalope->cantaloupe
+cantalopes->cantaloupes
 canvase->canvas
+canye->canaille
 caost->coast
 capabable->capable
 capabicity->capability
@@ -5805,7 +5851,13 @@ capible->capable
 capitolize->capitalize
 cappable->capable
 captable->capable
+capter->captor
+capters->captors
 captial->capital
+captian->captain
+captians->captains
+captin->captain
+captins->captains
 captrure->capture
 captued->captured
 capturd->captured
@@ -5813,6 +5865,8 @@ caputre->capture
 caputred->captured
 caputres->captures
 caputure->capture
+caraboo->caribou
+caraboos->caribous
 carachter->character
 caracter->character
 caractere->character
@@ -5820,8 +5874,11 @@ caracteristic->characteristic
 caracteristics->characteristics
 caracterized->characterized
 caracters->characters
+caraff->carafe
 carbus->cardbus
 carcas->carcass, Caracas,
+carcus->carcass
+carcuses->carcasses
 carefull->careful, carefully,
 carefuly->carefully
 careing->caring
@@ -5829,17 +5886,39 @@ carfull->careful
 cariage->carriage
 caridge->carriage
 cariier->carrier
+carimonial->ceremonial
+carimonies->ceremonies
+carimony->ceremony
+carinomial->ceremonial
+carinomies->ceremonies
+carinomy->ceremony
 carismatic->charismatic
 Carmalite->Carmelite
+carmonial->ceremonial
+carmonies->ceremonies
+carmony->ceremony
 Carnagie->Carnegie
 Carnagie-Mellon->Carnegie-Mellon
+carnavor->carnivore
+carnavores->carnivores
+carnavors->carnivores
 carnege->carnage, Carnegie,
 carnige->carnage, Carnegie,
 Carnigie->Carnegie
 Carnigie-Mellon->Carnegie-Mellon
 carniverous->carnivorous
+carnomial->ceremonial
+carnomies->ceremonies
+carnomy->ceremony
 caronavirus->coronavirus
 caronaviruses->coronaviruses
+carosel->carousel
+caroseles->carousels
+carosels->carousels
+carrage->carriage
+carrages->carriages
+carrear->career
+carrears->careers
 carreer->career
 carreid->carried
 carrers->careers
@@ -5860,10 +5939,18 @@ Carthagian->Carthaginian
 carthesian->cartesian
 carthographer->cartographer
 cartiesian->cartesian
+cartiladge->cartilage
+cartiledge->cartilage
 cartilege->cartilage
 cartilidge->cartilage
+cartladge->cartilage
+cartlage->cartilage
+cartledge->cartilage
+cartlege->cartilage
 cartrige->cartridge
 caryy->carry
+casarole->casserole
+casaroles->casseroles
 cascace->cascade
 case-insensative->case-insensitive
 case-insensetive->case-insensitive
@@ -5908,10 +5995,18 @@ casesentivite->case-sensitive
 casesesitive->case-sensitive
 casette->cassette
 cashe->cache
+casim->chasm
+casims->chasms
 casion->caisson
 caspule->capsule
 caspules->capsules
+cassarole->casserole
+cassaroles->casseroles
 cassawory->cassowary
+cassim->chasm
+cassims->chasms
+cassm->chasm
+cassms->chasms
 cassowarry->cassowary
 casue->cause
 casued->caused
@@ -5920,6 +6015,9 @@ casuing->causing
 casulaties->casualties
 casulaty->casualty
 cataalogue->catalogue
+cataclism->cataclysm
+cataclismic->cataclysmic
+cataclismical->cataclysmic
 catagori->category
 catagorie->category, categories,
 catagories->categories
@@ -5932,6 +6030,8 @@ catapillar->caterpillar
 catapillars->caterpillars
 catapiller->caterpillar
 catapillers->caterpillars
+catastrofies->catastrophes
+catastrofy->catastrophe
 catastronphic->catastrophic
 catastropic->catastrophic
 catastropically->catastrophically
@@ -5990,6 +6090,8 @@ causious->cautious
 cautio->caution
 cavaet->caveat
 cavaets->caveats
+cavren->cavern
+cavrens->caverns
 ccahe->cache
 ccale->scale
 ccertificate->certificate
@@ -6010,6 +6112,11 @@ ccustoms->customs
 cdecompress->decompress
 ceartype->cleartype
 Ceasar->Caesar
+ceasars->Caesars
+ceaser->Caesar
+ceasers->Caesars
+ceasser->Caesar
+ceassers->Caesars
 ceate->create
 ceated->created
 ceates->creates
@@ -6028,6 +6135,11 @@ cehcker->checker
 cehcking->checking
 cehcks->checks
 Celcius->Celsius
+cellabration->celebration
+cellabrations->celebrations
+cellebration->celebration
+cellebrations->celebrations
+celler->cellar
 celles->cells
 cellpading->cellpadding
 cellst->cells
@@ -6044,13 +6156,25 @@ cencretely->concretely
 cencter->center
 cencus->census
 cengter->center
+censability->sensibility
+censable->sensible
+censably->sensibly
 censequence->consequence
+censibility->sensibility
+censible->sensible
+censibly->sensibly
 censur->censor, censure,
 centain->certain
+centenal->sentinel
+centenals->sentinels
 cententenial->centennial
 centerd->centered
+centerfuge->centrifuge
+centerfuges->centrifuges
 centisencond->centisecond
 centisenconds->centiseconds
+centrafuge->centrifuge
+centrafuges->centrifuges
 centrifugeable->centrifugable
 centrigrade->centigrade
 centriod->centroid
@@ -6067,6 +6191,10 @@ cerainty->certainty
 cerate->create
 cerated->created, serrated,
 ceratin->certain, keratin,
+cercomstance->circumstance
+cercomstances->circumstances
+cercumstance->circumstance
+cercumstances->circumstances
 cereates->creates
 cerification->certification, verification,
 cerifications->certifications, verifications,
@@ -6078,7 +6206,18 @@ cerimonial->ceremonial
 cerimonies->ceremonies
 cerimonious->ceremonious
 cerimony->ceremony
+cerinomial->ceremonial
+cerinomies->ceremonies
+cerinomy->ceremony
+cermonial->ceremonial
+cermonies->ceremonies
+cermony->ceremony
+cernomial->ceremonial
+cernomies->ceremonies
+cernomy->ceremony
 ceromony->ceremony
+cerrebral->cerebral
+cerrebrally->cerebrally
 certaily->certainly
 certaincy->certainty
 certainity->certainty
@@ -6189,6 +6328,8 @@ challanges->challenges
 challege->challenge
 chambre->chamber
 chambres->chambers
+champain->Champagne
+champane->Champagne
 Champange->Champagne
 chanage->change
 chanaged->changed
@@ -6199,6 +6340,12 @@ chanceled->canceled
 chanceling->canceling
 chanched->changed
 chancnel->channel, cancel,
+chandaleer->chandelier
+chandaleers->chandeliers
+chandalier->chandelier
+chandaliers->chandeliers
+chandeleer->chandelier
+chandeleers->chandeliers
 chane->change, chain,
 chaned->changed, chained,
 chaneged->changed
@@ -6349,14 +6496,28 @@ chariman->chairman
 charistics->characteristics
 charizma->charisma
 chartroose->chartreuse
+chasim->chasm
+chasims->chasms
 chasnge->change, changes,
 chasr->chaser, chase,
+chassim->chasm
+chassims->chasms
+chassm->chasm
+chassms->chasms
 chassy->chassis
 chatacter->character
 chatacters->characters
 chatch->catch
 chatched->caught, chatted,
+chateao->château
+chateaos->châteaux
+chateo->château
+chateos->châteaux
 chater->chapter
+chatou->château
+chatous->châteaux
+chatow->château
+chatows->châteaux
 chawk->chalk
 chcek->check
 chceked->checked
@@ -6454,6 +6615,8 @@ childs->children, child's,
 chiled->child, chilled,
 chiledren->children
 chilren->children
+chimmenies->chimneys
+chimmeny->chimney
 chineese->Chinese
 chinense->Chinese
 chinesse->Chinese
@@ -6467,7 +6630,44 @@ chipertexts->ciphertexts
 chipet->chipset
 chipslect->chipselect
 chipstes->chipsets
+chisell->chisel
+chiselle->chisel
+chiselles->chisels
+chisil->chisel
+chisiled->chiseled
+chisiles->chisels
+chisiling->chiseling
+chisle->chisel
+chisled->chiseled
+chisles->chisels
+chisling->chiseling
 chiuldren->children
+chizell->chisel
+chizelle->chisel
+chizelled->chiseled
+chizelles->chisels
+chizelling->chiseling
+chizil->chisel
+chiziled->chiseled
+chiziles->chisels
+chiziling->chiseling
+chizle->chisel
+chizled->chiseled
+chizles->chisels
+chizling->chiseling
+chizzell->chisel
+chizzelle->chisel
+chizzelled->chiseled
+chizzelles->chisels
+chizzelling->chiseling
+chizzil->chisel
+chizziled->chiseled
+chizziles->chisels
+chizziling->chiseling
+chizzle->chisel
+chizzled->chiseled
+chizzles->chisels
+chizzling->chiseling
 chked->checked
 chlid->child
 chnage->change
@@ -6483,7 +6683,13 @@ chnged->changed
 chnges->changes
 chnging->changing
 chnnel->channel
+chochka->tchotchke
+chochkas->tchotchkes
 choclate->chocolate
+chocolot->chocolate
+chocolote->chocolate
+chocolotes->chocolates
+chocolots->chocolates
 choicing->choosing
 choise->choice
 choises->choices
@@ -6534,6 +6740,14 @@ cicruit->circuit
 cicruits->circuits
 cicular->circular
 ciculars->circulars
+cigarete->cigarette
+cigarett->cigarette
+cigarret->cigarette
+cigarrete->cigarette
+cigarrett->cigarette
+cigarrette->cigarette
+ciguret->cigarette
+cigurete->cigarette
 cihpher->cipher
 cihphers->ciphers
 cilent->client, silent,
@@ -6546,12 +6760,37 @@ cilindrical->cylindrical
 cilyndre->cylinder
 cilyndres->cylinders
 cilyndrs->cylinders
+cimetric->symmetric
+cimetrical->symmetrical
+cimetricaly->symmetrically
+cimetriclly->symmetrically
+cimetricly->symmetrically
+cimmetric->symmetric
+cimmetrical->symmetrical
+cimmetricaly->symmetrically
+cimmetriclly->symmetrically
+cimmetricly->symmetrically
+cimptom->symptom
+cimptomatic->symptomatic
+cimptomatically->symptomatically
+cimptomaticaly->symptomatically
+cimptomaticlly->symptomatically
+cimptomaticly->symptomatically
+cimptoms->symptoms
+cimptum->symptom
+cimptumatic->symptomatic
+cimptumatically->symptomatically
+cimptumaticaly->symptomatically
+cimptumaticlly->symptomatically
+cimptumaticly->symptomatically
+cimptums->symptoms
 Cincinatti->Cincinnati
 Cincinnatti->Cincinnati
 cinfiguration->configuration
 cinfigurations->configurations
 cintaner->container
 ciontrol->control
+ciotee->coyote
 ciper->cipher
 cipers->ciphers
 cipersuite->ciphersuite
@@ -6571,9 +6810,13 @@ ciphes->ciphers
 ciphr->cipher
 ciphrs->ciphers
 cips->chips
+circit->circuit
+circits->circuits
 circluar->circular
 circluarly->circularly
 circluars->circulars
+circomstance->circumstance
+circomstances->circumstances
 circomvent->circumvent
 circomvented->circumvented
 circomvents->circumvents
@@ -6639,6 +6882,34 @@ ciruits->circuits
 cirumflex->circumflex
 cirumstance->circumstance
 cirumstances->circumstances
+civalasation->civilisation
+civalasations->civilisations
+civalazation->civilization
+civalazations->civilizations
+civalesation->civilisation
+civalesations->civilisations
+civalezation->civilization
+civalezations->civilizations
+civalisation->civilisation
+civalisations->civilisations
+civalization->civilization
+civalizations->civilizations
+civelesation->civilisation
+civelesations->civilisations
+civelezation->civilization
+civelezations->civilizations
+civelisation->civilisation
+civelisations->civilisations
+civelization->civilization
+civelizations->civilizations
+civilasation->civilisation
+civilasations->civilisations
+civilazation->civilization
+civilazations->civilizations
+civilesation->civilisation
+civilesations->civilisations
+civilezation->civilization
+civilezations->civilizations
 civillian->civilian
 civillians->civilians
 cjange->change
@@ -6656,7 +6927,13 @@ claerly->clearly
 claibscale->calibscale
 claime->claim
 claimes->claims
+clairvoiant->clairvoyant
+clairvoiantes->clairvoyants
+clairvoiants->clairvoyants
 clame->claim
+claravoyant->clairvoyant
+claravoyantes->clairvoyants
+claravoyants->clairvoyants
 claread->cleared
 clared->cleared
 clarety->clarity
@@ -6714,6 +6991,9 @@ clearling->clearing
 clearnance->clearance
 clearnances->clearances
 clearouput->clearoutput
+clearstories->clerestories
+clearstory->clerestory
+clearstorys->clerestories
 clearted->cleared
 cleary->clearly
 cleaup->cleanup
@@ -6723,6 +7003,10 @@ cleean->clean
 cleen->clean
 cleened->cleaned
 cleens->cleans
+cleeshay->cliché
+cleeshays->clichés
+cleeshey->cliché
+cleesheys->clichés
 cleff->clef
 cleint's->client's
 cleint->client
@@ -6761,6 +7045,10 @@ clipboads->clipboards
 clipoard->clipboard
 clipoards->clipboards
 clipoing->clipping
+clishay->cliché
+clishays->clichés
+clishey->cliché
+clisheys->clichés
 cliuent->client
 cliuents->clients
 clloud->cloud
@@ -6780,8 +7068,11 @@ cloes->close
 cloesd->closed
 cloesed->closed
 cloesing->closing
+cloisonay->cloisonné
+cloisonays->cloisonnés
 clonez->clones, cloner,
 clonning->cloning
+cloreen->chlorine
 clory->glory
 clos->close
 closeing->closing
@@ -6859,6 +7150,10 @@ coalesc->coalesce
 coalescsing->coalescing
 coalesed->coalesced
 coalesence->coalescence
+coaless->coalesce
+coalessed->coalesced
+coalessense->coalescence
+coalesses->coalesces
 coalessing->coalescing
 coallate->collate
 coallates->collates
@@ -6905,11 +7200,14 @@ coaslescing->coalescing
 cobining->combining
 cobvers->covers
 coccinele->coccinelle
+cockateel->cockatiel
+cockateels->cockatiels
 coctail->cocktail
 cocument->document
 cocumentation->documentation
 cocuments->document
 codde->code, coded, coddle,
+codeen->codeine
 codeing->coding
 codepoitn->codepoint
 codesc->codecs
@@ -6984,7 +7282,9 @@ cofrimations->confirmations
 cofrimed->confirmed
 cofriming->confirming
 cofrims->confirms
+cogniscent->cognizant, cognisant,
 cognizent->cognizant
+cohabitating->cohabiting
 coherance->coherence
 coherancy->coherency
 coherant->coherent
@@ -7010,8 +7310,12 @@ coldplg->coldplug
 colected->collected
 colection->collection
 colections->collections
+coleeg->colleague
+coleeges->colleagues
+coleegs->colleagues
 colelction->collection
 colelctive->collective
+colera->cholera
 colerscheme->colorscheme
 colescing->coalescing
 colision->collision
@@ -7033,6 +7337,8 @@ collaspible->collapsible
 collasping->collapsing
 collationg->collation
 collborative->collaborative
+colleage->colleague
+colleages->colleagues
 collecing->collecting
 collecion->collection
 collecions->collections
@@ -7042,9 +7348,12 @@ collectin->collection
 collecton->collection
 collectons->collections
 colleection->collection
+collegate->collegiate
 collegue->colleague
 collegues->colleagues
 collektion->collection
+collender->colander
+collenders->colanders
 colletion->collection
 collidies->collides
 collisin->collision, collusion,
@@ -7058,6 +7367,7 @@ collistions->collisions
 colllapses->collapses
 collocalized->colocalized
 collonade->colonnade
+collone->cologne
 collonies->colonies
 collony->colony
 collorscheme->colorscheme
@@ -7183,6 +7493,8 @@ coment->comment
 comented->commented
 comenting->commenting
 coments->comments
+comerant->cormorant
+comerants->cormorants
 cometed->commented, competed,
 comfirm->confirm
 comflicting->conflicting
@@ -7413,6 +7725,7 @@ communiation->communication
 communicaion->communication
 communicatie->communication
 communicaton->communication
+communikay->communiqué
 communitcate->communicate
 communitcated->communicated
 communitcates->communicates
@@ -7438,6 +7751,7 @@ comonents->components
 comopnent->component
 comopnents->components
 comor->color
+comotion->commotion
 compability->compatibility
 compabillity->compatibility
 compabitiliby->compatibility
@@ -7569,6 +7883,10 @@ compation->compaction
 compatitbility->compatibility
 compativle->compatible
 compaytibility->compatibility
+compeat->compete
+compeated->competed
+compeates->competes
+compeating->competing
 compeitions->competitions
 compeletely->completely
 compelte->complete
@@ -7670,6 +7988,7 @@ complette->complete
 complettly->completely
 complety->completely
 complext->complexity
+complextion->complexion
 compliace->compliance
 complianse->compliance
 compliation->compilation
@@ -7849,6 +8168,8 @@ concatonates->concatenates
 concatonating->concatenating
 conceed->concede
 conceedd->conceded
+conceet->conceit
+conceeted->conceited
 concensors->consensus
 concensus->consensus
 concentate->concentrate
@@ -7858,12 +8179,20 @@ concentating->concentrating
 concentation->concentration
 concentic->concentric
 concentraze->concentrate
+conceous->conscious
+conceousally->consciously
+conceously->consciously
 concequence->consequence
 concequences->consequences
 concered->concerned
 concerened->concerned
 concering->concerning
 concerntrating->concentrating
+conchance->conscience
+conchances->consciences
+conchus->conscious
+conchusally->consciously
+conchusly->consciously
 concicely->concisely
 concider->consider
 concidered->considered
@@ -7876,11 +8205,15 @@ concious->conscious
 conciously->consciously
 conciousness->consciousness
 concrets->concrete, concerts,
+concured->conquered
 concurence->concurrence
 concurency->concurrency
 concurent->concurrent
 concurently->concurrently
 concurents->concurrents, concurrence,
+concurer->conqueror
+concures->conquers
+concuring->conquering
 concurrect->concurrent
 condamned->condemned
 condem->condemn
@@ -9211,6 +9544,8 @@ coresponds->corresponds
 corfirms->confirms
 coridal->cordial
 corispond->correspond
+cornel->colonel
+cornels->colonels
 cornmitted->committed
 corordinate->coordinate
 corordinates->coordinates
@@ -9484,8 +9819,12 @@ coummunities->communities
 coummunity->community
 coumpound->compound
 coumpounds->compounds
+councel->council
 councellor->councillor, counselor, councilor,
 councellors->councillors, counselors, councilors,
+councels->councils
+counciler->councilor
+councilers->councilors
 cound->could, count, found,
 counded->counted
 counding->counting
@@ -9495,6 +9834,8 @@ counld->could
 counpound->compound
 counpounds->compounds
 counries->countries, counties,
+counsil->counsel
+counsils->counsels
 countain->contain
 countainer->container
 countainers->containers
@@ -9604,12 +9945,15 @@ crahed->crashed
 crahes->crashes
 crahs->crash, crass,
 crahses->crashes
+cramugin->curmudgeon
+cramugins->curmudgeons
 crashaes->crashes
 crasheed->crashed
 crashees->crashes
 crashess->crashes
 crashign->crashing
 crashs->crashes
+cratashous->cretaceous
 cration->creation, ration, nation,
 crationalism->rationalism, nationalism,
 crationalist->rationalist, nationalist,
@@ -9651,6 +9995,7 @@ credists->credits
 creditted->credited
 creedence->credence
 cresent->crescent
+cresh->creche
 cresits->credits
 cretae->create
 cretaed->created
@@ -9701,11 +10046,19 @@ critisizes->criticises, criticizes,
 critisizing->criticising, criticizing,
 critized->criticized
 critizing->criticizing
+critque->critique
+critqued->critiqued
+critquing->critiquing
 croch->crotch
 crockadile->crocodile
 crockodiles->crocodiles
 cronological->chronological
 cronologically->chronologically
+crooz->cruise
+croozed->cruised
+croozer->cruiser
+croozes->cruises
+croozing->cruising
 croppped->cropped
 cros->cross
 cros-site->cross-site
@@ -9728,6 +10081,8 @@ crossute->cross-site
 crowdsigna->crowdsignal
 crowkay->croquet
 crowm->crown
+crowshay->crochet
+crowshays->crochets
 crrespond->correspond
 crsytal->crystal
 crsytalline->crystalline
@@ -9750,6 +10105,11 @@ crusor->cursor
 crutial->crucial
 crutially->crucially
 crutialy->crucially
+cruze->cruise
+cruzed->cruised
+cruzer->cruiser
+cruzes->cruises
+cruzing->cruising
 crypted->encrypted
 cryptocraphic->cryptographic
 cryptograhic->cryptographic
@@ -9777,6 +10137,8 @@ cuase->cause
 cuased->caused
 cuases->causes
 cuasing->causing
+cubburd->cupboard
+cubburds->cupboards
 cuestion->question
 cuestioned->questioned
 cuestions->questions
@@ -9787,6 +10149,8 @@ cummand->command
 cummulated->cumulated
 cummulative->cumulative
 cummunicate->communicate
+cumpus->compass
+cumpuses->compasses
 cumulatative->cumulative
 cumulattive->cumulative
 cuncurency->concurrency
@@ -9794,6 +10158,10 @@ cunted->counted, hunted,
 cunter->counter, hunter,
 cunterpart->counterpart
 cunting->counting, hunting,
+cuple->couple
+cuples->couples
+curage->courage
+curageous->courageous
 curce->curse, curve, course,
 curch->church
 curcuit->circuit
@@ -9811,9 +10179,13 @@ curerntly->currently
 curev->curve
 curevd->curved
 curevs->curves
+curiocity->curiosity
+curiosly->curiously
 curiousities->curiosities
 curiousity's->curiosity's
 curiousity->curiosity
+curnel->colonel
+curnels->colonels
 curnilinear->curvilinear
 currecnies->currencies
 currecny->currency
@@ -9866,9 +10238,16 @@ cursos->cursors, cursor,
 cursot->cursor
 cursro->cursor
 curtesy->courtesy, curtsy,
+curteus->courteous
+curteusly->courteously
+curvasious->curvaceous
 curvatrue->curvature
 curvatrues->curvatures
 curvelinear->curvilinear
+cushin->cushion
+cushins->cushions
+cusine->cuisine
+cusines->cuisines
 cusom->custom
 cusstom->custom
 cusstomer->customer
@@ -9962,6 +10341,13 @@ cylnder->cylinder
 cylnders->cylinders
 cylynders->cylinders
 cymk->CMYK
+cymptum->symptom
+cymptumatic->symptomatic
+cymptumatically->symptomatically
+cymptumaticaly->symptomatically
+cymptumaticlly->symptomatically
+cymptumaticly->symptomatically
+cymptums->symptoms
 cyphersuite->ciphersuite
 cyphersuites->ciphersuites
 cyphertext->ciphertext

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5887,14 +5887,17 @@ cariage->carriage
 caridge->carriage
 cariier->carrier
 carimonial->ceremonial
+carimonially->ceremonially
 carimonies->ceremonies
 carimony->ceremony
 carinomial->ceremonial
+carinomially->ceremonially
 carinomies->ceremonies
 carinomy->ceremony
 carismatic->charismatic
 Carmalite->Carmelite
 carmonial->ceremonial
+carmonially->ceremonially
 carmonies->ceremonies
 carmony->ceremony
 Carnagie->Carnegie
@@ -5908,6 +5911,7 @@ Carnigie->Carnegie
 Carnigie-Mellon->Carnegie-Mellon
 carniverous->carnivorous
 carnomial->ceremonial
+carnomially->ceremonially
 carnomies->ceremonies
 carnomy->ceremony
 caronavirus->coronavirus
@@ -6136,11 +6140,20 @@ cehcker->checker
 cehcking->checking
 cehcks->checks
 Celcius->Celsius
+cellabrate->celebrate
+cellabrated->celebrated
+cellabrates->celebrates
+cellabrating->celebrating
 cellabration->celebration
 cellabrations->celebrations
+cellebrate->celebrate
+cellebrated->celebrated
+cellebrates->celebrates
+cellebrating->celebrating
 cellebration->celebration
 cellebrations->celebrations
 celler->cellar
+cellers->cellars
 celles->cells
 cellpading->cellpadding
 cellst->cells
@@ -6157,6 +6170,7 @@ cencretely->concretely
 cencter->center
 cencus->census
 cengter->center
+censabilities->sensibilities
 censability->sensibility
 censable->sensible
 censably->sensibly
@@ -6194,8 +6208,12 @@ cerated->created, serrated,
 ceratin->certain, keratin,
 cercomstance->circumstance
 cercomstances->circumstances
+cercomstancial->circumstantial
+cercomstantial->circumstantial
 cercumstance->circumstance
 cercumstances->circumstances
+cercumstancial->circumstantial
+cercumstantial->circumstantial
 cereates->creates
 cerification->certification, verification,
 cerifications->certifications, verifications,
@@ -6208,12 +6226,15 @@ cerimonies->ceremonies
 cerimonious->ceremonious
 cerimony->ceremony
 cerinomial->ceremonial
+cerinomially->ceremonially
 cerinomies->ceremonies
 cerinomy->ceremony
 cermonial->ceremonial
+cermonially->ceremonially
 cermonies->ceremonies
 cermony->ceremony
 cernomial->ceremonial
+cernomially->ceremonially
 cernomies->ceremonies
 cernomy->ceremony
 ceromony->ceremony
@@ -6743,13 +6764,20 @@ cicruits->circuits
 cicular->circular
 ciculars->circulars
 cigarete->cigarette
+cigaretes->cigarettes
 cigarett->cigarette
 cigarret->cigarette
 cigarrete->cigarette
+cigarretes->cigarettes
+cigarrets->cigarettes
 cigarrett->cigarette
 cigarrette->cigarette
+cigarrettes->cigarettes
+cigarretts->cigarettes
 ciguret->cigarette
 cigurete->cigarette
+ciguretes->cigarettes
+cigurets->cigarettes
 cihpher->cipher
 cihphers->ciphers
 cilent->client, silent,
@@ -6793,6 +6821,7 @@ cinfigurations->configurations
 cintaner->container
 ciontrol->control
 ciotee->coyote
+ciotees->coyotes
 ciper->cipher
 cipers->ciphers
 cipersuite->ciphersuite
@@ -7285,7 +7314,7 @@ cofrimations->confirmations
 cofrimed->confirmed
 cofriming->confirming
 cofrims->confirms
-cogniscent->cognizant, cognisant,
+cogniscent->cognizant
 cognizent->cognizant
 cohabitating->cohabiting
 coherance->coherence
@@ -7370,6 +7399,7 @@ collistions->collisions
 colllapses->collapses
 collocalized->colocalized
 collocweall->colloquial
+collocweally->colloquially
 collonade->colonnade
 collone->cologne
 collonies->colonies
@@ -7504,6 +7534,7 @@ comfirm->confirm
 comflicting->conflicting
 comformance->conformance
 comfterble->comfortable
+comfterbly->comfortably
 comiled->compiled
 comilers->compilers
 comination->combination
@@ -7567,6 +7598,7 @@ commected->connected
 commecting->connecting
 commectivity->connectivity
 commedian->comedian
+commedians->comedians
 commedic->comedic
 commemerative->commemorative
 commemmorate->commemorate
@@ -7732,6 +7764,7 @@ communicaion->communication
 communicatie->communication
 communicaton->communication
 communikay->communiqué
+communikays->communiqués
 communitcate->communicate
 communitcated->communicated
 communitcates->communicates
@@ -7995,6 +8028,7 @@ complettly->completely
 complety->completely
 complext->complexity
 complextion->complexion
+complextions->complexions
 compliace->compliance
 complianse->compliance
 compliation->compilation
@@ -8211,16 +8245,17 @@ concious->conscious
 conciously->consciously
 conciousness->consciousness
 concrets->concrete, concerts,
-concured->conquered
+concured->concurred, conquered,
 concurence->concurrence
 concurency->concurrency
 concurent->concurrent
 concurently->concurrently
 concurents->concurrents, concurrence,
 concurer->conqueror
-concures->conquers
-concuring->conquering
+concures->concurs, conquers,
+concuring->concurring, conquering,
 concurrect->concurrent
+concurrectly->concurrently
 condamned->condemned
 condem->condemn
 condemmed->condemned
@@ -9825,10 +9860,12 @@ coummunities->communities
 coummunity->community
 coumpound->compound
 coumpounds->compounds
-councel->council
+councel->council, counsel,
+councelled->counselled
+councelling->counselling
 councellor->councillor, counselor, councilor,
 councellors->councillors, counselors, councilors,
-councels->councils
+councels->councils, counsels,
 counciler->councilor
 councilers->councilors
 cound->could, count, found,
@@ -10163,6 +10200,7 @@ cuncurency->concurrency
 cunted->counted, hunted,
 cunter->counter, hunter,
 cunterpart->counterpart
+cunters->counters, hunters,
 cunting->counting, hunting,
 cuple->couple
 cuples->couples

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -6039,6 +6039,7 @@ catastrphic->catastrophic
 catche->catch
 catched->caught
 catchi->catch
+catchip->ketchup
 catchs->catches
 categogical->categorical
 categogically->categorically
@@ -6655,6 +6656,7 @@ chizle->chisel
 chizled->chiseled
 chizles->chisels
 chizling->chiseling
+chizzel->chisel
 chizzell->chisel
 chizzelle->chisel
 chizzelled->chiseled
@@ -6931,6 +6933,7 @@ clairvoiant->clairvoyant
 clairvoiantes->clairvoyants
 clairvoiants->clairvoyants
 clame->claim
+clammer->clamber, clamor,
 claravoyant->clairvoyant
 claravoyantes->clairvoyants
 claravoyants->clairvoyants
@@ -7366,6 +7369,7 @@ collistion->collision
 collistions->collisions
 colllapses->collapses
 collocalized->colocalized
+collocweall->colloquial
 collonade->colonnade
 collone->cologne
 collonies->colonies
@@ -7499,6 +7503,7 @@ cometed->commented, competed,
 comfirm->confirm
 comflicting->conflicting
 comformance->conformance
+comfterble->comfortable
 comiled->compiled
 comilers->compilers
 comination->combination
@@ -7561,6 +7566,7 @@ commect->connect
 commected->connected
 commecting->connecting
 commectivity->connectivity
+commedian->comedian
 commedic->comedic
 commemerative->commemorative
 commemmorate->commemorate

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -60,6 +60,7 @@ characterise->characterize
 characterised->characterized
 characterises->characterizes
 characterising->characterizing
+cognisant->cognizant
 colour->color
 coloured->colored
 colourful->colorful

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -51,6 +51,7 @@ crated->created
 creche->crèche
 cristal->crystal
 crufts->cruft
+curios->curious
 dealign->dealing
 deffer->differ, defer,
 degrate->degrade


### PR DESCRIPTION
This replaces PR https://github.com/codespell-project/codespell/pull/1952. I took care of the comments from the code review, and also added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html