### PR TITLE
move `pullrequest` to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -29528,9 +29528,6 @@ Pucini->Puccini
 Puertorrican->Puerto Rican
 Puertorricans->Puerto Ricans
 pulisher->publisher
-pullrequenst->pull requests, pull request,
-pullrequest->pull request
-pullrequests->pull requests
 puls->pulse, plus,
 pumkin->pumpkin
 punctation->punctuation

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -48,6 +48,9 @@ outputof->output of, output-of,
 packat->packet
 process'->process's
 protecten->protection, protected,
+pullrequenst->pull requests, pull request,
+pullrequest->pull request
+pullrequests->pull requests
 pysic->physic
 recomment->recommend
 reday->ready


### PR DESCRIPTION
moving `pullrequest` et al to the code dictionary after seeing a false positive in a GitHub GraphQL query: https://docs.github.com/en/graphql/reference/objects#pullrequest