### PR TITLE
Typos from marvin.cs.uidaho.edu: O

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25412,6 +25412,7 @@ obvisous->obvious
 obvisously->obviously
 obyect->object
 obyekt->object
+ocapella->a cappella
 ocasion->occasion
 ocasional->occasional
 ocasionally->occasionally
@@ -25597,6 +25598,7 @@ oftenly->often
 ofter->often, offer, after,
 ofthe->of the
 ofthen->often, of then,
+oger->ogre
 oging->going, ogling,
 oher->other, her,
 oherwise->otherwise
@@ -25993,6 +25995,7 @@ orcestrator->orchestrator
 orded->ordered
 orderd->ordered
 ordert->ordered
+orderves->hors d'oeuvre
 ording->ordering
 ordner->order
 orede->order

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25300,7 +25300,11 @@ oakerously->ocherously
 oakery->ochery
 oaram->param
 obation->ovation
+obations->ovations
 obay->obey
+obayed->obeyed
+obaying->obeying
+obays->obeys
 obect->object
 obediance->obedience
 obediant->obedient
@@ -25486,6 +25490,8 @@ ocilater->oscillator
 ocilaters->oscillators
 ocilates->oscillates
 ocilating->oscillating
+ocilator->oscillator
+ocilators->oscillators
 oclock->o'clock
 ocntext->context
 ocorrence->occurrence
@@ -25599,6 +25605,8 @@ ofter->often, offer, after,
 ofthe->of the
 ofthen->often, of then,
 oger->ogre
+ogerish->ogreish
+ogers->ogres
 oging->going, ogling,
 oher->other, her,
 oherwise->otherwise
@@ -25629,8 +25637,10 @@ olt->old
 olther->other
 oly->only
 omage->homage
+omages->homages
 omaj->homage
 omaje->homage
+omajes->homages
 omishience->omniscience
 omishiences->omnisciences
 omishients->omniscience
@@ -25836,8 +25846,18 @@ opetional->optional
 ophan->orphan
 ophtalmology->ophthalmology
 opinyon->opinion
+opinyonable->opinionable
+opinyonaire->opinionnaire
+opinyonal->opinional
+opinyonate->opinionated
 opinyonated->opinionated
 opinyonatedly->opinionatedly
+opinyonative->opinionative
+opinyonator->opinionator
+opinyonators->opinionators
+opinyonist->opinionist
+opinyonists->opinionists
+opinyonnaire->opinionnaire
 opinyons->opinions
 opion->option
 opional->optional
@@ -32551,6 +32571,7 @@ seletions->selections, deletions,
 selets->selects
 self-comparisson->self-comparison
 self-contianed->self-contained
+self-opinyonated->self-opinionated
 self-referencial->self-referential
 self-refering->self-referring
 selfs->self

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25292,7 +25292,7 @@ nuturing->nurturing
 nwe->new
 nwo->now
 o'caml->OCaml
-oaker->ocher
+oaker->ocher, oakier, oaken, baker, faker, laker, maker, taker,
 oakereous->ocherous
 oakereously->ocherously
 oakerous->ocherous
@@ -25482,8 +25482,6 @@ occurrances->occurrences
 occurrencs->occurrences
 occurrs->occurs
 oce->once, one, ore,
-ochreous->ocherous
-ochry->ochery
 ocilate->oscillate
 ocilated->oscillated
 ocilater->oscillator
@@ -25498,8 +25496,8 @@ ocorrence->occurrence
 ocorrences->occurrences
 octect->octet
 octects->octets
-octive->octave
-octives->octaves
+octive->octave, active,
+octives->octaves, actives,
 Octobor->October
 octohedra->octahedra
 octohedral->octahedral
@@ -25638,7 +25636,7 @@ olther->other
 oly->only
 omage->homage
 omages->homages
-omaj->homage
+omaj->homage, Oman,
 omaje->homage
 omajes->homages
 omishience->omniscience
@@ -25654,6 +25652,7 @@ omitt->omit
 omlet->omelet
 omlets->omelets
 omlette->omelette
+omlettes->omelettes
 ommishience->omniscience
 ommishiences->omnisciences
 ommishients->omniscience
@@ -26007,6 +26006,8 @@ opyions->options
 orangatang->orangutan
 orangatangs->orangutans
 orcale->oracle
+orcestra->orchestra
+orcestras->orchestras
 orcestrate->orchestrate
 orcestrated->orchestrated
 orcestrates->orchestrates

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25292,7 +25292,14 @@ nuturing->nurturing
 nwe->new
 nwo->now
 o'caml->OCaml
+oaker->ocher
+oakereous->ocherous
+oakereously->ocherously
+oakerous->ocherous
+oakerously->ocherously
+oakery->ochery
 oaram->param
+obation->ovation
 obay->obey
 obect->object
 obediance->obedience
@@ -25360,6 +25367,10 @@ objtain->obtain
 objtained->obtained
 objtains->obtains
 objump->objdump
+obleek->oblique
+obleekly->obliquely
+oblisk->obelisk
+oblisks->obelisks
 oblitque->oblique
 obnject->object
 obscur->obscure
@@ -25425,8 +25436,11 @@ occassionally->occasionally
 occassionaly->occasionally
 occassioned->occasioned
 occassions->occasions
+occation->occasion
 occational->occasional
 occationally->occasionally
+occationly->occasionally
+occations->occasions
 occcur->occur
 occcured->occurred
 occcurs->occurs
@@ -25463,12 +25477,22 @@ occurrances->occurrences
 occurrencs->occurrences
 occurrs->occurs
 oce->once, one, ore,
+ochreous->ocherous
+ochry->ochery
+ocilate->oscillate
+ocilated->oscillated
+ocilater->oscillator
+ocilaters->oscillators
+ocilates->oscillates
+ocilating->oscillating
 oclock->o'clock
 ocntext->context
 ocorrence->occurrence
 ocorrences->occurrences
 octect->octet
 octects->octets
+octive->octave
+octives->octaves
 Octobor->October
 octohedra->octahedra
 octohedral->octahedral
@@ -25488,6 +25512,8 @@ ocurrences->occurrences
 ocurring->occurring
 ocurrred->occurred
 ocurrs->occurs
+odasee->odyssey
+odasees->odysseys
 oder->order, odor,
 odly->oddly
 ody->body
@@ -25502,6 +25528,9 @@ offcers->officers
 offcial->official
 offcially->officially
 offcials->officials
+offen->often
+offener->oftener
+offenest->oftenest
 offens->offend, offense, offends, offers,
 offerd->offered
 offereings->offerings
@@ -25525,6 +25554,14 @@ officeally->officially
 officeals->officials
 officealy->officially
 officialy->officially
+officianado->aficionado
+officianados->aficionados
+officionado->aficionado
+officionados->aficionados
+offisianado->aficionado
+offisianados->aficionados
+offisionado->aficionado
+offisionados->aficionados
 offlaod->offload
 offlaoded->offloaded
 offlaoding->offloading
@@ -25543,6 +25580,14 @@ offstets->offsets
 offten->often
 oficial->official
 oficially->officially
+oficianado->aficionado
+oficianados->aficionados
+oficionado->aficionado
+oficionados->aficionados
+ofisianado->aficionado
+ofisianados->aficionados
+ofisionado->aficionado
+ofisionados->aficionados
 ofmodule->of module
 ofo->of
 ofrom->from
@@ -25581,11 +25626,28 @@ olny->only
 olt->old
 olther->other
 oly->only
+omage->homage
+omaj->homage
+omaje->homage
+omishience->omniscience
+omishiences->omnisciences
+omishients->omniscience
+omishints->omniscience
+omisience->omniscience
+omisiences->omnisciences
 omision->omission
 omited->omitted
 omiting->omitting
 omitt->omit
+omlet->omelet
+omlets->omelets
 omlette->omelette
+ommishience->omniscience
+ommishiences->omnisciences
+ommishients->omniscience
+ommishints->omniscience
+ommisience->omniscience
+ommisiences->omnisciences
 ommision->omission
 ommission->omission
 ommit->omit
@@ -25594,6 +25656,12 @@ ommiting->omitting
 ommits->omits
 ommitted->omitted
 ommitting->omitting
+omnishience->omniscience
+omnishiences->omnisciences
+omnishients->omniscience
+omnishints->omniscience
+omnisience->omniscience
+omnisiences->omnisciences
 omniverous->omnivorous
 omniverously->omnivorously
 omplementaion->implementation
@@ -25616,7 +25684,15 @@ onliene->online
 onlly->only
 onlye->only
 onlyonce->only once
+onmishience->omniscience
+onmishiences->omnisciences
+onmishients->omniscience
+onmishints->omniscience
+onmisience->omniscience
+onmisiences->omnisciences
 onoly->only
+onomanopea->onomatopoeia
+onomonopea->onomatopoeia
 onot->note, not,
 onother->another
 ons->owns
@@ -25638,6 +25714,7 @@ ontrolled->controlled
 onveience->convenience
 onw->own
 onwed->owned
+onwee->ennui
 onwer->owner
 onwership->ownership
 onwing->owning
@@ -25652,6 +25729,9 @@ opactiy->opacity
 opacy->opacity
 opague->opaque
 opatque->opaque
+opayk->opaque
+opaykely->opaquely
+opaykes->opaques
 opbject->object
 opbjective->objective
 opbjects->objects
@@ -25753,6 +25833,10 @@ opertors->operators
 opetional->optional
 ophan->orphan
 ophtalmology->ophthalmology
+opinyon->opinion
+opinyonated->opinionated
+opinyonatedly->opinionatedly
+opinyons->opinions
 opion->option
 opional->optional
 opionally->optionally
@@ -25898,7 +25982,14 @@ opulate->populate, opiate, opulent,
 opulates->populates, opiates,
 opyion->option
 opyions->options
+orangatang->orangutan
+orangatangs->orangutans
 orcale->oracle
+orcestrate->orchestrate
+orcestrated->orchestrated
+orcestrates->orchestrates
+orcestrating->orchestrating
+orcestrator->orchestrator
 orded->ordered
 orderd->ordered
 ordert->ordered
@@ -25908,6 +25999,7 @@ orede->order
 oredes->orders
 oreding->ordering
 oredred->ordered
+oregeno->oregano
 orfer->order, offer,
 orgamise->organise
 organim->organism
@@ -25970,6 +26062,8 @@ oriant->orient
 oriantate->orientate
 oriantated->orientated
 oriantation->orientation
+oricle->oracle
+oricles->oracles
 oridinal->ordinal, original,
 oridinarily->ordinarily
 orieation->orientation
@@ -26026,6 +26120,8 @@ orignially->originally
 origninal->original
 oringal->original
 oringally->originally
+orkid->orchid
+orkids->orchids
 orpan->orphan
 orpanage->orphanage
 orpaned->orphaned
@@ -26046,12 +26142,18 @@ oscilate->oscillate
 oscilated->oscillated
 oscilating->oscillating
 oscilator->oscillator
+oscillater->oscillator
+oscillaters->oscillators
 oscilliscope->oscilloscope
 oscilliscopes->oscilloscopes
 osffset->offset
 osffsets->offsets
 osffsetting->offsetting
 osicllations->oscillations
+osterage->ostrich
+osterages->ostriches
+ostridge->ostrich
+ostridges->ostriches
 ot->to, of, or, not,
 otain->obtain
 otained->obtained
@@ -26294,6 +26396,20 @@ overwritren->overwritten
 overwrittes->overwrites
 overwrittin->overwriting
 overwritting->overwriting
+overzealis->overzealous
+overzealisly->overzealously
+overzealos->overzealous
+overzealosly->overzealously
+overzealus->overzealous
+overzealusly->overzealously
+overzelis->overzealous
+overzelisly->overzealously
+overzelos->overzealous
+overzelosly->overzealously
+overzelous->overzealous
+overzelously->overzealously
+overzelus->overzealous
+overzelusly->overzealously
 ovewrite->overwrite
 ovewrites->overwrites
 ovewriting->overwriting

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -253,6 +253,7 @@ normalise->normalize
 normalised->normalized
 normalises->normalizes
 normalising->normalizing
+ochre->ocher
 optimisation->optimization
 optimisations->optimizations
 optimise->optimize

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -1,4 +1,5 @@
 ablet->able, tablet,
+acapella->a cappella
 accreting->accrediting
 acter->actor
 acters->actors
@@ -132,6 +133,7 @@ moue->mouse
 multistory->multistorey, multi-storey,
 nickle->nickel
 noes->nose, knows, nodes, does,
+ochry->ochery, ochrey,
 oerflow->overflow
 oerflowed->overflowed
 oerflowing->overflowing


### PR DESCRIPTION
This replaces PR #1964. I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html