### PR TITLE
Move `ifset->if set` to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -19334,7 +19334,6 @@ idividuals->individuals
 idons->icons
 iechart->piechart
 ifself->itself
-ifset->if set
 ignest->ingest
 ignested->ingested
 ignesting->ingesting

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -28,6 +28,7 @@ gae->game, Gael, gale,
 hist->heist, his,
 iam->I am, aim,
 iff->if
+ifset->if set
 isenough->is enough
 ith->with
 jupyter->Jupiter


### PR DESCRIPTION
`@ifset` is a texinfo keyword, so this gives too many false positives, especially in GNU projects.

See: https://www.gnu.org/software/texinfo/manual/texinfo/html_node/_0040ifset-_0040ifclear.html