### PR TITLE
Typos from marvin.cs.uidaho.edu: J

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21949,7 +21949,7 @@ journies->journeys
 journing->journeying
 journy->journey
 journyed->journeyed
-journyes->journeyed
+journyes->journeys, journeyed,
 journying->journeying
 journys->journeys
 joystik->joystick

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21946,6 +21946,12 @@ jossle->jostle
 jouney->journey
 journied->journeyed
 journies->journeys
+journing->journeying
+journy->journey
+journyed->journeyed
+journyes->journeyed
+journying->journeying
+journys->journeys
 joystik->joystick
 jpin->join
 jpng->png, jpg, jpeg,
@@ -21968,6 +21974,18 @@ juni->June
 jupyther->Jupyter
 juristiction->jurisdiction
 juristictions->jurisdictions
+jurnal->journal
+jurnaled->journaled
+jurnaler->journaler
+jurnales->journals
+jurnaling->journaling
+jurnals->journals
+jurnied->journeyed
+jurnies->journeys
+jurny->journey
+jurnyed->journeyed
+jurnyes->journeys
+jurnys->journeys
 jus->just
 juse->just, juice, Jude, June,
 justfied->justified


### PR DESCRIPTION
This replaces PR https://github.com/codespell-project/codespell/pull/1959.

See: http://marvin.cs.uidaho.edu/misspell.html