### PR TITLE
Typos from marvin.cs.uidaho.edu: F

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -16088,6 +16088,7 @@ familliar->familiar
 familly->family
 famlilies->families
 famlily->family
+famly->family
 famoust->famous
 fanatism->fanaticism
 fancyness->fanciness
@@ -16096,6 +16097,7 @@ farction->fraction, faction,
 Farenheight->Fahrenheit
 Farenheit->Fahrenheit
 farest->fairest, farthest,
+fariar->farrier
 faries->fairies
 farmasudical->pharmaceutical
 farmework->framework
@@ -16142,6 +16144,7 @@ fautured->featured
 fautures->features
 fauturing->featuring
 favoutrable->favourable
+favritt->favorite
 favuourites->favourites
 faymus->famous
 fcound->found

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -16091,19 +16091,36 @@ famlily->family
 famoust->famous
 fanatism->fanaticism
 fancyness->fanciness
+fane->fan, feign,
 farction->fraction, faction,
 Farenheight->Fahrenheit
 Farenheit->Fahrenheit
 farest->fairest, farthest,
 faries->fairies
+farmasudical->pharmaceutical
 farmework->framework
+farse->farce
+farses->farces
 fasade->facade
 fase->faze, phase, false,
 fased->fazed, phased,
+faseeshus->facetious
+faseeshusly->facetiously
+fasen->fasten
+fasend->fastened
+fasened->fastened
 fases->fazes, phases,
+fashism->fascism
+fashon->fashion
+fashonable->fashionable
+fashoned->fashioned
+fashoning->fashioning
+fashons->fashions
 fasing->fazing, phasing,
 fasion->fashion
 fasle->false
+fasodd->facade
+fasodds->facades
 fassade->facade
 fassinate->fascinate
 fasterner->fastener
@@ -16699,6 +16716,7 @@ foramatting->formatting
 foramt->format
 forat->format
 forbad->forbade
+forbatum->verbatim
 forbbiden->forbidden
 forbiden->forbidden
 forbit->forbid
@@ -16711,6 +16729,7 @@ forcaster->forecaster
 forcasters->forecasters
 forcasting->forecasting
 forcasts->forecasts
+forceably->forcibly
 forcot->forgot
 forece->force
 foreced->forced
@@ -16722,12 +16741,19 @@ forementionned->aforementioned
 forermly->formerly
 foreward->foreword, forward,
 forfiet->forfeit
+forfit->forfeit
+forfited->forfeited
+forfiting->forfeiting
+forfits->forfeits
 forgeround->foreground
 forgoten->forgotten
 forgotton->forgotten
 forground->foreground
 forhead->forehead
 foriegn->foreign
+forin->foreign
+foriner->foreigner
+foriners->foreigners
 forld->fold
 forlder->folder
 forlders->folders
@@ -16735,6 +16761,7 @@ Formalhaut->Fomalhaut
 formallize->formalize
 formallized->formalized
 formaly->formally, formerly,
+forman->foreman
 formate->format
 formated->formatted
 formater->formatter
@@ -16754,6 +16781,7 @@ formattted->formatted
 formattting->formatting
 formelly->formerly
 formely->formerly
+formen->foremen
 formend->formed
 formes->forms, formed,
 formidible->formidable
@@ -16764,6 +16792,8 @@ formua->formula
 formual->formula
 formuale->formulae
 formuals->formulas
+formulaical->formulaic
+formulayic->formulaic
 fornat->format
 fornated->formatted
 fornater->formatter
@@ -16910,6 +16940,7 @@ frequentily->frequently
 frequeny->frequency, frequently, frequent,
 frequncies->frequencies
 frequncy->frequency
+frew-frew->frou-frou
 freze->freeze
 frezes->freezes
 frgament->fragment
@@ -17083,6 +17114,8 @@ fundementals->fundamentals
 funguses->fungi
 funktion->function
 funnnily->funnily
+funrel->funeral
+funrels->funerals
 funtion->function
 funtional->functional
 funtionalities->functionalities
@@ -17146,8 +17179,11 @@ furuther->further
 furutre->future
 furzzer->fuzzer
 fuschia->fuchsia
+fusha->fuchsia
+fushas->fuchsias
 fushed->flushed
 fushing->flushing
+futal->futile
 futer->further, future,
 futher->further
 futherize->further

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -16099,10 +16099,13 @@ Farenheit->Fahrenheit
 farest->fairest, farthest,
 fariar->farrier
 faries->fairies
+farmasudic->pharmaceutic
 farmasudical->pharmaceutical
+farmasudics->pharmaceutics
 farmework->framework
 farse->farce
 farses->farces
+farsical->farcical
 fasade->facade
 fase->faze, phase, false,
 fased->fazed, phased,
@@ -16111,8 +16114,12 @@ faseeshusly->facetiously
 fasen->fasten
 fasend->fastened
 fasened->fastened
+fasening->fastening
+fasens->fastens, fasels,
 fases->fazes, phases,
 fashism->fascism
+fashist->fascist
+fashists->fascists
 fashon->fashion
 fashonable->fashionable
 fashoned->fashioned
@@ -16764,7 +16771,6 @@ Formalhaut->Fomalhaut
 formallize->formalize
 formallized->formalized
 formaly->formally, formerly,
-forman->foreman
 formate->format
 formated->formatted
 formater->formatter

--- a/codespell_lib/data/dictionary_names.txt
+++ b/codespell_lib/data/dictionary_names.txt
@@ -6,6 +6,7 @@ bae->base
 bridget->bridged, bridge,
 chang->change
 fike->file
+forman->foreman
 liszt->list
 que->queue
 sargent->sergeant, argent,


### PR DESCRIPTION
This replaces PR #1955. I took care of the comments from the code review, and also added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html