### PR TITLE
Typos from marvin.cs.uidaho.edu: T

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -35801,6 +35801,10 @@ teahers->teachers
 teamplate->template
 teamplates->templates
 teated->treated
+teatotaler->teetotaler
+teatotalers->teetotalers
+teatotler->teetotaler
+teatotlers->teetotalers
 teched->taught
 techer->teacher
 techers->teachers
@@ -35840,6 +35844,8 @@ tecnicians->technicians
 tecnique->technique
 tecniques->techniques
 tedeous->tedious
+teetotler->teetotaler
+teetotlers->teetotalers
 tefine->define
 teh->the
 tehnically->technically
@@ -36537,6 +36543,7 @@ toolsbox->toolbox
 toom->tomb
 tooo->todo, too, tool, took,
 toos->tools
+Toosday->Tuesday
 tootonic->teutonic
 topicaizer->topicalizer
 topologie->topology
@@ -36552,6 +36559,7 @@ tortilini->tortellini
 tortise->tortoise
 torward->toward
 torwards->towards
+Tosday->Tuesday, today,
 totaly->totally
 totat->total
 totation->rotation
@@ -37057,7 +37065,12 @@ trempoline->trampoline
 treshhold->threshold
 treshold->threshold
 tressle->trestle
+tresure->treasure
+tresures->treasures
 treting->treating
+trew->true
+trewthful->truthful
+trewthfully->truthfully
 trgistration->registration
 trhe->the
 trhough->through
@@ -37076,6 +37089,8 @@ trianing->training
 trianlge->triangle
 trianlges->triangles
 trians->trains
+triathalon->triathlon
+triathalons->triathlons
 triger->trigger, tiger,
 trigered->triggered
 trigerred->triggered
@@ -37088,6 +37103,7 @@ triggerred->triggered
 triggerring->triggering
 triggerrs->triggers
 triggger->trigger
+trignametric->trigonometric
 trignometric->trigonometric
 trignometry->trigonometry
 triguered->triggered
@@ -37104,6 +37120,8 @@ trimmng->trimming
 trinagle->triangle
 trinagles->triangles
 tring->trying, string, ring,
+tringket->trinket
+tringkets->trinkets
 trings->strings, rings,
 triniy->trinity
 triology->trilogy
@@ -37111,6 +37129,22 @@ tripel->triple
 tripeld->tripled
 tripels->triples
 tripple->triple
+triptick->triptych
+triptickes->triptychs
+tripticks->triptychs
+triptish->triptych
+triptishes->triptychs
+triptishs->triptychs
+triscadecafobia->triskaidekaphobia
+triscadecaphobia->triskaidekaphobia
+triscaidecafobia->triskaidekaphobia
+triscaidecaphobia->triskaidekaphobia
+triscaidekafobia->triskaidekaphobia
+triscaidekaphobia->triskaidekaphobia
+triskadecafobia->triskaidekaphobia
+triskadecaphobia->triskaidekaphobia
+triskadekafobia->triskaidekaphobia
+triskadekaphobia->triskaidekaphobia
 triuangulate->triangulate
 trival->trivial
 trivally->trivially
@@ -37123,10 +37157,29 @@ trnasmits->transmits
 trnsfer->transfer
 trnsfered->transferred
 trnsfers->transfers
+trogladite->troglodyte
+trogladitic->troglodytic
+trogladitical->troglodytical
+trogladitism->troglodytism
+troglidite->troglodyte
+trogliditic->troglodytic
+trogliditical->troglodytical
+trogliditism->troglodytism
+troglodite->troglodyte
+trogloditic->troglodytic
+trogloditical->troglodytical
+trogloditism->troglodytism
 troling->trolling
+trolly->trolley
+trooso->trousseau
+troosos->trousseaux, trousseaus,
+troosso->trousseau
+troossos->trousseaux, trousseaus,
 trottle->throttle
 trottled->throttled, trotted,
 trottling->throttling, trotting,
+troubador->troubadour
+troubadors->troubadours
 troubeshoot->troubleshoot
 troubeshooted->troubleshooted
 troubeshooter->troubleshooter
@@ -37149,6 +37202,10 @@ trrigger->trigger
 trriggered->triggered
 trriggering->triggering
 trriggers->triggers
+trubador->troubadour
+trubadors->troubadours
+trubadour->troubadour
+trubadours->troubadours
 trubble->trouble
 trubbled->troubled
 trubbles->troubles
@@ -37166,6 +37223,9 @@ trucnating->truncating
 truct->struct
 truelly->truly
 truely->truly
+truged->trudged
+trugged->trudged, tugged,
+truging->trudging
 truied->tried
 trully->truly
 trun->turn
@@ -37193,12 +37253,18 @@ trys->tries
 tryying->trying
 ttests->tests
 tthe->the
+tucan->toucan
+tucans->toucans
 tuesdey->Tuesday
 tuesdsy->Tuesday
 tufure->future
 tuhmbnail->thumbnail
 tunelled->tunnelled
 tunelling->tunneling
+tung->tongue
+tunges->tongues
+tungs->tongues
+tungues->tongues
 tunned->tuned
 tunnell->tunnel
 tunning->tuning, running,
@@ -37207,12 +37273,18 @@ tuotirals->tutorials
 tupel->tuple
 tupple->tuple
 tupples->tuples
+turain->terrain
+turains->terrains
+turcoise->turquoise
 ture->true, pure,
+turkoise->turquoise
 turle->turtle
 turly->truly
 turnk->trunk, turnkey, turn,
 turorial->tutorial
 turorials->tutorials
+turrain->terrain
+turrains->terrains
 turtleh->turtle
 turtlehs->turtles
 turtorial->tutorial
@@ -37232,6 +37304,7 @@ twodimenional->two-dimensional
 twodimenionsal->two-dimensional
 twon->town
 twoo->two, too,
+Twosday->Tuesday
 twpo->two
 tye->type, tie,
 tyep->type

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -36384,7 +36384,6 @@ thumbbnail->thumbnail
 thumbnal->thumbnail
 thumbnals->thumbnails
 thundebird->thunderbird
-thur->their
 thurday->Thursday
 thurough->thorough
 thurrow->thorough
@@ -37068,9 +37067,12 @@ treshhold->threshold
 treshold->threshold
 tressle->trestle
 tresure->treasure
+tresured->treasured
+tresurer->treasurer
 tresures->treasures
+tresuring->treasuring
 treting->treating
-trew->true
+trew->true, threw,
 trewthful->truthful
 trewthfully->truthfully
 trgistration->registration
@@ -37106,6 +37108,7 @@ triggerring->triggering
 triggerrs->triggers
 triggger->trigger
 trignametric->trigonometric
+trignametry->trigonometry
 trignometric->trigonometric
 trignometry->trigonometry
 triguered->triggered
@@ -37160,19 +37163,23 @@ trnsfer->transfer
 trnsfered->transferred
 trnsfers->transfers
 trogladite->troglodyte
+trogladites->troglodytes
 trogladitic->troglodytic
 trogladitical->troglodytical
 trogladitism->troglodytism
 troglidite->troglodyte
+troglidites->troglodytes
 trogliditic->troglodytic
 trogliditical->troglodytical
 trogliditism->troglodytism
 troglodite->troglodyte
+troglodites->troglodytes
 trogloditic->troglodytic
 trogloditical->troglodytical
 trogloditism->troglodytism
 troling->trolling
 trolly->trolley
+trollys->trolleys
 trooso->trousseau
 troosos->trousseaux, trousseaus,
 troosso->trousseau

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -36273,6 +36273,7 @@ thnig->thing
 thnigs->things
 thoese->those, these,
 thonic->chthonic
+thorasic->thoracic
 thoroidal->toroidal
 thoroughty->thoroughly
 thorugh->through, thorough,
@@ -36383,6 +36384,7 @@ thumbbnail->thumbnail
 thumbnal->thumbnail
 thumbnals->thumbnails
 thundebird->thunderbird
+thur->their
 thurday->Thursday
 thurough->thorough
 thurrow->thorough


### PR DESCRIPTION
This replaces PR https://github.com/codespell-project/codespell/pull/1969. I've added in several variations myself.

See: http://marvin.cs.uidaho.edu/misspell.html