### PR TITLE
Typos from marvin.cs.uidaho.edu: H

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18583,10 +18583,15 @@ hadnler->handler
 haeder->header
 haemorrage->haemorrhage
 haev->have, heave,
+hagas->haggis
+hagases->haggises
+hagasses->haggises
 hahve->have, halve, half,
 halarious->hilarious
 hald->held, hold, half, hall,
 halfs->halves
+hallaluja->hallelujah
+hallaluya->hallelujah
 Hallowean->Hallowe'en, Halloween,
 halp->help
 halpoints->halfpoints
@@ -18637,6 +18642,8 @@ handskake->handshake
 handwirting->handwriting
 hanel->handle
 hangig->hanging
+hankerchif->handkerchief
+hankerchifs->handkerchiefs
 hanlde->handle
 hanlded->handled
 hanlder->handler
@@ -18695,6 +18702,10 @@ hardward->hardware
 hardwdare->hardware
 hardwirted->hardwired
 harge->charge
+harrang->harangue
+harranged->harangued
+harranges->harangues
+harranging->haranguing
 harras->harass
 harrased->harassed
 harrases->harasses
@@ -18798,7 +18809,7 @@ hemipsheres->hemispheres
 hemishpere->hemisphere
 hemishperes->hemispheres
 hemmorhage->hemorrhage
-hemorage->haemorrhage
+hemorage->hemorrhage
 henc->hence
 henderence->hindrance
 hendler->handler
@@ -18931,6 +18942,7 @@ hilighted->highlighted
 hilighting->highlighting
 hilights->highlights
 hillarious->hilarious
+hims->his, hymns,
 himselv->himself
 hinderance->hindrance
 hinderence->hindrance

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18942,7 +18942,6 @@ hilighted->highlighted
 hilighting->highlighting
 hilights->highlights
 hillarious->hilarious
-hims->his, hymns,
 himselv->himself
 hinderance->hindrance
 hinderence->hindrance

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -18609,6 +18609,8 @@ hander->handler
 handfull->handful
 handhake->handshake
 handker->handler
+handkerchif->handkerchief
+handkerchifs->handkerchiefs
 handleer->handler
 handleing->handling
 handlig->handling
@@ -18703,9 +18705,11 @@ hardwdare->hardware
 hardwirted->hardwired
 harge->charge
 harrang->harangue
-harranged->harangued
-harranges->harangues
-harranging->haranguing
+harrange->harangue, arrange,
+harranged->harangued, arranged,
+harranger->haranguer, arranger,
+harranges->harangues, arranges,
+harranging->haranguing, arranging,
 harras->harass
 harrased->harassed
 harrases->harasses
@@ -18808,8 +18812,16 @@ hemipshere->hemisphere
 hemipsheres->hemispheres
 hemishpere->hemisphere
 hemishperes->hemispheres
-hemmorhage->hemorrhage
-hemorage->hemorrhage
+hemmorhage->haemorrhage, hemorrhage,
+hemmorhaged->haemorrhaged, hemorrhaged,
+hemmorhages->haemorrhages, hemorrhages,
+hemmorhagic->haemorrhagic, hemorrhagic,
+hemmorhaging->haemorrhaging, hemorrhaging,
+hemorage->haemorrhage, hemorrhage,
+hemoraged->haemorrhaged, hemorrhaged,
+hemorages->haemorrhages, hemorrhages,
+hemoragic->haemorrhagic, hemorrhagic,
+hemoraging->haemorrhaging, hemorrhaging,
 henc->hence
 henderence->hindrance
 hendler->handler

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -155,6 +155,10 @@ grey->gray
 greyed->grayed
 greyish->grayish
 greys->grays
+haemorrhage->hemorrhage
+haemorrhaged->hemorrhaged
+haemorrhages->hemorrhages
+haemorrhaging->hemorrhaging
 honour->honor
 honoured->honored
 honouring->honoring

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -93,6 +93,7 @@ guerillas->guerrillas
 hart->heart, harm,
 heterogenous->heterogeneous
 hided->hidden, hid,
+hims->his, hymns,
 hove->have, hover, love,
 impassible->impassable, impossible,
 implicity->implicitly, simplicity,


### PR DESCRIPTION
This replaces PR #1957. I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html