### PR TITLE
Typos from marvin.cs.uidaho.edu: D

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -9984,6 +9984,9 @@ cyrto->crypto
 cywgin->Cygwin
 daa->data
 dabase->database
+dabree->debris
+dabue->debut
+dackery->daiquiri
 daclaration->declaration
 dacquiri->daiquiri
 dadlock->deadlock
@@ -10008,9 +10011,11 @@ damange->damage
 damanged->damaged
 damanges->damages
 damanging->damaging
+damed->damned
 damenor->demeanor
 dameon->daemon, demon, Damien,
 damge->damage
+daming->damning
 dammage->damage
 dammages->damages
 damon->daemon, demon,
@@ -10020,6 +10025,7 @@ dandidates->candidates
 dangereous->dangerous
 daplicating->duplicating
 Dardenelles->Dardanelles
+darma->dharma
 dasboard->dashboard
 dasboards->dashboards
 dasdot->dashdot
@@ -10032,6 +10038,7 @@ dashboars->dashboards
 dashbord->dashboard
 dashbords->dashboards
 dashs->dashes
+daspora->diaspora
 dasy->days, dash, daisy, easy,
 data-strcuture->data-structure
 data-strcutures->data-structures
@@ -10095,6 +10102,7 @@ daty->data, date,
 daugher->daughter
 daugther->daughter
 daugthers->daughters
+daybue->debut
 dbeian->Debian
 DCHP->DHCP
 dcok->dock
@@ -10277,6 +10285,10 @@ decendentant->descendant
 decendentants->descendants
 decendents->descendents, descendants,
 decending->descending
+decern->discern
+decerned->discerned
+decerning->discerning
+decerns->discerns
 deciaml->decimal
 deciamls->decimals
 decices->decides
@@ -10300,6 +10312,8 @@ decieved->deceived
 decieves->deceives
 decieving->deceiving
 decimials->decimals
+deciple->disciple
+deciples->disciples
 decison->decision
 decission->decision
 declar->declare
@@ -10502,6 +10516,10 @@ deeep->deep
 deelte->delete
 deendencies->dependencies
 deendency->dependency
+deepo->depot
+deepos->depots
+deesil->diesel
+deezil->diesel
 defail->detail
 defailt->default
 defalt->default
@@ -10610,6 +10628,7 @@ defind->defined, defund,
 definde->defined, defines, define,
 definded->defined, defunded,
 definding->defining
+defineable->definable
 defineas->defines
 defineed->defined
 definend->defined
@@ -10649,6 +10668,8 @@ defintion->definition
 defintions->definitions
 defintition->definition
 defintivly->definitively
+defishant->deficient
+defishantly->deficiently
 defition->definition
 defitions->definitions
 deflaut->default
@@ -10827,6 +10848,7 @@ deliverate->deliberate
 delivermode->deliverymode
 deliverying->delivering
 deliverys->deliveries, delivers,
+delt->dealt
 delte->delete
 delted->deleted
 deltes->deletes
@@ -10834,6 +10856,8 @@ delting->deleting
 deltion->deletion
 delusionally->delusively
 delvery->delivery
+demagog->demagogue
+demagogs->demagogues
 demaind->demand
 demaned->demand, demeaned,
 demenor->demeanor
@@ -11748,12 +11772,15 @@ dichtomy->dichotomy
 dicionaries->dictionaries
 dicionary->dictionary
 dicipline->discipline
+dicision->decision
+dicisions->decisions
 dicitonaries->dictionaries
 dicitonary->dictionary
 dicline->decline
 diconnected->disconnected
 diconnection->disconnection
 diconnects->disconnects
+dicotomy->dichotomy
 dicover->discover
 dicovered->discovered
 dicovering->discovering
@@ -11954,6 +11981,8 @@ dilligence->diligence
 dilligent->diligent
 dilligently->diligently
 dillimport->dllimport
+dimand->diamond
+dimands->diamonds
 dimansion->dimension
 dimansional->dimensional
 dimansions->dimensions
@@ -11994,15 +12023,21 @@ dimmensioning->dimensioning
 dimmensions->dimensions
 dimnension->dimension
 dimnention->dimension
+dimond->diamond
+dimonds->diamonds
 dimunitive->diminutive
 dinamic->dynamic
 dinamically->dynamically
 dinamicaly->dynamically
 dinamiclly->dynamically
 dinamicly->dynamically
+dingee->dinghy
+dingees->dinghies
+dinghys->dinghies
 dinmaic->dynamic
 dinteractively->interactively
 diong->doing
+dioreha->diarrhea
 diosese->diocese
 diphtong->diphthong
 diphtongs->diphthongs
@@ -12015,6 +12050,7 @@ diplomancy->diplomacy
 dipose->dispose, depose,
 diposed->disposed, deposed,
 diposing->disposing, deposing,
+diptheria->diphtheria
 dipthong->diphthong
 dipthongs->diphthongs
 dircet->direct
@@ -12126,6 +12162,14 @@ disalow->disallow
 disambigouate->disambiguate
 disambiguaiton->disambiguation
 disambiguiation->disambiguation
+disapait->dissipate
+disapaited->dissipated
+disapaiting->dissipating
+disapaits->dissipates
+disapat->dissipate
+disapated->dissipated
+disapating->dissipating
+disapats->dissipates
 disapear->disappear
 disapeard->disappeared
 disapeared->disappeared
@@ -12147,6 +12191,11 @@ disapperars->disappears
 disappered->disappeared
 disappering->disappearing
 disappers->disappears
+disappline->discipline
+disapplined->disciplined
+disapplines->disciplines
+disapplining->disciplining
+disapplins->disciplines
 disapporval->disapproval
 disapporve->disapprove
 disapporved->disapproved
@@ -12942,6 +12991,8 @@ dosn't->doesn't
 dosn;t->doesn't
 dosnt->doesn't
 dosposing->disposing
+dosseay->dossier
+dosseays->dossiers
 dosument->document
 dosuments->documents
 dota->data
@@ -13130,6 +13181,7 @@ droppend->dropped
 droppped->dropped
 dropse->drops
 droput->dropout
+drowt->drought
 druing->during
 druming->drumming
 drummless->drumless
@@ -13148,12 +13200,17 @@ dstinations->destinations
 dthe->the
 dtoring->storing
 dubios->dubious
+duble->double
+dubled->doubled
+dubley->doubly
 dublicade->duplicate
 dublicat->duplicate
 dublicate->duplicate
 dublicated->duplicated
 dublicates->duplicates
 dublication->duplication
+dubling->doubling, Dublin,
+dubly->doubly
 ducment->document
 ducument->document
 dueing->doing, during, dueling,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12308,6 +12308,8 @@ discontinous->discontinuous
 discontinuos->discontinuous
 discontinus->discontinue, discontinuous,
 discoraged->discouraged
+discotek->discotheque
+discoteque->discotheque
 discouranged->discouraged
 discourarged->discouraged
 discourrage->discourage

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10011,11 +10011,11 @@ damange->damage
 damanged->damaged
 damanges->damages
 damanging->damaging
-damed->damned
+damed->damped, damned, gamed, domed,
 damenor->demeanor
 dameon->daemon, demon, Damien,
 damge->damage
-daming->damning
+daming->damning, damping, gaming, doming,
 dammage->damage
 dammages->damages
 damon->daemon, demon,
@@ -10039,6 +10039,7 @@ dashbord->dashboard
 dashbords->dashboards
 dashs->dashes
 daspora->diaspora
+dasporas->diasporas
 dasy->days, dash, daisy, easy,
 data-strcuture->data-structure
 data-strcutures->data-structures
@@ -11769,6 +11770,10 @@ dicationaries->dictionaries
 dicationary->dictionary
 dicergence->divergence
 dichtomy->dichotomy
+dicide->decide
+dicided->decided
+dicides->decides
+diciding->deciding
 dicionaries->dictionaries
 dicionary->dictionary
 dicipline->discipline
@@ -11780,6 +11785,7 @@ dicline->decline
 diconnected->disconnected
 diconnection->disconnection
 diconnects->disconnects
+dicotomies->dichotomies
 dicotomy->dichotomy
 dicover->discover
 dicovered->discovered
@@ -11981,8 +11987,8 @@ dilligence->diligence
 dilligent->diligent
 dilligently->diligently
 dillimport->dllimport
-dimand->diamond
-dimands->diamonds
+dimand->demand, diamond,
+dimands->demands, diamonds,
 dimansion->dimension
 dimansional->dimensional
 dimansions->dimensions
@@ -13184,6 +13190,7 @@ droppped->dropped
 dropse->drops
 droput->dropout
 drowt->drought
+drowts->droughts
 druing->during
 druming->drumming
 drummless->drumless


### PR DESCRIPTION
This replaces PR #1953. I took care of the comments from the code review, and also added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html