### PR TITLE
Typos from marvin.cs.uidaho.edu: G

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -17976,6 +17976,10 @@ fysisist->physicist
 fysisit->physicist
 gabage->garbage
 gadged->gadget, gauged,
+gage->gauge
+gages->gauges
+gagit->gadget
+gagits->gadgets
 galatic->galactic
 Galations->Galatians
 gallaries->galleries
@@ -18007,11 +18011,14 @@ gard->guard
 gardai->gardaí
 garentee->guarantee
 gargage->garbage, garage,
+garilla->guerrilla
+garillas->guerrillas
 garnison->garrison
 garuantee->guarantee
 garuanteed->guaranteed
 garuantees->guarantees
 garuantied->guaranteed
+gastly->ghastly
 gatable->gateable
 gateing->gating
 gatherig->gathering
@@ -18034,6 +18041,8 @@ gaus'->Gauss'
 gaus's->Gauss'
 gaus->Gauss, gauze,
 gausian->gaussian
+gayity->gaiety
+gaysha->geisha
 geeneric->generic
 geenrate->generate
 geenrated->generated
@@ -18302,6 +18311,8 @@ goruped->grouped
 goruping->grouping
 gorups->groups
 gost->ghost
+gotee->goatee
+gotees->goatees
 Gothenberg->Gothenburg
 Gottleib->Gottlieb
 goup->group
@@ -18318,6 +18329,8 @@ govermental->governmental
 govermnment->government
 governer->governor
 governmnet->government
+govoner->governor
+govoners->governors
 govorment->government
 govormental->governmental
 govornment->government
@@ -18338,6 +18351,8 @@ grahics->graphics
 grahpic->graphic
 grahpical->graphical
 grahpics->graphics
+graineries->granaries
+grainery->granary
 gramar->grammar
 gramatically->grammatically
 grammartical->grammatical
@@ -18345,7 +18360,21 @@ grammaticaly->grammatically
 grammer->grammar
 grammers->grammars
 granchildren->grandchildren
+grandeeos->grandiose
+grandise->aggrandise
+grandised->aggrandised
+grandisement->aggrandisement
+grandiser->aggrandiser
+grandises->aggrandises
+grandising->aggrandising
+grandize->aggrandize
+grandized->aggrandized
+grandizement->aggrandizement
+grandizer->aggrandizer
+grandizes->aggrandizes
+grandizing->aggrandizing
 granilarity->granularity
+granjure->grandeur
 granuality->granularity
 granualtiry->granularity
 granularty->granularity
@@ -18378,6 +18407,10 @@ grigorian->Gregorian
 grobal->global
 grobally->globally
 grometry->geometry
+groosome->gruesome
+groosomely->gruesomely
+groosum->gruesome
+groosumly->gruesome
 grooup->group
 groouped->grouped
 groouping->grouping
@@ -18386,6 +18419,8 @@ grop->group, drop,
 gropu->group
 gropuing->grouping
 gropus->groups, gropes,
+groshuries->groceries
+groshury->grocery
 groth->growth
 groubpy->groupby
 groupd->grouped
@@ -18393,6 +18428,8 @@ groupe->grouped, group,
 groupes->groups, grouped,
 groupping->grouping
 groupt->grouped
+growtesk->grotesque
+growteskly->grotesquely
 grranted->granted
 gruop->group
 gruopd->grouped
@@ -18542,6 +18579,7 @@ guass->Gauss
 guassian->Gaussian
 Guatamala->Guatemala
 Guatamalan->Guatemalan
+gubnatorial->gubernatorial
 gud->good
 gude->guide, good,
 guerrila->guerrilla
@@ -18564,7 +18602,14 @@ gurantees->guarantees
 gurrantee->guarantee
 guttaral->guttural
 gutteral->guttural
+guyser->geyser
+guysers->geysers
+guyzer->geyser
+guyzers->geysers
+gwava->guava
 gylph->glyph
+gymnist->gymnast
+gymnistic->gymnastic
 gziniflate->gzinflate
 gziped->gzipped
 haa->has

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18011,6 +18011,7 @@ gard->guard
 gardai->gardaí
 garentee->guarantee
 gargage->garbage, garage,
+gargoil->gargoyle
 garilla->guerrilla
 garillas->guerrillas
 garnison->garrison

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18012,6 +18012,7 @@ gardai->gardaí
 garentee->guarantee
 gargage->garbage, garage,
 gargoil->gargoyle
+gargoils->gargoyles
 garilla->guerrilla
 garillas->guerrillas
 garnison->garrison
@@ -18019,7 +18020,7 @@ garuantee->guarantee
 garuanteed->guaranteed
 garuantees->guarantees
 garuantied->guaranteed
-gastly->ghastly
+gastly->ghastly, vastly,
 gatable->gateable
 gateing->gating
 gatherig->gathering
@@ -18044,6 +18045,7 @@ gaus->Gauss, gauze,
 gausian->gaussian
 gayity->gaiety
 gaysha->geisha
+gayshas->geishas
 geeneric->generic
 geenrate->generate
 geenrated->generated
@@ -18611,6 +18613,8 @@ gwava->guava
 gylph->glyph
 gymnist->gymnast
 gymnistic->gymnastic
+gymnistics->gymnastics
+gymnists->gymnasts
 gziniflate->gzinflate
 gziped->gzipped
 haa->has

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -1,5 +1,10 @@
 acknowledgement->acknowledgment
 acknowledgements->acknowledgments
+aggrandise->aggrandize
+aggrandised->aggrandized
+aggrandisement->aggrandizement
+aggrandises->aggrandizes
+aggrandising->aggrandizing
 amortise->amortize
 amortised->amortized
 amortises->amortizes


### PR DESCRIPTION
This replaces PR #1956 . I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html