### PR TITLE
Typos from marvin.cs.uidaho.edu: K

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21838,7 +21838,14 @@ kighbosh->kibosh
 kighboshed->kiboshed
 kighboshes->kiboshes
 kighboshing->kiboshing
+kimera->chimera
+kimeric->chimeric
+kimerical->chimerical
+kimerically->chimerically
 kimerra->chimera
+kimerric->chimeric
+kimerrical->chimerical
+kimerrically->chimerically
 kindergarden->kindergarten
 kindgergarden->kindergarten
 kindgergarten->kindergarten

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21757,11 +21757,14 @@ juxtified->justified
 juxtifies->justifies
 juxtifying->justifying
 kackie->khaki
+kackies->khakis
 kake->cake, take,
 kakfa->Kafka
 kalidescope->kaleidoscope
 kalidescopes->kaleidoscopes
 karisma->charisma
+karismatic->charismatic
+karismatically->charismatically
 kazakstan->Kazakhstan
 keep-alives->keep-alive
 keept->kept
@@ -21780,8 +21783,8 @@ kernal->kernel
 kernals->kernels
 kernerl->kernel
 kernerls->kernels
-kernul->colonel
-kernuls->colonels
+kernul->kernel, colonel,
+kernuls->kernels, colonels,
 ket->key, kept,
 keword->keyword
 kewords->keywords
@@ -21824,6 +21827,13 @@ kibutz->kibbutz
 kibutzes->kibbutzim
 kibutzim->kibbutzim
 kidknap->kidnap
+kidknapped->kidnapped
+kidknappee->kidnappee
+kidknappees->kidnappees
+kidknapper->kidnapper
+kidknappers->kidnappers
+kidknapping->kidnapping
+kidknaps->kidnaps
 kighbosh->kibosh
 kighboshed->kiboshed
 kighboshes->kiboshes
@@ -21838,6 +21848,7 @@ kinnect->Kinect
 kiyack->kayak
 kiyacked->kayaked
 kiyacker->kayaker
+kiyackers->kayakers
 kiyacking->kayaking
 kiyacks->kayaks
 klenex->kleenex
@@ -21878,15 +21889,18 @@ konwn->known
 konws->knows
 kookoo->cuckoo
 kookoos->cuckoos
-koolot->culottes
+koolot->culotte
+koolots->culottes
 koordinate->coordinate
 koordinates->coordinates
 kown->known
 kresh->crèche
 kronicle->chronicle
+kronicled->chronicled
 kronicler->chronicler
 kroniclers->chroniclers
 kronicles->chronicles
+kronicling->chronicling
 kubenates->Kubernetes
 kubenernetes->Kubernetes
 kubenertes->Kubernetes

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21756,11 +21756,16 @@ juxtifications->justifications
 juxtified->justified
 juxtifies->justifies
 juxtifying->justifying
+kackie->khaki
 kake->cake, take,
 kakfa->Kafka
+kalidescope->kaleidoscope
+kalidescopes->kaleidoscopes
+karisma->charisma
 kazakstan->Kazakhstan
 keep-alives->keep-alive
 keept->kept
+keesh->quiche
 kenel->kernel, kennel,
 kenels->kernels, kennels,
 kenerl->kernel
@@ -21775,6 +21780,8 @@ kernal->kernel
 kernals->kernels
 kernerl->kernel
 kernerls->kernels
+kernul->colonel
+kernuls->colonels
 ket->key, kept,
 keword->keyword
 kewords->keywords
@@ -21797,6 +21804,8 @@ keybroad->keyboard
 keybroads->keyboards
 keyevente->keyevent
 keyords->keywords
+keyosk->kiosk
+keyosks->kiosks
 keyoutch->keytouch
 keyowrd->keyword
 keypair->key pair
@@ -21811,23 +21820,45 @@ keyworkds->keywords
 keyworks->keywords, key works,
 keywors->keywords
 keywprd->keyword
+kibutz->kibbutz
+kibutzes->kibbutzim
+kibutzim->kibbutzim
+kidknap->kidnap
+kighbosh->kibosh
+kighboshed->kiboshed
+kighboshes->kiboshes
+kighboshing->kiboshing
+kimerra->chimera
 kindergarden->kindergarten
 kindgergarden->kindergarten
 kindgergarten->kindergarten
 kinf->kind
 kinfs->kinds
 kinnect->Kinect
+kiyack->kayak
+kiyacked->kayaked
+kiyacker->kayaker
+kiyacking->kayaking
+kiyacks->kayaks
 klenex->kleenex
 klick->click
 klicked->clicked
 klicks->clicks
 klunky->clunky
+knarl->gnarl
+knarled->gnarled
+knarling->gnarling
+knarls->gnarls
+knarly->gnarly
 knive->knife
 kno->know
+knockous->noxious
+knockously->noxiously
 knowladge->knowledge
 knowlage->knowledge
 knowlageable->knowledgeable
 knowledgable->knowledgeable
+knowlegable->knowledgeable
 knowlegde->knowledge
 knowlege->knowledge
 knowlegeabel->knowledgeable
@@ -21845,9 +21876,17 @@ konstants->constants
 konw->know
 konwn->known
 konws->knows
+kookoo->cuckoo
+kookoos->cuckoos
+koolot->culottes
 koordinate->coordinate
 koordinates->coordinates
 kown->known
+kresh->crèche
+kronicle->chronicle
+kronicler->chronicler
+kroniclers->chroniclers
+kronicles->chronicles
 kubenates->Kubernetes
 kubenernetes->Kubernetes
 kubenertes->Kubernetes
@@ -21861,8 +21900,14 @@ kubernates->Kubernetes
 kubernests->Kubernetes
 kubernete->Kubernetes
 kuberntes->Kubernetes
+Kwanza->Kwanzaa
 kwno->know
 kwoledgebase->knowledge base
+kwuzines->cuisines
+kyebosh->kibosh
+kyeboshed->kiboshed
+kyeboshes->kiboshes
+kyeboshing->kiboshing
 kyrillic->cyrillic
 labatory->lavatory, laboratory,
 labbel->label

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21903,6 +21903,7 @@ kuberntes->Kubernetes
 Kwanza->Kwanzaa
 kwno->know
 kwoledgebase->knowledge base
+kwuzine->cuisine
 kwuzines->cuisines
 kyebosh->kibosh
 kyeboshed->kiboshed


### PR DESCRIPTION
This replaces PR #1960. I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html