### PR TITLE
usable / useable: force recommended spelling

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -31901,6 +31901,7 @@ reuqesting->requesting
 reuqests->requests
 reurn->return
 reursively->recursively
+reuseable->reusable
 reuslt->result
 reussing->reusing
 reutnred->returned


### PR DESCRIPTION
It is always `usable` in British English:
* [Cambridge](https://dictionary.cambridge.org/dictionary/english/usable)
* [Oxford Learner's](https://www.oxfordlearnersdictionaries.com/definition/english/usable)
* [Longman](https://www.ldoceonline.com/dictionary/usable)
* [Macmillan](https://www.macmillandictionary.com/dictionary/british/usable)

But `useable` is a less common but acceptable variant in the US:
* [Merriam-Webster](https://www.merriam-webster.com/dictionary/usable)
* [Collins](https://www.collinsdictionary.com/dictionary/english/useable)