### PR TITLE
dedent/outdent is used a lot in Python

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11137,7 +11137,6 @@ dedected->detected, deducted,
 dedection->detection, deduction,
 dedections->detections
 dedects->detects, deducts,
-dedented->indented
 dedfined->defined
 dedidate->dedicate
 dedidated->dedicated


### PR DESCRIPTION
Probably no one would write `dedent` instead of `indent` unwillingly. So using `dedent` is a deliberate use of neologism, not a spelling error.

Fixes #2692.