### PR TITLE
Move `keyservers->key servers' to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21919,7 +21919,6 @@ keyoutch->keytouch
 keyowrd->keyword
 keypair->key pair
 keypairs->key pairs
-keyservers->key servers
 keystokes->keystrokes
 keyward->keyword
 keywoards->keywords

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -33,6 +33,7 @@ isenough->is enough
 ith->with
 jupyter->Jupiter
 keyserver->key server
+keyservers->key servers
 lateset->latest
 lite->light
 movei->movie


### PR DESCRIPTION
Since `keyserver->key server` is already in the "code" dictionary, I think the plural form should be there too.

(IMHO, they should both be removed, but that is a separate and ongoing discussion in #2084.)