### PR TITLE
Focussed is correct in British English

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -17341,8 +17341,6 @@ focument->document
 focuse->focus
 focusf->focus
 focuss->focus
-focussed->focused
-focusses->focuses
 fof->for
 foget->forget
 fogot->forgot
@@ -30770,7 +30768,6 @@ refletion->reflection
 refletions->reflections
 reflets->reflects
 refocuss->refocus
-refocussed->refocused
 reformated->reformatted
 reformating->reformatting
 reformattd->reformatted


### PR DESCRIPTION
According to Longman, `focussed` is British English and `focused` American English.

Fixes #2707.