### PR TITLE
Typos from marvin.cs.uidaho.edu: U

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -37790,7 +37790,19 @@ unambigous->unambiguous
 unambigously->unambiguously
 unamed->unnamed
 unanimuous->unanimous
+unanimuously->unanimously
+unannimous->unanimous
+unannimously->unanimously
+unannomous->unanimous
+unannomously->unanimously
+unannomus->unanimous
+unannomusly->unanimously
+unanomous->unanimous
+unanomously->unanimously
+unanomus->unanimous
+unanomusly->unanimously
 unanymous->unanimous
+unanymously->unanimously
 unappretiated->unappreciated
 unappretiative->unappreciative
 unapprieciated->unappreciated
@@ -38026,6 +38038,7 @@ undorder->unorder
 undordered->unordered
 undoubtely->undoubtedly
 undreground->underground
+unduely->unduly
 undupplicated->unduplicated
 uneccesary->unnecessary
 uneccessarily->unnecessarily
@@ -38142,6 +38155,8 @@ unhilighted->unhighlighted
 unhilights->unhighlights
 Unicde->Unicode
 unich->unix
+unick->eunuch, unix,
+unicks->eunuchs
 unidentifiedly->unidentified
 unidimensionnal->unidimensional
 unifform->uniform
@@ -38268,6 +38283,7 @@ unkonwns->unknowns
 unkown->unknown
 unkowns->unknowns
 unkwown->unknown
+unlabled->unlabeled
 unlcear->unclear
 unleess->unless, unleash,
 unles->unless

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22156,9 +22156,9 @@ kyeboshing->kiboshing
 kyrillic->cyrillic
 labatory->lavatory, laboratory,
 labbel->label
-labbeled->labeled
+labbeled->labeled, labelled,
 labbels->labels
-labed->labeled
+labed->labeled, labelled,
 labeld->labelled
 labirinth->labyrinth
 lable->label
@@ -38283,7 +38283,7 @@ unkonwns->unknowns
 unkown->unknown
 unkowns->unknowns
 unkwown->unknown
-unlabled->unlabeled
+unlabled->unlabeled, unlabelled,
 unlcear->unclear
 unleess->unless, unleash,
 unles->unless


### PR DESCRIPTION
This replaces PR https://github.com/codespell-project/codespell/pull/1970.

See: http://marvin.cs.uidaho.edu/misspell.html