### PR TITLE
sizeable is correct, resizeable should be correct too

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32301,8 +32301,7 @@ resitances->resistances
 resitor->resistor
 resitors->resistors
 resivwar->reservoir
-resizeable->resizable
-resizeble->resizable
+resizeble->resizeable, resizable,
 reslection->reselection
 reslove->resolve
 resloved->resolved
@@ -34733,6 +34732,7 @@ siwtched->switched
 siwtching->switching
 Sixtin->Sistine, Sixteen,
 siz->size, six,
+sizeble->sizeable, sizable,
 sizemologist->seismologist
 sizemologists->seismologists
 sizemologogical->seismological


### PR DESCRIPTION
The proper spelling in the UK is `sizeable`.
In the US, both `sizeable` and `sizable` are valid.