### PR TITLE
Typos from marvin.cs.uidaho.edu: S

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32793,6 +32793,7 @@ sanwich->sandwich
 sanwiches->sandwiches
 sanytise->sanitise
 sanytize->sanitize
+sapeena->subpoena
 saphire->sapphire
 saphires->sapphires
 sargant->sergeant
@@ -33674,6 +33675,7 @@ seriouslly->seriously
 seriuos->serious
 serivce->service
 serivces->services
+seround->surround
 serrebral->cerebral
 serrebrally->cerebrally
 sersies->series
@@ -33851,6 +33853,7 @@ sheperedly->shepherdly
 shepereds->shepherds
 shepes->shapes
 sheping->shaping
+shepperd->shepherd
 shepre->sphere
 shepres->spheres
 sherif->sheriff
@@ -34002,6 +34005,7 @@ sigantures->signatures
 sigen->sign
 sighrynge->syringe
 sighrynges->syringes
+sighth->scythe
 sigificance->significance
 sigificant->significant
 siginificant->significant
@@ -34046,6 +34050,7 @@ signular->singular
 signularity->singularity
 sigrynge->syringe
 sigrynges->syringes
+siguret->cigarette
 silabus->syllabus
 silabuses->syllabuses
 silentely->silently
@@ -36427,6 +36432,7 @@ suseeds->secedes
 susepect->suspect
 suseptable->susceptible
 suseptible->susceptible
+susinct->succinct
 susinctly->succinctly
 susinkt->succinct
 suspedn->suspend

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32794,6 +32794,9 @@ sanwiches->sandwiches
 sanytise->sanitise
 sanytize->sanitize
 sapeena->subpoena
+sapeenad->subpoenaed
+sapeenaing->subpoenaing
+sapeenas->subpoenas
 saphire->sapphire
 saphires->sapphires
 sargant->sergeant
@@ -32801,9 +32804,11 @@ sargeant->sergeant
 sarimonial->ceremonial
 sarimonies->ceremonies
 sarimony->ceremony
+sarimonys->ceremonies
 sarinomial->ceremonial
 sarinomies->ceremonies
 sarinomy->ceremony
+sarinomys->ceremonies
 sart->start, star,
 sarted->started
 sarter->starter
@@ -32865,6 +32870,7 @@ savere->severe
 savety->safety
 savgroup->savegroup
 savve->save, savvy, salve,
+savves->saves, salves,
 savy->savvy
 sawtay->sauté
 sawtayed->sautéd
@@ -33356,7 +33362,9 @@ sensability->sensibility
 sensable->sensible
 sensably->sensibly
 sensative->sensitive
+sensativity->sensitivity
 sensetive->sensitive
+sensetivity->sensitivity
 sensisble->sensible
 sensistive->sensitive
 sensistively->sensitively, sensitivity,
@@ -33613,9 +33621,11 @@ seralizing->serializing
 seramonial->ceremonial
 seramonies->ceremonies
 seramony->ceremony
+seramonys->ceremonies
 seranomial->ceremonial
 seranomies->ceremonies
 seranomy->ceremony
+seranomys->ceremonies
 serch->search
 serched->searched
 serches->searches
@@ -33665,9 +33675,11 @@ serieses->series
 serimonial->ceremonial
 serimonies->ceremonies
 serimony->ceremony
+serimonys->ceremonies
 serinomial->ceremonial
 serinomies->ceremonies
 serinomy->ceremony
+serinomys->ceremonies
 serios->serious
 seriouly->seriously
 seriousally->seriously
@@ -33676,6 +33688,9 @@ seriuos->serious
 serivce->service
 serivces->services
 seround->surround
+serounded->surrounded
+serounding->surrounding
+serounds->surrounds
 serrebral->cerebral
 serrebrally->cerebrally
 sersies->series
@@ -33845,6 +33860,8 @@ sheilding->shielding
 sheilds->shields
 sheme->scheme, shame,
 shepard->shepherd
+sheparded->shepherded
+sheparding->shepherding
 shepards->shepherds
 shepe->shape
 sheped->shaped, shepherd,
@@ -33854,9 +33871,13 @@ shepereds->shepherds
 shepes->shapes
 sheping->shaping
 shepperd->shepherd
+shepperded->shepherded
+shepperding->shepherding
+shepperds->shepherds
 shepre->sphere
 shepres->spheres
 sherif->sheriff
+sherifs->sheriffs
 shfit->shift
 shfited->shifted
 shfiting->shifting
@@ -34005,7 +34026,8 @@ sigantures->signatures
 sigen->sign
 sighrynge->syringe
 sighrynges->syringes
-sighth->scythe
+sighth->scythe, sight,
+sighths->scythes, sights,
 sigificance->significance
 sigificant->significant
 siginificant->significant
@@ -34051,6 +34073,10 @@ signularity->singularity
 sigrynge->syringe
 sigrynges->syringes
 siguret->cigarette
+sigurete->cigarette
+siguretes->cigarettes
+sigurets->cigarettes
+sigurette->cigarette
 silabus->syllabus
 silabuses->syllabuses
 silentely->silently
@@ -34059,10 +34085,12 @@ silhouete->silhouette
 silhoueted->silhouetted
 silhouetes->silhouettes
 silhoueting->silhouetting
+silhouetist->silhouettist
 silhouwet->silhouette
 silhouweted->silhouetted
 silhouwetes->silhouettes
 silhouweting->silhouetting
+silhouwetist->silhouettist
 silibus->syllabus
 silibuses->syllabuses
 siliently->silently, saliently,
@@ -34077,6 +34105,7 @@ silouete->silhouette
 siloueted->silhouetted
 silouetes->silhouettes
 siloueting->silhouetting
+silouetist->silhouettist
 silouhette->silhouette
 silouhetted->silhouetted
 silouhettes->silhouettes
@@ -34085,10 +34114,12 @@ silouwet->silhouette
 silouweted->silhouetted
 silouwetes->silhouettes
 silouweting->silhouetting
+silouwetist->silhouettist
 silowet->silhouette
 siloweted->silhouetted
 silowetes->silhouettes
 siloweting->silhouetting
+silowetist->silhouettist
 silybus->syllabus
 silybuses->syllabuses
 simeple->simple
@@ -34251,12 +34282,18 @@ singuarl->singular
 singulat->singular
 singulaties->singularities
 sinic->cynic
+sinical->cynical
+sinically->cynically
+sinicaly->cynically
 sinics->cynics
 sinlge->single
 sinlges->singles
 sinnagog->synagogue
 sinnagogs->synagogues
 sinnic->cynic
+sinnical->cynical
+sinnically->cynically
+sinnicaly->cynically
 sinnics->cynics
 sinply->simply
 sinse->sines, since,
@@ -34297,12 +34334,19 @@ sirectory->directory
 sirects->directs
 siringe->syringe
 siringes->syringes
+sirvayl->surveil
+sirvayled->surveiled
 sirvaylence->surveillance
+sirvayles->surveils
+sirvayling->surveiling
+sirvayls->surveils
 sirynge->syringe
 sirynges->syringes
 sise->size, sisal,
 sisnce->since
 sisser->scissor
+sissered->scissored
+sissering->scissoring
 sissers->scissors
 sist->cyst
 sistem->system
@@ -34357,14 +34401,18 @@ situtation->situation
 situtations->situations
 siutable->suitable
 siute->suite
-sive->sieve
-sives->sieves
+sive->sieve, save,
+sived->sieved, saved,
+sives->sieves, saves,
 sivible->visible
+siving->sieving, saving,
 siwtch->switch
 siwtched->switched
 siwtching->switching
 Sixtin->Sistine, Sixteen,
 siz->size, six,
+sizemologist->seismologist
+sizemologists->seismologists
 sizemologogical->seismological
 sizemologogically->seismologically
 sizemology->seismology
@@ -34397,6 +34445,7 @@ skippped->skipped
 skippps->skips
 skipt->skip, Skype, skipped,
 skitsofrinic->schizophrenic
+skitsofrinics->schizophrenics
 skool->school
 skooled->schooled
 skooling->schooling
@@ -34498,6 +34547,8 @@ socripted->scripted
 socripting->scripting
 socripts->scripts
 sodder->solder
+soddered->soldered
+soddering->soldering
 sodders->solders
 sodo->sudo, soda, sod, sods, dodo, solo,
 sodu->sudo, soda, sod, sods,
@@ -34530,6 +34581,8 @@ solated->isolated
 solates->isolates
 solating->isolating
 soldger->soldier
+soldgered->soldiered
+soldgering->soldiering
 soldgers->soldiers
 soler->solver, solar, solely,
 soley->solely
@@ -34540,6 +34593,8 @@ solfes->solves
 solfing->solving
 solfs->solves
 solger->soldier
+solgered->soldiered
+solgering->soldiering
 solgers->soldiers
 soliders->soldiers
 solification->solidification
@@ -35461,6 +35516,7 @@ stawk->stalk
 stcokbrush->stockbrush
 stdanard->standard
 stdanards->standards
+stegnographic->steganographic
 stegnography->steganography
 stength->strength
 steram->stream
@@ -36414,11 +36470,12 @@ susbsystem->subsystem
 susbsystems->subsystems
 susbsytem->subsystem
 susbsytems->subsystems
-suscede->secede
-susceded->seceded
+suscede->secede, succeed,
+susceded->seceded, succeeded,
 susceder->seceder
-suscedes->secedes
-susceding->seceding
+susceders->seceders
+suscedes->secedes, succeeds,
+susceding->seceding, succeeding,
 suscribe->subscribe
 suscribed->subscribed
 suscribes->subscribes

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32721,6 +32721,10 @@ rythmic->rhythmic
 rythyms->rhythms
 saame->same
 sabatage->sabotage
+sabatosh->sabotage
+sabatoshed->sabotaged
+sabatoshes->sabotages
+sabatoshing->sabotaging
 sabatour->saboteur
 sacalar->scalar
 sacalars->scalars
@@ -32793,6 +32797,12 @@ saphire->sapphire
 saphires->sapphires
 sargant->sergeant
 sargeant->sergeant
+sarimonial->ceremonial
+sarimonies->ceremonies
+sarimony->ceremony
+sarinomial->ceremonial
+sarinomies->ceremonies
+sarinomy->ceremony
 sart->start, star,
 sarted->started
 sarter->starter
@@ -32840,6 +32850,11 @@ saturdey->Saturday
 satursday->Saturday
 satus->status
 saught->sought
+sautay->sauté
+sautayed->sautéd
+sautayes->sautés
+sautaying->sautéing
+sautays->sautés
 sav->save
 savees->saves
 saveing->saving
@@ -32850,8 +32865,24 @@ savety->safety
 savgroup->savegroup
 savve->save, savvy, salve,
 savy->savvy
+sawtay->sauté
+sawtayed->sautéd
+sawtayes->sautés
+sawtaying->sautéing
+sawtays->sautés
+sawte->sauté
+sawteed->sautéd
+sawtees->sautés
+sawteing->sautéing
+sawtes->sautés
 saxaphone->saxophone
 sbsampling->subsampling
+scafold->scaffold
+scafolded->scaffolded
+scafolder->scaffolder
+scafoldes->scaffolds
+scafolding->scaffolding
+scafolds->scaffolds
 scahr->schar
 scalarr->scalar
 scaleability->scalability
@@ -32893,6 +32924,8 @@ sceen->scene, seen, screen, scheme,
 sceens->scenes, screens, schemes,
 sceme->scheme, scene,
 scemes->schemes, scenes,
+scenaireo->scenario
+scenaireos->scenarios
 scenarion->scenario
 scenarions->scenarios
 scence->scene, science, sense,
@@ -33158,6 +33191,10 @@ securuity->security
 sedereal->sidereal
 seeem->seem
 seeen->seen
+seege->siege
+seeged->sieged
+seeges->sieges
+seeging->sieging
 seelect->select
 seelected->selected
 seemes->seems
@@ -33169,6 +33206,12 @@ seeting->seating, setting, seething,
 seetings->settings
 seeverities->severities
 seeverity->severity
+seez->seize
+seezed->seized
+seezes->seizes
+seezing->seizing
+seezure->seizure
+seezures->seizures
 segault->segfault
 segaults->segfaults
 segement->segment
@@ -33197,8 +33240,12 @@ segmetned->segmented
 segmetns->segments
 segument->segment
 seguoys->segues
+segway->segue
+segwayed->segued
+segwaying->segueing
 seh->she
 seige->siege
+seina->sienna
 seing->seeing
 seinor->senior
 seires->series
@@ -33282,10 +33329,14 @@ sempaphores->semaphores
 semphore->semaphore
 semphores->semaphores
 sempphore->semaphore
+senaireo->scenario
+senaireos->scenarios
 senaphore->semaphore
 senaphores->semaphores
 senario->scenario
 senarios->scenarios
+senarreo->scenario
+senarreos->scenarios
 sence->sense, since,
 sencond->second
 sencondary->secondary
@@ -33300,6 +33351,9 @@ senintels->sentinels
 senitnel->sentinel
 senitnels->sentinels
 senquence->sequence
+sensability->sensibility
+sensable->sensible
+sensably->sensibly
 sensative->sensitive
 sensetive->sensitive
 sensisble->sensible
@@ -33323,6 +33377,8 @@ sensure->censure
 sentance->sentence
 sentances->sentences
 senteces->sentences
+sentenal->sentinel
+sentenals->sentinels
 sentense->sentence
 sentienl->sentinel
 sentinal->sentinel
@@ -33467,6 +33523,10 @@ sepetated->separated
 sepetately->separately
 sepetates->separates
 sepina->subpoena
+seplicural->sepulchral
+seplicurally->sepulchrally
+seplicuraly->sepulchrally
+seplicurlly->sepulchrally
 seporate->separate
 sepparation->separation
 sepparations->separations
@@ -33478,6 +33538,9 @@ seprated->separated
 seprator->separator
 seprators->separators
 Septemer->September
+sepulchraly->sepulchrally
+sepulchrlly->sepulchrally
+sepulchrly->sepulchrally
 sepulchure->sepulchre, sepulcher,
 sepulcre->sepulchre, sepulcher,
 seqence->sequence
@@ -33546,6 +33609,12 @@ seralize->serialize
 seralized->serialized
 seralizes->serializes
 seralizing->serializing
+seramonial->ceremonial
+seramonies->ceremonies
+seramony->ceremony
+seranomial->ceremonial
+seranomies->ceremonies
+seranomy->ceremony
 serch->search
 serched->searched
 serches->searches
@@ -33554,9 +33623,17 @@ sercive->service
 sercived->serviced
 sercives->services
 serciving->servicing
+serebral->cerebral
+serebrally->cerebrally
+sereous->serious
+sereousally->seriously
+sereouslly->seriously
+sereously->seriously
 sereverless->serverless
 serevrless->serverless
 sergent->sergeant
+sergun->surgeon
+serguns->surgeons
 serialialisation->serialisation
 serialialise->serialise
 serialialised->serialised
@@ -33584,11 +33661,21 @@ serices->services, series,
 serie->series
 seriel->serial
 serieses->series
+serimonial->ceremonial
+serimonies->ceremonies
+serimony->ceremony
+serinomial->ceremonial
+serinomies->ceremonies
+serinomy->ceremony
 serios->serious
 seriouly->seriously
+seriousally->seriously
+seriouslly->seriously
 seriuos->serious
 serivce->service
 serivces->services
+serrebral->cerebral
+serrebrally->cerebrally
 sersies->series
 sertificate->certificate
 sertificated->certificated
@@ -33629,6 +33716,17 @@ servoced->serviced
 servoces->services
 servocing->servicing
 serwer->server, sewer,
+sescede->secede
+sesceded->seceded
+sesceder->seceder
+sescedes->secedes
+sesceding->seceding
+seseed->secede
+seseeded->seceded
+seseeder->seceder
+seseedes->secedes
+seseeding->seceding
+seseeds->secedes
 sesion->session
 sesions->sessions
 sesitive->sensitive
@@ -33723,7 +33821,8 @@ sharloton->charlatan
 sharraid->charade
 sharraids->charades
 shashes->slashes
-shatow->château
+shatow->château, châteaux,
+shatows->châteaus, châteauxs,
 shbang->shebang
 sheat->sheath, sheet, cheat,
 sheck->check, cheque, shuck,
@@ -33743,6 +33842,8 @@ sheilded->shielded
 sheilding->shielding
 sheilds->shields
 sheme->scheme, shame,
+shepard->shepherd
+shepards->shepherds
 shepe->shape
 sheped->shaped, shepherd,
 shepered->shepherd
@@ -33874,6 +33975,8 @@ sibtitle->subtitle
 sibtitles->subtitles
 sicinct->succinct
 sicinctly->succinctly
+sickamore->sycamore
+sickamores->sycamores
 sicne->since
 sidde->side
 sideral->sidereal
@@ -33897,6 +34000,8 @@ sigals->signals, sigils,
 siganture->signature
 sigantures->signatures
 sigen->sign
+sighrynge->syringe
+sighrynges->syringes
 sigificance->significance
 sigificant->significant
 siginificant->significant
@@ -33939,14 +34044,54 @@ signto->sign to
 signul->signal
 signular->singular
 signularity->singularity
+sigrynge->syringe
+sigrynges->syringes
+silabus->syllabus
+silabuses->syllabuses
 silentely->silently
 silenty->silently
+silhouete->silhouette
+silhoueted->silhouetted
+silhouetes->silhouettes
+silhoueting->silhouetting
+silhouwet->silhouette
+silhouweted->silhouetted
+silhouwetes->silhouettes
+silhouweting->silhouetting
+silibus->syllabus
+silibuses->syllabuses
 siliently->silently, saliently,
+sillabus->syllabus
+sillabuses->syllabuses
+sillibus->syllabus
+sillibuses->syllabuses
+sillybus->syllabus
+sillybuses->syllabuses
+silouet->silhouette
+silouete->silhouette
+siloueted->silhouetted
+silouetes->silhouettes
+siloueting->silhouetting
 silouhette->silhouette
 silouhetted->silhouetted
 silouhettes->silhouettes
 silouhetting->silhouetting
+silouwet->silhouette
+silouweted->silhouetted
+silouwetes->silhouettes
+silouweting->silhouetting
+silowet->silhouette
+siloweted->silhouetted
+silowetes->silhouettes
+siloweting->silhouetting
+silybus->syllabus
+silybuses->syllabuses
 simeple->simple
+simetric->symmetric
+simetrical->symmetrical
+simetricaly->symmetrically
+simetriclly->symmetrically
+simetricly->symmetrically
 simetrie->symmetry
 simetries->symmetries
 simgle->single
@@ -33980,6 +34125,9 @@ simlifying->simplifying
 simly->simply, simile, smiley,
 simmetric->symmetric
 simmetrical->symmetrical
+simmetricaly->symmetrically
+simmetriclly->symmetrically
+simmetricly->symmetrically
 simmetry->symmetry
 simmilar->similar
 simpification->simplification
@@ -34002,6 +34150,20 @@ simpliifcation->simplification
 simpliifcations->simplifications
 simplist->simplest
 simpliy->simply, simplify,
+simptom->symptom
+simptomatic->symptomatic
+simptomatically->symptomatically
+simptomaticaly->symptomatically
+simptomaticlly->symptomatically
+simptomaticly->symptomatically
+simptoms->symptoms
+simptum->symptom
+simptumatic->symptomatic
+simptumatically->symptomatically
+simptumaticaly->symptomatically
+simptumaticlly->symptomatically
+simptumaticly->symptomatically
+simptums->symptoms
 simpy->simply
 simualte->simulate
 simualted->simulated
@@ -34037,6 +34199,8 @@ simultanous->simultaneous
 simultanously->simultaneously
 simulteniously->simultaneously
 simutaneously->simultaneously
+sinagog->synagogue
+sinagogs->synagogues
 sinature->signature
 sincerley->sincerely
 sincerly->sincerely
@@ -34056,6 +34220,7 @@ singificand->significand, significant,
 singl->single
 singlar->singular
 single-threded->single-threaded
+singlely->singly
 singls->singles, single,
 singlton->singleton
 singltons->singletons
@@ -34080,8 +34245,14 @@ singuarity->singularity
 singuarl->singular
 singulat->singular
 singulaties->singularities
+sinic->cynic
+sinics->cynics
 sinlge->single
 sinlges->singles
+sinnagog->synagogue
+sinnagogs->synagogues
+sinnic->cynic
+sinnics->cynics
 sinply->simply
 sinse->sines, since,
 sintac->syntax
@@ -34119,8 +34290,16 @@ sirectories->directories
 sirectors->directors
 sirectory->directory
 sirects->directs
+siringe->syringe
+siringes->syringes
+sirvaylence->surveillance
+sirynge->syringe
+sirynges->syringes
 sise->size, sisal,
 sisnce->since
+sisser->scissor
+sissers->scissors
+sist->cyst
 sistem->system
 sistematically->systematically
 sistematics->systematics
@@ -34140,6 +34319,7 @@ sistemized->systemized
 sistemizes->systemizes
 sistemizing->systemizing
 sistems->systems
+sists->cysts
 sitation->situation
 sitations->situations
 sitaution->situation
@@ -34172,12 +34352,19 @@ situtation->situation
 situtations->situations
 siutable->suitable
 siute->suite
+sive->sieve
+sives->sieves
 sivible->visible
 siwtch->switch
 siwtched->switched
 siwtching->switching
 Sixtin->Sistine, Sixteen,
 siz->size, six,
+sizemologogical->seismological
+sizemologogically->seismologically
+sizemology->seismology
+sizor->sizer, scissor,
+sizors->sizers, scissors,
 sizre->size
 Skagerak->Skagerrak
 skalar->scalar
@@ -34204,7 +34391,20 @@ skippd->skipped
 skippped->skipped
 skippps->skips
 skipt->skip, Skype, skipped,
+skitsofrinic->schizophrenic
+skool->school
+skooled->schooled
+skooling->schooling
+skools->schools
 skopped->skipped, shopped, slopped, stopped,
+skurge->scourge
+skurged->scourged
+skurges->scourges
+skurging->scourging
+skwalk->squawk
+skwalked->squawked
+skwalking->squawking
+skwalks->squawks
 skyp->skip, Skype,
 slac->slack
 slach->slash
@@ -34222,6 +34422,10 @@ slection->selection
 sleect->select
 sleeped->slept
 sleepp->sleep
+slewth->sleuth
+slewthed->sleuthed
+slewthing->sleuthing
+slewths->sleuths
 slicable->sliceable
 slient->silent
 sliently->silently
@@ -34236,6 +34440,11 @@ sligthly->slightly
 sligtly->slightly
 sliped->slipped
 sliseshow->slideshow
+slite->sleight
+slooth->sleuth
+sloothed->sleuthing
+sloothing->sleuthing
+slooths->sleuths
 slowy->slowly
 slq->sql
 sluggify->slugify
@@ -34283,6 +34492,8 @@ socript->script
 socripted->scripted
 socripting->scripting
 socripts->scripts
+sodder->solder
+sodders->solders
 sodo->sudo, soda, sod, sods, dodo, solo,
 sodu->sudo, soda, sod, sods,
 soecialize->specialized
@@ -34290,6 +34501,10 @@ soem->some
 soemthing->something
 soemwhere->somewhere
 sofisticated->sophisticated
+sofmore->sophomore
+sofmores->sophomores
+sofomore->sophomore
+sofomores->sophomores
 softend->softened
 softwade->software
 softwares->software
@@ -34302,11 +34517,15 @@ soiurce->source
 soket->socket
 sokets->sockets
 solarmutx->solarmutex
+solataire->solitaire
+solatare->solitaire
 solatary->solitary
 solate->isolate
 solated->isolated
 solates->isolates
 solating->isolating
+soldger->soldier
+soldgers->soldiers
 soler->solver, solar, solely,
 soley->solely
 solf->solve, sold,
@@ -34315,6 +34534,8 @@ solfer->solver, solder,
 solfes->solves
 solfing->solving
 solfs->solves
+solger->soldier
+solgers->soldiers
 soliders->soldiers
 solification->solidification
 soliliquy->soliloquy
@@ -34382,11 +34603,18 @@ soodonim->pseudonym
 sooit->suet, suit, soot,
 soop->soup, scoop, snoop, soap,
 soource->source
+soovinear->souvenir
+soovinears->souvenirs
+soovineer->souvenir
+soovineers->souvenirs
+soovinneer->souvenir
+soovinneers->souvenirs
 sophicated->sophisticated
 sophisicated->sophisticated
 sophisitcated->sophisticated
 sophisticted->sophisticated
 sophmore->sophomore
+sophmores->sophomores
 sopund->sound
 sopunded->sounded
 sopunding->sounding
@@ -34427,6 +34655,7 @@ soultion->solution
 soultions->solutions
 soundard->soundcard
 sountrack->soundtrack
+sourbraten->sauerbraten
 sourc->source
 sourcd->sourced, source,
 sourcde->sourced, source,
@@ -34445,6 +34674,12 @@ sourthern->southern
 southbrige->southbridge
 souvenier->souvenir
 souveniers->souvenirs
+souvinear->souvenir
+souvinears->souvenirs
+souvineer->souvenir
+souvineers->souvenirs
+souvinneer->souvenir
+souvinneers->souvenirs
 soveits->soviets
 sover->solver
 sovereignity->sovereignty
@@ -35221,6 +35456,7 @@ stawk->stalk
 stcokbrush->stockbrush
 stdanard->standard
 stdanards->standards
+stegnography->steganography
 stength->strength
 steram->stream
 steramed->streamed
@@ -36173,10 +36409,21 @@ susbsystem->subsystem
 susbsystems->subsystems
 susbsytem->subsystem
 susbsytems->subsystems
+suscede->secede
+susceded->seceded
+susceder->seceder
+suscedes->secedes
+susceding->seceding
 suscribe->subscribe
 suscribed->subscribed
 suscribes->subscribes
 suscript->subscript
+suseed->secede
+suseeded->seceded
+suseeder->seceder
+suseedes->secedes
+suseeding->seceding
+suseeds->secedes
 susepect->suspect
 suseptable->susceptible
 suseptible->susceptible
@@ -36191,6 +36438,12 @@ suspicous->suspicious
 suspicously->suspiciously
 suspision->suspicion
 suspsend->suspend
+susseed->secede
+susseeded->seceded
+susseeder->seceder
+susseedes->secedes
+susseeding->seceding
+susseeds->secedes
 sussinct->succinct
 sustainaiblity->sustainability
 sustem->system
@@ -36355,6 +36608,13 @@ symobolic->symbolic
 symobolical->symbolical
 symol->symbol
 symols->symbols
+symptum->symptom
+symptumatic->symptomatic
+symptumatically->symptomatically
+symptumaticaly->symptomatically
+symptumaticlly->symptomatically
+symptumaticly->symptomatically
+symptums->symptoms
 synagouge->synagogue
 synamic->dynamic
 synax->syntax

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -33252,7 +33252,7 @@ segwayed->segued
 segwaying->segueing
 seh->she
 seige->siege
-seina->sienna
+seina->sienna, seine,
 seing->seeing
 seinor->senior
 seires->series
@@ -33636,7 +33636,7 @@ sercives->services
 serciving->servicing
 serebral->cerebral
 serebrally->cerebrally
-sereous->serious
+sereous->serious, serous,
 sereousally->seriously
 sereouslly->seriously
 sereously->seriously
@@ -33838,8 +33838,8 @@ sharloton->charlatan
 sharraid->charade
 sharraids->charades
 shashes->slashes
-shatow->château, châteaux,
-shatows->châteaus, châteauxs,
+shatow->shadow, château, châteaux,
+shatows->shadows, châteaux, châteaus,
 shbang->shebang
 sheat->sheath, sheet, cheat,
 sheck->check, cheque, shuck,
@@ -34281,7 +34281,7 @@ singuarity->singularity
 singuarl->singular
 singulat->singular
 singulaties->singularities
-sinic->cynic
+sinic->cynic, sonic,
 sinical->cynical
 sinically->cynically
 sinicaly->cynically
@@ -34344,11 +34344,11 @@ sirynge->syringe
 sirynges->syringes
 sise->size, sisal,
 sisnce->since
-sisser->scissor
+sisser->scissor, sister, sissier,
 sissered->scissored
 sissering->scissoring
-sissers->scissors
-sist->cyst
+sissers->scissors, sisters,
+sist->cyst, sits, sift,
 sistem->system
 sistematically->systematically
 sistematics->systematics
@@ -34368,7 +34368,7 @@ sistemized->systemized
 sistemizes->systemizes
 sistemizing->systemizing
 sistems->systems
-sists->cysts
+sists->cysts, sifts, sits,
 sitation->situation
 sitations->situations
 sitaution->situation
@@ -34494,8 +34494,8 @@ sligthly->slightly
 sligtly->slightly
 sliped->slipped
 sliseshow->slideshow
-slite->sleight
-slooth->sleuth
+slite->sleight, elite, slide, site,
+slooth->sleuth, sloth, sooth,
 sloothed->sleuthing
 sloothing->sleuthing
 slooths->sleuths

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -363,6 +363,8 @@ sterilised->sterilized
 steriliser->sterilizer
 sterilises->sterilizes
 sterilising->sterilizing
+storey->story
+storeys->stories
 summarise->summarize
 summarised->summarized
 summarises->summarizes


### PR DESCRIPTION
This replaces PR https://github.com/codespell-project/codespell/pull/1968. I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html