### PR TITLE
Typos from marvin.cs.uidaho.edu: Q

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -28933,9 +28933,12 @@ qtuie->quite, quiet,
 quadddec->quaddec
 quadranle->quadrangle
 quadraped->quadruped
+quadrapedal->quadrupedal
 quadrapeds->quadrupeds
 quadroople->quadruple
+quadroopled->quadrupled
 quadrooples->quadruples
+quadroopling->quadrupling
 quafeur->coiffure
 quafeured->coiffured
 quailified->qualified
@@ -29024,7 +29027,9 @@ quizes->quizzes
 quizs->quizzes
 quizzs->quizzes
 quoshant->quotient
+quoshants->quotients
 quotaion->quotation
+quotaions->quotations
 quoteed->quoted
 quotent->quotient
 quottes->quotes

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -29015,8 +29015,6 @@ quiest->quest, quiet,
 quiests->quests
 quikc->quick
 quinessential->quintessential
-quire->choir
-quires->choirs
 quitely->quite, quietly,
 quith->quit, with,
 quiting->quitting

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -28932,13 +28932,21 @@ qouting->quoting
 qtuie->quite, quiet,
 quadddec->quaddec
 quadranle->quadrangle
+quadraped->quadruped
+quadrapeds->quadrupeds
+quadroople->quadruple
+quadrooples->quadruples
+quafeur->coiffure
+quafeured->coiffured
 quailified->qualified
 qualfied->qualified
 qualfy->qualify
 qualifer->qualifier
 qualitification->qualification
 qualitifications->qualifications
+quanities->quantities
 quanitified->quantified
+quanity->quantity
 quanlification->qualification, quantification,
 quanlified->qualified, quantified,
 quanlifies->qualifies, quantifies,
@@ -28974,6 +28982,8 @@ querry->query, quarry,
 queryies->queries
 queryinterace->queryinterface
 querys->queries
+quesant->croissant
+quesants->croissants
 queset->quest
 quesets->quests
 quesiton->question
@@ -28982,7 +28992,11 @@ quesitons->questions
 quesr->quest
 quesrs->quests
 quess->guess, quests,
+quessant->croissant
+quessants->croissants
 questionaire->questionnaire
+questionare->questionnaire
+questionares->questionnaires
 questionnair->questionnaire
 questoin->question
 questoins->questions
@@ -29001,12 +29015,17 @@ quiest->quest, quiet,
 quiests->quests
 quikc->quick
 quinessential->quintessential
+quire->choir
+quires->choirs
 quitely->quite, quietly,
 quith->quit, with,
 quiting->quitting
 quitt->quit
 quitted->quit
 quizes->quizzes
+quizs->quizzes
+quizzs->quizzes
+quoshant->quotient
 quotaion->quotation
 quoteed->quoted
 quotent->quotient
@@ -29016,6 +29035,14 @@ quroum->quorum
 qust->quest
 qusts->quests
 qutie->quite, quiet,
+quwesant->croissant
+quwesants->croissants
+quwessant->croissant
+quwessants->croissants
+qwesant->croissant
+qwesants->croissants
+qwessant->croissant
+qwessants->croissants
 rabinnical->rabbinical
 racaus->raucous
 ractise->practise


### PR DESCRIPTION
This replaces PR https://github.com/codespell-project/codespell/pull/1966. I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html