### PR TITLE
Move `ws->was` to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -40515,7 +40515,6 @@ wryth->writhe
 wrythed->writhed
 wrythes->writhes
 wrything->writhing
-ws->was
 wsee->see
 wser->user
 wth->with

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -87,4 +87,5 @@ wan->want
 warmup->warm up, warm-up,
 were'->we're
 whome->whom
+ws->was
 yesterdays->yesterday's


### PR DESCRIPTION
I'm seeing a large amount of false positives for `ws->was` in Emacs: it's used as an acronym for "white space", "Watt second", and "wrapscan" among other things. I'm also seeing _no_ useful corrections; every hit is a false positive.

I therefore suggest moving it to the code dictionary.