### PR TITLE
Use type annotations directly from chardet package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,11 @@ toml = [
     "tomli; python_version < '3.11'"
 ]
 types = [
+    "chardet>=5.1.0",
     "mypy",
     "pytest",
     "pytest-cov",
     "pytest-dependency",
-    "types-chardet",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Starting with chardet 5.1.0, the package now includes type annotations. The typeshed stubs are obsolete and should no longer be used.

See the release notes:
https://github.com/chardet/chardet/releases/tag/5.1.0

> Add type annotations to the project and run mypy on CI