### PR TITLE
Typos from marvin.cs.uidaho.edu: P

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27925,6 +27925,7 @@ pilons->pylons
 pimxap->pixmap
 pimxaps->pixmaps
 pinapple->pineapple
+pincher->pinscher
 pinnaple->pineapple
 pinockle->pinochle
 pinoneered->pioneered
@@ -28031,7 +28032,7 @@ plausable->plausible
 playble->playable
 playfull->playful, playfully,
 playge->plague
-playgerise->plagiarise
+playgerise->plagiarize, plagiarise,
 playgerize->plagiarize
 playgropund->playground
 playist->playlist
@@ -28989,6 +28990,7 @@ pririty->priority, privity,
 prirority->priority
 pris->prise, prism,
 priting->printing
+privaledge->privilege
 privalege->privilege
 privaleges->privileges
 privaye->private

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -26928,8 +26928,9 @@ paermission->permission
 paermissions->permissions
 paeth->path
 pagagraph->paragraph
-pagent->pageant
-pagents->pageants
+pagent->pageant, plangent,
+pagentry->pageantry, plangently,
+pagents->pageants, plangents,
 pahses->phases
 paht->path, pat, part,
 pahts->paths, pats, parts,
@@ -27115,10 +27116,10 @@ paret->parent, parrot,
 paretheses->parentheses
 parfay->parfait
 parge->large
-paria->pariah
+paria->pariah, parka,
 parial->partial
 parially->partially
-parias->pariahs
+parias->pariahs, parkas,
 paricular->particular
 paricularly->particularly
 parisitic->parasitic
@@ -27137,8 +27138,8 @@ parititioning->partitioning
 parititions->partitions
 paritiy->parity
 parituclar->particular
-parkay->parquet
-parkays->parquets
+parkay->parquet, parlay, parkway,
+parkays->parquets, parlays, parkways,
 parlament->parliament
 parlamentary->parliamentary
 parlaments->parliaments
@@ -27192,7 +27193,7 @@ parrent->parent
 parsef->parsed, parser, parsec,
 parseing->parsing
 parsering->parsing
-parshal->partial
+parshal->partial, marshal,
 parshally->partially
 parshaly->partially
 parsial->partial
@@ -27388,12 +27389,12 @@ peapel->people
 peapels->peoples
 peaple->people
 peaples->peoples
-pease->peace, piece,
-peased->pieced
+pease->peace, piece, please, lease,
+peased->pieced, pleased, leased,
 peaseful->peaceful
 peasefully->peacefully
-peases->pieces
-peasing->piecing
+peases->pieces, pleases, leases,
+peasing->piecing, pleasing, leasing,
 pecentage->percentage
 pecified->specified, pacified,
 pecularities->peculiarities
@@ -27828,7 +27829,7 @@ pessiary->pessary
 petetion->petition
 pevent->prevent
 pevents->prevents
-pewder->pewter
+pewder->pewter, powder, lewder,
 pezier->bezier
 phanthom->phantom
 pharmaseudical->pharmaceutical
@@ -27849,8 +27850,8 @@ pharmasutical->pharmaceutical
 pharmasutically->pharmaceutical
 pharmasuticals->pharmaceuticals
 pharmasuticaly->pharmaceutical
-Pharoah->Pharaoh
-pharoh->Pharaoh
+pharoah->pharaoh
+pharoh->pharaoh
 phasepsace->phasespace
 phasis->phases
 phenomenom->phenomenon
@@ -27876,7 +27877,7 @@ phisically->physically
 phisicaly->physically
 phisics->physics
 phisosophy->philosophy
-phlem->phlegm
+phlem->phlegm, phloem,
 phlema->phlegma
 phlematic->phlegmatic
 phlematically->phlegmatically
@@ -27938,7 +27939,7 @@ pickyunes->picayunes
 picniced->picnicked
 picnicer->picnicker
 picnicing->picnicking
-picnick->picnic, picknick,
+picnick->picnic
 picnicks->picnics
 picoseond->picosecond
 picoseonds->picoseconds
@@ -27949,8 +27950,8 @@ pictureskness->picturesqueness
 pieceweise->piecewise, piece wise,
 piecewiese->piecewise, piece wise,
 piecwise->piecewise, piece wise,
-pigen->pigeon
-pigens->pigeons
+pigen->pigeon, pigpen,
+pigens->pigeons, pigpens,
 piggypack->piggyback
 piggypacked->piggybacked
 pigin->pigeon
@@ -27967,8 +27968,8 @@ pilgramig->pilgrimage
 pilgramige->pilgrimage
 pilgrimmage->pilgrimage
 pilgrimmages->pilgrimages
-pilon->pylon
-pilons->pylons
+pilon->pylon, pillion,
+pilons->pylons, pillions,
 pimxap->pixmap
 pimxaps->pixmaps
 pinapple->pineapple
@@ -28079,7 +28080,7 @@ plausable->plausible
 playble->playable
 playfull->playful, playfully,
 playge->plague
-playgerise->plagiarize, plagiarise,
+playgerise->plagiarise
 playgerize->plagiarize
 playgropund->playground
 playist->playlist
@@ -29608,7 +29609,7 @@ protecte->protected, protect,
 protectiv->protective
 protectoin->protection
 protedcted->protected
-proteen->protein
+proteen->protein, protean, preteen,
 protential->potential
 protext->protect
 protocal->protocol

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -26884,6 +26884,7 @@ paceholder->placeholder
 pach->patch, path,
 pachage->package
 paches->patches
+pachooly->patchouli
 pacht->patch
 pachtches->patches
 pachtes->patches
@@ -26917,6 +26918,8 @@ packtes->packets
 pactch->patch
 pactched->patched
 pactches->patches
+paculier->peculiar
+paculierly->peculiarly
 padam->param
 padd->pad, padded,
 padds->pads
@@ -26925,6 +26928,8 @@ paermission->permission
 paermissions->permissions
 paeth->path
 pagagraph->paragraph
+pagent->pageant
+pagents->pageants
 pahses->phases
 paht->path, pat, part,
 pahts->paths, pats, parts,
@@ -26933,6 +26938,18 @@ paied->paid, paired,
 painiting->painting
 paintile->painttile
 paintin->painting
+pairocheal->parochial
+pairocheality->parochiality
+pairocheally->parochially
+pairocheel->parochial
+pairocheelity->parochiality
+pairocheelly->parochially
+pairokeal->parochial
+pairokeality->parochiality
+pairokeally->parochially
+pairokeel->parochial
+pairokeelity->parochiality
+pairokeelly->parochially
 paitience->patience
 paiting->painting
 pakage->package
@@ -27096,9 +27113,12 @@ parenthises->parentheses
 parenthsis->parenthesis
 paret->parent, parrot,
 paretheses->parentheses
+parfay->parfait
 parge->large
+paria->pariah
 parial->partial
 parially->partially
+parias->pariahs
 paricular->particular
 paricularly->particularly
 parisitic->parasitic
@@ -27117,15 +27137,26 @@ parititioning->partitioning
 parititions->partitions
 paritiy->parity
 parituclar->particular
+parkay->parquet
+parkays->parquets
+parlament->parliament
+parlamentary->parliamentary
+parlaments->parliaments
 parliment->parliament
+parlimentary->parliamentary
+parliments->parliaments
 parm->param, pram, Parma,
 parmaeter->parameter
 parmaeters->parameters
 parmameter->parameter
 parmameters->parameters
 parmaters->parameters
+parmesian->Parmesan
 parmeter->parameter
 parmeters->parameters
+parmetian->Parmesan
+parmisan->Parmesan
+parmisian->Parmesan
 parms->params, prams,
 parmter->parameter
 parmters->parameters
@@ -27136,8 +27167,23 @@ parntering->partnering
 parnters->partners
 parntership->partnership
 parnterships->partnerships
+parocheal->parochial
+parocheality->parochiality
+parocheally->parochially
+parocheel->parochial
+parocheelity->parochiality
+parocheelly->parochially
+parokeal->parochial
+parokeality->parochiality
+parokeally->parochially
+parokeel->parochial
+parokeelity->parochiality
+parokeelly->parochially
 parrakeets->parakeets
 parralel->parallel
+parralell->parallel
+parralelly->parallelly
+parralely->parallelly
 parrallel->parallel
 parrallell->parallel
 parrallelly->parallelly
@@ -27146,6 +27192,10 @@ parrent->parent
 parsef->parsed, parser, parsec,
 parseing->parsing
 parsering->parsing
+parshally->partially
+parshaly->partially
+parsially->partially
+parsialy->partially
 parsin->parsing
 parstree->parse tree
 partaining->pertaining
@@ -27218,6 +27268,10 @@ partiular->particular
 partiularly->particularly
 partiulars->particulars
 pary->party, parry,
+pascheurise->pasteurise
+pascheurize->pasteurize
+paschurise->pasteurise
+paschurize->pasteurize
 pase->pass, pace, parse,
 pased->passed, parsed,
 pasengers->passengers
@@ -27252,8 +27306,12 @@ passwirds->passwords
 passwrod->password
 passwrods->passwords
 pasteing->pasting
+pasteries->pastries
+pastery->pastry
 pasttime->pastime
 pastural->pastoral
+pasturise->pasteurise
+pasturize->pasteurize
 pasword->password
 paswords->passwords
 patameter->parameter
@@ -27296,8 +27354,17 @@ peacd->peace
 peacefuland->peaceful and
 peacify->pacify
 peageant->pageant
+peanochle->pinochle
+peanockle->pinochle
+peanuchle->pinochle
+peanuckle->pinochle
+peapel->people
+peapels->peoples
 peaple->people
 peaples->peoples
+pease->peace
+peaseful->peaceful
+peasefully->peacefully
 pecentage->percentage
 pecified->specified, pacified,
 pecularities->peculiarities
@@ -27305,7 +27372,14 @@ pecularity->peculiarity
 peculure->peculiar
 pedestrain->pedestrian
 peding->pending
+pedistal->pedestal
+pedistals->pedestals
 pedning->pending
+peedmont->piedmont
+peedmonts->piedmonts
+peepel->people
+peepels->peoples
+peerowet->pirouette
 pefer->prefer
 peferable->preferable
 peferably->preferably
@@ -27334,15 +27408,23 @@ peirods->periods
 Peloponnes->Peloponnese, Peloponnesus,
 penalities->penalties
 penality->penalty
+penatentury->penitentiary
 penatly->penalty
 pendantic->pedantic
 pendig->pending
 pendning->pending
 penerator->penetrator
+pengwen->penguin
+pengwens->penguins
+pengwin->penguin
+pengwins->penguins
 penisula->peninsula
 penisular->peninsular
 pennal->panel
 pennals->panels
+pennensula->peninsula
+pennensular->peninsular
+pennensulas->peninsulas
 penninsula->peninsula
 penninsular->peninsular
 pennisula->peninsula
@@ -27350,6 +27432,7 @@ Pennyslvania->Pennsylvania
 pensinula->peninsula
 pensle->pencil
 penultimante->penultimate
+penwar->peignoir
 peom->poem
 peoms->poems
 peopel->people
@@ -27504,6 +27587,14 @@ perfromance->performance
 perfromed->performed
 perfroming->performing
 perfroms->performs
+perfur->prefer
+perfurd->preferred
+perfured->preferred
+perfuring->preferring
+perfurrd->preferred
+perfurred->preferred
+perfurring->preferring
+perfurs->prefers
 perhabs->perhaps
 perhas->perhaps
 perhasp->perhaps
@@ -27531,6 +27622,10 @@ peristent->persistent
 perjery->perjury
 perjorative->pejorative
 perlciritc->perlcritic
+perliferate->proliferate
+perliferated->proliferated
+perliferates->proliferates
+perliferating->proliferating
 permable->permeable
 permament->permanent
 permamently->permanently
@@ -27600,8 +27695,17 @@ perpsective->perspective
 perpsectives->perspectives
 perrror->perror
 persan->person
+persciuos->precious
+persciuosly->preciously
+perscius->precious
+persciusly->preciously
 persective->perspective
 persectives->perspectives
+perseed->precede
+perseeded->preceded
+perseedes->precedes
+perseeding->preceding
+perseeds->precedes
 persepctive->perspective
 persepective->perspective
 persepectives->perspectives
@@ -27615,6 +27719,16 @@ perservering->persevering
 perserves->preserves
 perserving->preserving
 perseverence->perseverance
+persew->pursue
+persewed->pursued
+persewer->pursuer
+persewes->pursues
+persewing->pursuing
+persews->pursues
+pershis->precious
+pershisly->preciously
+pershus->precious
+pershusly->preciously
 persisit->persist
 persisited->persisted
 persistance->persistence
@@ -27636,6 +27750,10 @@ personnal->personal
 personnaly->personally
 personnell->personnel
 perspecitve->perspective
+perssious->precious
+perssiously->preciously
+perssiuos->precious
+perssiuosly->preciously
 persuded->persuaded
 persue->pursue
 persued->pursued
@@ -27643,9 +27761,14 @@ persuing->pursuing
 persuit->pursuit
 persuits->pursuits
 persumably->presumably
+perticipate->participate
+perticipated->participated
+perticipates->participates
+perticipating->participating
 perticular->particular
 perticularly->particularly
 perticulars->particulars
+pertinate->pertinent
 pertrub->perturb
 pertrubation->perturbation
 pertrubations->perturbations
@@ -27661,15 +27784,33 @@ perturbate->perturb
 perturbates->perturbs
 perturbe->perturb, perturbed,
 perview->preview, purview,
+perview->purview
+perviews->purviews
 pervious->previous
 perviously->previously
 pessiary->pessary
 petetion->petition
 pevent->prevent
 pevents->prevents
+pewder->pewter
 pezier->bezier
 phanthom->phantom
+pharmaseudical->pharmaceutical
+pharmaseudically->pharmaceutical
+pharmaseudicaly->pharmaceutical
+pharmaseutical->pharmaceutical
+pharmaseutically->pharmaceutical
+pharmaseuticaly->pharmaceutical
+pharmasist->pharmacist
+pharmasists->pharmacists
+pharmasudical->pharmaceutical
+pharmasudically->pharmaceutical
+pharmasudicaly->pharmaceutical
+pharmasutical->pharmaceutical
+pharmasutically->pharmaceutical
+pharmasuticaly->pharmaceutical
 Pharoah->Pharaoh
+pharoh->Pharaoh
 phasepsace->phasespace
 phasis->phases
 phenomenom->phenomenon
@@ -27695,6 +27836,7 @@ phisically->physically
 phisicaly->physically
 phisics->physics
 phisosophy->philosophy
+phlem->phlegm
 Phonecian->Phoenecian
 phoneticly->phonetically
 phongraph->phonograph
@@ -27715,6 +27857,16 @@ phylosophical->philosophical
 physcial->physical
 physial->physical
 physicaly->physically
+physican->physician
+physicans->physicians
+physicion->physician
+physicions->physicians
+physisan->physician
+physisans->physicians
+physisian->physician
+physisians->physicians
+physision->physician
+physisions->physicians
 physisist->physicist
 phython->python
 phyton->python
@@ -27723,22 +27875,62 @@ piar->pair, pier, pliers,
 piars->pairs, piers, pliers,
 piblisher->publisher
 pice->piece
+pich->pitch
 pich->pitch, pick, pinch,
+picknic->picnic
+pickniced->picnicked
+picknicer->picnicker
+picknicing->picnicking
+picknick->picnic
+picknicked->picnicked
+picknicker->picnicker
+picknicking->picnicking
+picknicks->picnics
+picknics->picnics
+pickyune->picayune
+pickyunes->picayunes
+picniced->picnicked
+picnicer->picnicker
+picnicing->picnicking
+picnick->picnic
+picnicks->picnics
 picoseond->picosecond
 picoseonds->picoseconds
+picturesk->picturesque
+pictureskely->picturesquely
+pictureskly->picturesquely
+pictureskness->picturesqueness
 pieceweise->piecewise, piece wise,
 piecewiese->piecewise, piece wise,
 piecwise->piecewise, piece wise,
+pigen->pigeon
+pigens->pigeons
 piggypack->piggyback
 piggypacked->piggybacked
+pigin->pigeon
+pigins->pigeons
+pigun->pigeon
+piguns->pigeons
+pijeon->pigeon
+pijeons->pigeons
+pijun->pigeon
+pijuns->pigeons
+pilgram->pilgrim
+pilgramidge->pilgrimage
+pilgramig->pilgrimage
 pilgrimmage->pilgrimage
 pilgrimmages->pilgrimages
+pilon->pylon
+pilons->pylons
 pimxap->pixmap
 pimxaps->pixmaps
 pinapple->pineapple
 pinnaple->pineapple
+pinockle->pinochle
 pinoneered->pioneered
 pinter->pointer, printer,
+pinuchle->pinochle
+pinuckle->pinochle
 piont->point
 pionter->pointer
 pionts->points
@@ -27760,6 +27952,7 @@ pipleline->pipeline
 piplelines->pipelines
 pipline->pipeline
 piplines->pipelines
+pirric->Pyrrhic
 pitmap->pixmap, bitmap,
 pitty->pity
 pivott->pivot
@@ -27780,13 +27973,16 @@ placemet->placement, placemat, place mat,
 placemets->placements, placemats, place mats,
 placholder->placeholder
 placholders->placeholders
+plack->plaque
 placmenet->placement
 placmenets->placements
+plad->plaid
 plaform->platform
 plaforms->platforms
 plaftorm->platform
 plaftorms->platforms
 plagarism->plagiarism
+plagerism->plagiarism
 plalform->platform
 plalforms->platforms
 planation->plantation
@@ -27816,6 +28012,8 @@ platformt->platforms
 platfrom->platform
 platfroms->platforms
 plathome->platform
+platoe->plateau
+platoes->plateaus
 platofmr->platform
 platofmrs->platforms
 platofms->platforms
@@ -27826,6 +28024,8 @@ platofrm->platform
 platofrms->platforms
 plattform->platform
 plattforms->platforms
+plattoe->plateau
+plattoes->plateaus
 plausability->plausibility
 plausable->plausible
 playble->playable
@@ -28303,6 +28503,8 @@ pracitcally->practically
 practial->practical
 practially->practically
 practicaly->practically
+practicianer->practitioner
+practicianers->practitioners
 practicioner->practitioner
 practicioners->practitioners
 practicly->practically
@@ -28325,6 +28527,9 @@ praries->prairies
 pratical->practical
 pratically->practically
 pratice->practice
+prayries->prairies
+prayry->prairie
+prayrys->prairies
 prcess->process
 prcesses->processes
 prcessing->processing
@@ -28493,6 +28698,9 @@ preffixed->prefixed
 preffixes->prefixes
 preffixing->prefixing
 prefices->prefixes
+preficiency->proficiency
+preficient->proficient
+preficientsy->proficiency
 prefitler->prefilter
 prefitlered->prefiltered
 prefitlering->prefiltering
@@ -28509,6 +28717,10 @@ prejected->projected
 prejection->projection
 prejections->projections
 prejects->projects, prefects,
+prejudgudice->prejudice
+prejudgudiced->prejudiced
+prejudgudices->prejudices
+prejudgudicing->prejudicing
 preliferation->proliferation
 prelimitary->preliminary
 premeire->premiere
@@ -28575,6 +28787,14 @@ preriod->period
 preriodic->periodic
 prersistent->persistent
 presance->presence
+presbaterian->Presbyterian
+presbaterians->Presbyterians
+presbaterien->Presbyterian
+presbateriens->Presbyterians
+presciuos->precious
+presciuosly->preciously
+prescius->precious
+presciusly->preciously
 prescripe->prescribe
 prescriped->prescribed
 prescrition->prescription
@@ -28605,6 +28825,10 @@ preseverance->perseverance
 preseverence->perseverance
 preseves->preserves
 preseving->preserving
+preshis->precious
+preshisly->preciously
+preshus->precious
+preshusly->preciously
 presicion->precision
 presidenital->presidential
 presidental->presidential
@@ -28631,6 +28855,10 @@ presse->pressed, press,
 pressent->present
 pressentation->presentation
 pressented->presented
+pressious->precious
+pressiously->preciously
+pressiuos->precious
+pressiuosly->preciously
 pressre->pressure
 presss->press, presses,
 pressue->pressure
@@ -28715,6 +28943,7 @@ primatively->primitively
 primatives->primitives
 primay->primary
 primeter->perimeter
+primevil->primeval
 primimitive->primitive
 primitave->primitive
 primitiv->primitive
@@ -28799,6 +29028,8 @@ privision->provision
 privisional->provisional
 privisions->provisions
 privledge->privilege
+privlege->privilege
+privleged->privileged
 privleges->privileges
 privte->private
 prject->project
@@ -29102,6 +29333,7 @@ progrom->pogrom, program,
 progroms->pogroms, programs,
 progrss->progress
 prohabition->prohibition
+prohibative->prohibitive
 prohibitted->prohibited
 prohibitting->prohibiting
 prohibt->prohibit
@@ -29132,7 +29364,9 @@ prolbems->problems
 prolem->problem
 prolematic->problematic
 prolems->problems
+prolicks->prolix
 prologomena->prolegomena
+promatory->promontory
 prominance->prominence
 prominant->prominent
 prominantly->prominently
@@ -29276,6 +29510,9 @@ propperty->property
 proprely->properly
 propreties->properties
 proprety->property
+propriatery->proprietary
+proprieter->proprietor
+proprieters->proprietors
 proprietory->proprietary
 proproable->probable
 proproably->probably
@@ -29320,9 +29557,12 @@ protecte->protected, protect,
 protectiv->protective
 protectoin->protection
 protedcted->protected
+proteen->protein
 protential->potential
 protext->protect
 protocal->protocol
+protocall->protocol
+protocalls->protocols
 protocals->protocols
 protocl->protocol
 protocls->protocols
@@ -29450,6 +29690,8 @@ psueudo->pseudo
 psuh->push
 psychadelic->psychedelic
 psycology->psychology
+psydonym->pseudonym
+psydonyms->pseudonyms
 psyhic->psychic
 ptd->pdf
 ptherad->pthread
@@ -29532,6 +29774,8 @@ puls->pulse, plus,
 pumkin->pumpkin
 punctation->punctuation
 punctiation->punctuation
+pundent->pundit
+pundents->pundits
 puplar->popular
 puplarity->popularity
 puplate->populate
@@ -29554,6 +29798,7 @@ purpse->purpose
 pursuade->persuade
 pursuaded->persuaded
 pursuades->persuades
+purtain->pertain
 pusehd->pushed
 pususading->persuading
 puting->putting

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27192,8 +27192,10 @@ parrent->parent
 parsef->parsed, parser, parsec,
 parseing->parsing
 parsering->parsing
+parshal->partial
 parshally->partially
 parshaly->partially
+parsial->partial
 parsially->partially
 parsialy->partially
 parsin->parsing
@@ -27268,10 +27270,26 @@ partiular->particular
 partiularly->particularly
 partiulars->particulars
 pary->party, parry,
+pascheurisation->pasteurisation
 pascheurise->pasteurise
+pascheurised->pasteurised
+pascheurises->pasteurises
+pascheurising->pasteurising
+pascheurization->pasteurization
 pascheurize->pasteurize
+pascheurized->pasteurized
+pascheurizes->pasteurizes
+pascheurizing->pasteurizing
+paschurisation->pasteurisation
 paschurise->pasteurise
+paschurised->pasteurised
+paschurises->pasteurises
+paschurising->pasteurising
+paschurization->pasteurization
 paschurize->pasteurize
+paschurized->pasteurized
+paschurizes->pasteurizes
+paschurizing->pasteurizing
 pase->pass, pace, parse,
 pased->passed, parsed,
 pasengers->passengers
@@ -27310,8 +27328,16 @@ pasteries->pastries
 pastery->pastry
 pasttime->pastime
 pastural->pastoral
+pasturisation->pasteurisation
 pasturise->pasteurise
+pasturised->pasteurised
+pasturises->pasteurises
+pasturising->pasteurising
+pasturization->pasteurization
 pasturize->pasteurize
+pasturized->pasteurized
+pasturizes->pasteurizes
+pasturizing->pasteurizing
 pasword->password
 paswords->passwords
 patameter->parameter
@@ -27362,9 +27388,12 @@ peapel->people
 peapels->peoples
 peaple->people
 peaples->peoples
-pease->peace
+pease->peace, piece,
+peased->pieced
 peaseful->peaceful
 peasefully->peacefully
+peases->pieces
+peasing->piecing
 pecentage->percentage
 pecified->specified, pacified,
 pecularities->peculiarities
@@ -27380,6 +27409,8 @@ peedmonts->piedmonts
 peepel->people
 peepels->peoples
 peerowet->pirouette
+peerowetes->pirouettes
+peerowets->pirouettes
 pefer->prefer
 peferable->preferable
 peferably->preferably
@@ -27408,6 +27439,7 @@ peirods->periods
 Peloponnes->Peloponnese, Peloponnesus,
 penalities->penalties
 penality->penalty
+penatenturies->penitentiaries
 penatentury->penitentiary
 penatly->penalty
 pendantic->pedantic
@@ -27427,7 +27459,10 @@ pennensular->peninsular
 pennensulas->peninsulas
 penninsula->peninsula
 penninsular->peninsular
+penninsulas->peninsulas
 pennisula->peninsula
+pennisular->peninsular
+pennisulas->peninsulas
 Pennyslvania->Pennsylvania
 pensinula->peninsula
 pensle->pencil
@@ -27765,10 +27800,12 @@ perticipate->participate
 perticipated->participated
 perticipates->participates
 perticipating->participating
+perticipation->participation
 perticular->particular
 perticularly->particularly
 perticulars->particulars
 pertinate->pertinent
+pertinately->pertinently
 pertrub->perturb
 pertrubation->perturbation
 pertrubations->perturbations
@@ -27784,8 +27821,7 @@ perturbate->perturb
 perturbates->perturbs
 perturbe->perturb, perturbed,
 perview->preview, purview,
-perview->purview
-perviews->purviews
+perviews->previews, purviews,
 pervious->previous
 perviously->previously
 pessiary->pessary
@@ -27797,17 +27833,21 @@ pezier->bezier
 phanthom->phantom
 pharmaseudical->pharmaceutical
 pharmaseudically->pharmaceutical
+pharmaseudicals->pharmaceuticals
 pharmaseudicaly->pharmaceutical
 pharmaseutical->pharmaceutical
 pharmaseutically->pharmaceutical
+pharmaseuticals->pharmaceuticals
 pharmaseuticaly->pharmaceutical
 pharmasist->pharmacist
 pharmasists->pharmacists
 pharmasudical->pharmaceutical
 pharmasudically->pharmaceutical
+pharmasudicals->pharmaceuticals
 pharmasudicaly->pharmaceutical
 pharmasutical->pharmaceutical
 pharmasutically->pharmaceutical
+pharmasuticals->pharmaceuticals
 pharmasuticaly->pharmaceutical
 Pharoah->Pharaoh
 pharoh->Pharaoh
@@ -27837,6 +27877,11 @@ phisicaly->physically
 phisics->physics
 phisosophy->philosophy
 phlem->phlegm
+phlema->phlegma
+phlematic->phlegmatic
+phlematically->phlegmatically
+phlematous->phlegmatous
+phlemy->phlegmy
 Phonecian->Phoenecian
 phoneticly->phonetically
 phongraph->phonograph
@@ -27875,13 +27920,14 @@ piar->pair, pier, pliers,
 piars->pairs, piers, pliers,
 piblisher->publisher
 pice->piece
-pich->pitch
 pich->pitch, pick, pinch,
+piched->pitched, picked, pinched,
+piches->pitches, pinches,
+piching->pitching, picking, pinching,
 picknic->picnic
 pickniced->picnicked
 picknicer->picnicker
 picknicing->picnicking
-picknick->picnic
 picknicked->picnicked
 picknicker->picnicker
 picknicking->picnicking
@@ -27892,7 +27938,7 @@ pickyunes->picayunes
 picniced->picnicked
 picnicer->picnicker
 picnicing->picnicking
-picnick->picnic
+picnick->picnic, picknick,
 picnicks->picnics
 picoseond->picosecond
 picoseonds->picoseconds
@@ -27918,6 +27964,7 @@ pijuns->pigeons
 pilgram->pilgrim
 pilgramidge->pilgrimage
 pilgramig->pilgrimage
+pilgramige->pilgrimage
 pilgrimmage->pilgrimage
 pilgrimmages->pilgrimages
 pilon->pylon
@@ -27974,10 +28021,10 @@ placemet->placement, placemat, place mat,
 placemets->placements, placemats, place mats,
 placholder->placeholder
 placholders->placeholders
-plack->plaque
 placmenet->placement
 placmenets->placements
-plad->plaid
+plad->plaid, plead,
+pladed->plaided, pleaded,
 plaform->platform
 plaforms->platforms
 plaftorm->platform
@@ -28700,7 +28747,9 @@ preffixes->prefixes
 preffixing->prefixing
 prefices->prefixes
 preficiency->proficiency
+preficiensy->proficiency
 preficient->proficient
+preficiently->proficiently
 preficientsy->proficiency
 prefitler->prefilter
 prefitlered->prefiltered
@@ -29683,6 +29732,10 @@ pssed->passed
 pssibility->possibility
 psudo->pseudo
 psudoinverse->pseudoinverse
+psudonym->pseudonym
+psudonymity->pseudonymity
+psudonymous->pseudonymous
+psudonyms->pseudonyms
 psuedo->pseudo
 psuedo-fork->pseudo-fork
 psuedocode->pseudocode
@@ -29693,6 +29746,8 @@ psuh->push
 psychadelic->psychedelic
 psycology->psychology
 psydonym->pseudonym
+psydonymity->pseudonymity
+psydonymous->pseudonymous
 psydonyms->pseudonyms
 psyhic->psychic
 ptd->pdf
@@ -29801,6 +29856,9 @@ pursuade->persuade
 pursuaded->persuaded
 pursuades->persuades
 purtain->pertain
+purtained->pertained
+purtaining->pertaining
+purtains->pertains
 pusehd->pushed
 pususading->persuading
 puting->putting

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -275,6 +275,11 @@ organiser->organizer
 organisers->organizers
 organises->organizes
 organising->organizing
+pasteurisation->pasteurization
+pasteurise->pasteurize
+pasteurised->pasteurized
+pasteurises->pasteurizes
+pasteurising->pasteurizing
 penalise->penalize
 penalised->penalized
 penalises->penalizes

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -150,6 +150,7 @@ patters->patterns
 pavings->paving
 payed->paid
 plack->plaque
+placks->plaques
 planed->planned
 pleas->please
 predicable->predictable

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -149,6 +149,7 @@ patter->pattern
 patters->patterns
 pavings->paving
 payed->paid
+plack->plaque
 planed->planned
 pleas->please
 predicable->predictable


### PR DESCRIPTION
This replaces PR https://github.com/codespell-project/codespell/pull/1965. I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html