### PR TITLE
Typos from marvin.cs.uidaho.edu: E

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14291,9 +14291,7 @@ emplying->employing
 emplyment->employment
 emplyments->employments
 emporer->emperor
-empress->impress
 empressed->impressed
-empresses->impresses
 empressing->impressing
 empressive->impressive
 empressively->impressively

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -14619,7 +14619,10 @@ enrtry->entry
 enrty->entry
 ensconsed->ensconced
 entaglements->entanglements
+entend->intend
 entended->intended
+entending->intending
+entends->intends
 entension->extension
 entensions->extensions
 entent->intent

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13939,6 +13939,10 @@ ecxited->excited
 ecxites->excites
 ecxiting->exciting
 ecxtracted->extracted
+eczecute->execute
+eczecuted->executed
+eczecutes->executes
+eczecuting->executing
 eczecutive->executive
 eczecutives->executives
 EDCDIC->EBCDIC
@@ -14228,7 +14232,8 @@ embeed->embed
 embezelled->embezzled
 emblamatic->emblematic
 embold->embolden
-embrio->embryos
+embrio->embryo
+embrios->embryos
 embrodery->embroidery
 emcas->emacs
 emcompass->encompass
@@ -14273,6 +14278,7 @@ emought->enough
 empass->impasse
 empasses->impasses
 emperial->imperial
+emperially->imperially
 emperical->empirical
 emperically->empirically
 emphaised->emphasised
@@ -14341,6 +14347,7 @@ enble->enable
 enbrace->embrace
 enbraced->embraced
 enbracer->embracer
+enbraces->embraces
 enbracing->embracing
 encapsualtes->encapsulates
 encapsulatzion->encapsulation
@@ -14765,10 +14772,10 @@ environmont->environment
 environnement->environment
 environtment->environment
 envoke->invoke, evoke,
-envoked->invoked
-envoker->invoker
-envokes->invokes
-envoking->invoking
+envoked->invoked, evoked,
+envoker->invoker, evoker,
+envokes->invokes, evokes,
+envoking->invoking, evoking,
 envolutionary->evolutionary
 envolved->involved
 envorce->enforce
@@ -14928,6 +14935,7 @@ escaltion->escalation
 escapeable->escapable
 escapemant->escapement
 escartment->escarpment
+escartments->escarpments
 escased->escaped
 escate->escalate, escape,
 escated->escalated, escaped,
@@ -15014,10 +15022,6 @@ establishs->establishes
 establising->establishing
 establsihed->established
 estbalishment->establishment
-esthetic->aesthetic
-esthetically->aesthetically
-estheticly->aesthetically
-esthetics->aesthetics
 estimage->estimate
 estimages->estimates
 estiomator->estimator
@@ -15029,6 +15033,7 @@ etablish->establish
 etablishd->established
 etablished->established
 etablishing->establishing
+etamologies->etymologies
 etamology->etymology
 etcc->etc
 etcp->etc
@@ -15160,6 +15165,7 @@ everyting->everything
 everytone->everyone
 everywher->everywhere
 evesdrop->eavesdrop
+evesdropped->eavesdropped
 evesdropper->eavesdropper
 evesdropping->eavesdropping
 evesdrops->eavesdrops

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13883,6 +13883,7 @@ eanable->enable
 eanble->enable
 earch->search, each,
 eariler->earlier
+earily->eerily
 earleir->earlier
 earler->earlier
 earliear->earlier
@@ -13891,6 +13892,8 @@ earlist->earliest
 earlyer->earlier
 earnt->earned
 earpeice->earpiece
+eary->eerie
+earyly->eerily
 easely->easily
 easer->easier, eraser,
 easili->easily
@@ -13902,6 +13905,9 @@ easly->easily
 easyer->easier
 eaturn->return, eaten, Saturn,
 eaxct->exact
+eazier->easier
+eaziest->easiest
+eazy->easy
 ebale->enable
 ebaled->enabled
 EBCIDC->EBCDIC
@@ -13933,11 +13939,15 @@ ecxited->excited
 ecxites->excites
 ecxiting->exciting
 ecxtracted->extracted
+eczecutive->executive
+eczecutives->executives
 EDCDIC->EBCDIC
 eddge->edge
 eddges->edges
 edditable->editable
 ede->edge
+edeycat->etiquette
+edeycats->etiquettes
 ediable->editable
 edige->edge
 ediges->edges
@@ -13962,6 +13972,9 @@ edning->ending, edging,
 edxpected->expected
 eearly->early
 eeeprom->EEPROM
+eeger->eager
+eegerly->eagerly
+eejus->aegis
 eescription->description
 eevery->every
 eeverything->everything
@@ -14047,6 +14060,13 @@ einstance->instance
 eisntance->instance
 eiter->either
 eith->with
+elagance->elegant
+elagant->elegant
+elagantly->elegantly
+elamentaries->elementaries
+elamentary->elementary
+elamentries->elementaries
+elamentry->elementary
 elaspe->elapse
 elasped->elapsed
 elaspes->elapses
@@ -14062,6 +14082,7 @@ electical->electrical
 electirc->electric
 electircal->electrical
 electon->election, electron,
+electorial->electoral
 electrial->electrical
 electricly->electrically
 electricty->electricity
@@ -14092,6 +14113,7 @@ elemens->elements
 elemenst->elements
 elementay->elementary
 elemente->element, elements,
+elementries->elementaries
 elementry->elementary
 elemet->element
 elemetal->elemental
@@ -14168,6 +14190,7 @@ emables->enables
 emabling->enabling
 emailling->emailing
 emasc->emacs
+embalance->imbalance
 embaras->embarrass
 embarased->embarrassed
 embarases->embarrasses
@@ -14179,6 +14202,10 @@ embarasses->embarrasses
 embarassing->embarrassing
 embarassingly->embarrassingly
 embarassment->embarrassment
+embaress->embarrass
+embaressed->embarrassed
+embaresses->embarrasses
+embaressing->embarrassing
 embargos->embargoes
 embarras->embarrass
 embarrased->embarrassed
@@ -14201,6 +14228,7 @@ embeed->embed
 embezelled->embezzled
 emblamatic->emblematic
 embold->embolden
+embrio->embryos
 embrodery->embroidery
 emcas->emacs
 emcompass->encompass
@@ -14210,6 +14238,8 @@ emedded->embedded
 emegrency->emergency
 emenet->element
 emenets->elements
+emense->immense
+emensely->immensely
 emiited->emitted
 eminate->emanate
 eminated->emanated
@@ -14240,6 +14270,9 @@ emnity->enmity
 emoty->empty
 emough->enough
 emought->enough
+empass->impasse
+empasses->impasses
+emperial->imperial
 emperical->empirical
 emperically->empirically
 emphaised->emphasised
@@ -14258,6 +14291,12 @@ emplying->employing
 emplyment->employment
 emplyments->employments
 emporer->emperor
+empress->impress
+empressed->impressed
+empresses->impresses
+empressing->impressing
+empressive->impressive
+empressively->impressively
 emprically->empirically
 emprisoned->imprisoned
 emprove->improve
@@ -14301,6 +14340,10 @@ enbales->enables
 enbaling->enabling
 enbedding->embedding
 enble->enable
+enbrace->embrace
+enbraced->embraced
+enbracer->embracer
+enbracing->embracing
 encapsualtes->encapsulates
 encapsulatzion->encapsulation
 encapsultion->encapsulation
@@ -14331,6 +14374,10 @@ encompas->encompass
 encompased->encompassed
 encompases->encompasses
 encompasing->encompassing
+encompus->encompass
+encompused->encompassed
+encompuses->encompasses
+encompusing->encompassing
 enconde->encode
 enconded->encoded
 enconder->encoder
@@ -14407,6 +14454,11 @@ endcoding->encoding
 endcodings->encodings
 endding->ending
 ende->end
+endever->endeavor
+endevered->endeavored
+endeveres->endeavors
+endevering->endeavoring
+endevers->endeavors
 endevors->endeavors
 endevour->endeavour
 endfi->endif
@@ -14429,6 +14481,7 @@ endpont->endpoint
 endponts->endpoints
 endsup->ends up
 enduce->induce
+endur->endure
 eneables->enables
 enebale->enable
 enebaled->enabled
@@ -14518,6 +14571,8 @@ enocdings->encodings
 enogh->enough
 enoght->enough
 enoguh->enough
+enormass->enormous
+enormassly->enormously
 enouch->enough
 enoucnter->encounter
 enoucntered->encountered
@@ -14562,7 +14617,9 @@ entaglements->entanglements
 entended->intended
 entension->extension
 entensions->extensions
+entent->intent
 ententries->entries
+entents->intents
 enterance->entrance
 enteratinment->entertainment
 entereing->entering
@@ -14577,6 +14634,9 @@ entety->entity
 enthaplies->enthalpies
 enthaply->enthalpy
 enthousiasm->enthusiasm
+enthuseastic->enthusiastic
+enthuseastically->enthusiastically
+enthuseasticly->enthusiastically
 enthusiam->enthusiasm
 enthusiatic->enthusiastic
 entierly->entirely
@@ -14610,6 +14670,8 @@ entquiry->enquiry, inquiry,
 entrace->entrance
 entraced->entranced
 entraces->entrances
+entrapeneur->entrepreneur
+entrapeneurs->entrepreneur
 entreis->entries
 entrepeneur->entrepreneur
 entrepeneurs->entrepreneurs
@@ -14623,6 +14685,7 @@ enttry->entry
 entusiastic->enthusiastic
 entusiastically->enthusiastically
 enty->entry, entity,
+enuf->enough
 enulation->emulation
 enumarate->enumerate
 enumarated->enumerated
@@ -14704,6 +14767,10 @@ environmont->environment
 environnement->environment
 environtment->environment
 envoke->invoke, evoke,
+envoked->invoked
+envoker->invoker
+envokes->invokes
+envoking->invoking
 envolutionary->evolutionary
 envolved->involved
 envorce->enforce
@@ -14736,6 +14803,7 @@ epigramic->epigrammatic
 epilgoue->epilogue
 episdoe->episode
 episdoes->episodes
+epitamy->epitome
 eploit->exploit
 eploits->exploits
 epmty->empty
@@ -14861,6 +14929,7 @@ escalting->escalating
 escaltion->escalation
 escapeable->escapable
 escapemant->escapement
+escartment->escarpment
 escased->escaped
 escate->escalate, escape,
 escated->escalated, escaped,
@@ -14947,15 +15016,22 @@ establishs->establishes
 establising->establishing
 establsihed->established
 estbalishment->establishment
+esthetic->aesthetic
+esthetically->aesthetically
+estheticly->aesthetically
+esthetics->aesthetics
 estimage->estimate
 estimages->estimates
 estiomator->estimator
 estiomators->estimators
+estuwarries->estuaries
+estuwarry->estuary
 esy->easy
 etablish->establish
 etablishd->established
 etablished->established
 etablishing->establishing
+etamology->etymology
 etcc->etc
 etcp->etc
 etend->extend, attend,
@@ -15085,12 +15161,20 @@ everytime->every time
 everyting->everything
 everytone->everyone
 everywher->everywhere
+evesdrop->eavesdrop
+evesdropper->eavesdropper
+evesdropping->eavesdropping
+evesdrops->eavesdrops
 evey->every
 eveyone->everyone
 eveyr->every
 evidentally->evidently
 evironment->environment
 evironments->environments
+eviserate->eviscerate
+eviserated->eviscerated
+eviserates->eviscerates
+eviserating->eviscerating
 evition->eviction
 evluate->evaluate
 evluated->evaluated
@@ -15666,17 +15750,27 @@ exhautivity->exhaustivity
 exhcuast->exhaust
 exhcuasted->exhausted
 exhibtion->exhibition
+exhilerate->exhilarate
+exhilerated->exhilarated
+exhilerates->exhilarates
+exhilerating->exhilarating
 exhist->exist
 exhistance->existence
 exhisted->existed
 exhistence->existence
 exhisting->existing
 exhists->exists
+exhorbitent->exorbitant
+exhorbitently->exorbitantly
 exhostive->exhaustive
 exhustiveness->exhaustiveness
 exibition->exhibition
 exibitions->exhibitions
 exicting->exciting
+exilerate->exhilarate
+exilerated->exhilarated
+exilerates->exhilarates
+exilerating->exhilarating
 exinct->extinct
 exipration->expiration
 exipre->expire
@@ -15753,7 +15847,7 @@ exntry->entry
 exolicit->explicit
 exolicitly->explicitly
 exonorate->exonerate
-exort->export
+exort->export, exhort,
 exorted->exported, extorted, exerted,
 exoskelaton->exoskeleton
 expalin->explain
@@ -16608,6 +16702,8 @@ exturdes->extrudes
 exturding->extruding
 exuberent->exuberant
 exucuted->executed
+exurpt->excerpt
+exurpts->excerpts
 eyar->year, eyas,
 eyars->years, eyas,
 eyasr->years, eyas,

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -66,6 +66,8 @@ discontentment->discontent
 discreet->discrete
 discus->discuss
 discuses->discusses
+empress->impress
+empresses->impresses
 fallow->follow
 fallowed->followed
 fallowing->following


### PR DESCRIPTION
This replaces PR #1954. I took care of the comments from the code review, and also added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html