### PR TITLE
Typos from marvin.cs.uidaho.edu: L

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22071,8 +22071,6 @@ laguages->languages
 laguague->language
 laguagues->languages
 laiter->later
-lama->llama
-lamas->llamas
 lamda->lambda
 lamdas->lambdas
 lanaguage->language
@@ -22585,7 +22583,6 @@ loactions->locations
 loadig->loading
 loadin->loading
 loadning->loading
-loath->loathe
 locae->locate
 locaes->locates
 locahost->localhost

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22053,6 +22053,16 @@ lables->labels
 labling->labeling, labelling,
 labouriously->laboriously
 labratory->laboratory
+labrynth->labyrinth
+labrynths->labyrinths
+lacker->lacquer
+lackered->lacquered
+lackeres->lacquers
+lackering->lacquering
+lackers->lacquers
+lackrimose->lachrymose
+lackrimosity->lachrymosity
+lackrimosly->lachrymosely
 laer->later, layer,
 lagacies->legacies
 lagacy->legacy
@@ -22061,6 +22071,8 @@ laguages->languages
 laguague->language
 laguagues->languages
 laiter->later
+lama->llama
+lamas->llamas
 lamda->lambda
 lamdas->lambdas
 lanaguage->language
@@ -22073,6 +22085,8 @@ langages->languages
 langauage->language
 langauge->language
 langauges->languages
+langerie->lingerie
+langerray->lingerie
 langeuage->language
 langeuagesection->languagesection
 langht->length
@@ -22131,8 +22145,16 @@ larg->large
 larget->larger, largest, target,
 largets->largest, targets,
 largst->largest
+laringes->larynxes
+larinx->larynx
+larinxes->larynxes
 larrry->larry
+larvas->larvae
+larvay->larvae
+larvays->larvae
+larvy->larvae
 laso->also, lasso,
+lasonya->lasagna
 lastes->latest
 lastest->latest, last,
 lastr->last
@@ -22163,6 +22185,10 @@ lavelling->levelling, labelling,
 lavels->levels, labels,
 layed->laid
 layou->layout
+layringes->larynges
+layrinks->larynx
+layrinx->larynx
+layrinxes->larynxes
 layser->layer, laser,
 laysered->layered, lasered,
 laysering->layering, lasering,
@@ -22193,17 +22219,29 @@ leagl->legal
 leaglise->legalise
 leaglity->legality
 leaglize->legalize
+leaneant->lenient
+leaneantly->leniently
 leanr->lean, learn, leaner,
 leapyear->leap year
 leapyears->leap years
 leary->leery
 leaset->least
+leasure->leisure
+leasurely->leisurely
+leasures->leisures
 leasy->least
 leat->lead, leak, least, leaf,
 leathal->lethal
 leats->least
 leaveing->leaving
 leavong->leaving
+leeg->league
+leegs->leagues
+leegun->legion
+leeguns->legions
+leesure->leisure
+leesurely->leisurely
+leesures->leisures
 lefted->left
 legac->legacy
 legact->legacy
@@ -22214,6 +22252,9 @@ leggacies->legacies
 leggacy->legacy
 leght->length
 leghts->lengths
+legionair->legionnaire
+legionaires->legionnaires
+legionairs->legionnaires
 legitamate->legitimate
 legitimiately->legitimately
 legitmate->legitimate
@@ -22222,6 +22263,8 @@ legth->length
 legths->lengths
 leibnitz->leibniz
 leightweight->lightweight
+lemosine->limousine
+lemosines->limousines
 lene->lens
 lenggth->length
 lengh->length
@@ -22250,6 +22293,13 @@ lentgh->length
 lentghs->lengths
 lenth->length
 lenths->lengths
+lepard->leopard
+lepards->leopards
+lepracan->leprechaun
+lepracans->leprechauns
+leprachan->leprechaun
+leprachans->leprechauns
+lepracy->leprosy
 leran->learn
 leraned->learned
 lerans->learns
@@ -22272,6 +22322,12 @@ levetates->levitates
 levetating->levitating
 levl->level
 levle->level
+lew->lieu, hew, sew, dew,
+lewchemia->leukemia
+lewow->luau
+lewows->luaus
+lewtenant->lieutenant
+lewtenants->lieutenants
 lexial->lexical
 lexigraphic->lexicographic
 lexigraphical->lexicographical
@@ -22357,6 +22413,7 @@ licesning->licensing
 licesnse->license
 licesnses->licenses
 licesnsing->licensing
+licker->liquor
 licsense->license
 licsenses->licenses
 licsensing->licensing
@@ -22384,6 +22441,10 @@ lightwieght->lightweight
 lightwight->lightweight
 lightyear->light year
 lightyears->light years
+ligitamacy->legitimacy
+ligitamassy->legitimacy
+ligitamate->legitimate
+ligitamately->legitimately
 ligth->light
 ligthing->lighting
 ligths->lights
@@ -22432,6 +22493,8 @@ limitter->limiter
 limitting->limiting
 limitts->limits
 limk->link
+limosine->limousine
+limosines->limousines
 limted->limited
 limti->limit
 limts->limits
@@ -22500,6 +22563,7 @@ litterally->literally
 litterals->literals
 litterate->literate
 litterature->literature
+liturature->literature
 liuke->like
 liveing->living
 livel->level
@@ -22521,6 +22585,7 @@ loactions->locations
 loadig->loading
 loadin->loading
 loadning->loading
+loath->loathe
 locae->locate
 locaes->locates
 locahost->localhost
@@ -22637,9 +22702,13 @@ lsip->lisp
 lsit->list, slit, sit,
 lsits->lists, slits, sits,
 luckly->luckily
+lugage->luggage
+lugages->luggage
 lukid->lucid, Likud,
 luminose->luminous
 luminousity->luminosity
+lushis->luscious
+lushisly->lusciously
 lveo->love
 lvoe->love
 Lybia->Libya

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22323,7 +22323,7 @@ levetating->levitating
 levl->level
 levle->level
 lew->lieu, hew, sew, dew,
-lewchemia->leukemia
+lewchemia->leukaemia, leukemia,
 lewow->luau
 lewows->luaus
 lewtenant->lieutenant

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22064,6 +22064,7 @@ lackrimose->lachrymose
 lackrimosity->lachrymosity
 lackrimosly->lachrymosely
 laer->later, layer,
+laf->laugh
 lagacies->legacies
 lagacy->legacy
 laguage->language
@@ -22071,6 +22072,7 @@ laguages->languages
 laguague->language
 laguagues->languages
 laiter->later
+lambast->lambaste
 lamda->lambda
 lamdas->lambdas
 lanaguage->language
@@ -22678,6 +22680,7 @@ loock->look, lock,
 loockdown->lockdown
 loocking->looking, locking,
 loockup->lookup, lockup,
+lood->lewd
 lookes->looks
 looknig->looking
 looop->loop
@@ -22693,6 +22696,7 @@ losted->listed, lost, lasted,
 lotation->rotation, flotation,
 lotharingen->Lothringen
 lowd->load, low, loud,
+lozonya->lasagna
 lpatform->platform
 lsat->last, slat, sat,
 lsip->lisp

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22064,7 +22064,7 @@ lackrimose->lachrymose
 lackrimosity->lachrymosity
 lackrimosly->lachrymosely
 laer->later, layer,
-laf->laugh
+laf->laugh, leaf, loaf, lad, lag, lac, kaf, kaph,
 lagacies->legacies
 lagacy->legacy
 laguage->language
@@ -22072,7 +22072,6 @@ laguages->languages
 laguague->language
 laguagues->languages
 laiter->later
-lambast->lambaste
 lamda->lambda
 lamdas->lambdas
 lanaguage->language
@@ -22680,7 +22679,7 @@ loock->look, lock,
 loockdown->lockdown
 loocking->looking, locking,
 loockup->lookup, lockup,
-lood->lewd
+lood->lewd, blood, flood, mood, look, loom,
 lookes->looks
 looknig->looking
 looop->loop

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -201,6 +201,7 @@ legalise->legalize
 legalised->legalized
 legalises->legalizes
 legalising->legalizing
+leukaemia->leukemia
 licence->license
 licences->licenses
 litre->liter

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -106,10 +106,13 @@ ingenuous->ingenious
 inly->only
 irregardless->regardless
 knifes->knives
+lama->llama
+lamas->llamas
 leaded->led, lead,
 leas->least, lease,
 lightening->lightning, lighting,
 loafing->loading
+loath->loathe
 lod->load, loud, lode,
 loos->loose, lose,
 loosing->losing


### PR DESCRIPTION
This replaces PR #1961. I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html