### PR TITLE
Remove alias make targets to facilitate tab completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,11 @@ SORT_ARGS := -f -b
 
 DICTIONARIES := codespell_lib/data/dictionary*.txt
 
-PHONY := all check check-dictionaries sort-dictionaries trim-dictionaries check-dictionary sort-dictionary trim-dictionary check-dist flake8 pytest pypi clean
+PHONY := all check check-dictionaries sort-dictionaries trim-dictionaries check-dist flake8 pytest pypi clean
 
 all: check-dictionaries codespell.1
 
 check: check-dictionaries check-dist flake8 pytest
-
-check-dictionary: check-dictionaries
-sort-dictionary: sort-dictionaries
-trim-dictionary: trim-dictionaries
 
 codespell.1: codespell.1.include Makefile
 	PYTHONPATH=. help2man codespell --include codespell.1.include --no-info --output codespell.1


### PR DESCRIPTION
When running the check/sort/trim make targets, I normally type something along the lines of:

    make check-d<TAB>

And let the shell tab completion finish the line for me. As there exists multiple variations, (check-dictionary and check-dictionaries) tab completion stops at the common substring and then I must finish typing the rest of the command.

By removing the aliases, tab completion will complete the full command immediately.