### PR TITLE
pre-commit: Upgrade psf/black for stable style 2023

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
       - id: check-case-conflict
       - id: check-toml
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.28.0
+    rev: v1.29.0
     hooks:
       - id: yamllint
         args:
@@ -60,7 +60,7 @@ repos:
           - -d
           - '{extends: relaxed, rules: {line-length: {max: 90}}}'
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
@@ -68,7 +68,7 @@ repos:
     hooks:
       - id: python-bandit-vulnerability-check
   - repo:  https://github.com/PyCQA/autoflake
-    rev: v2.0.0
+    rev: v2.0.1
     hooks:
       - id: autoflake
   - repo: https://github.com/PyCQA/flake8
@@ -84,7 +84,7 @@ repos:
           - pycodestyle>=2.9.1
           - pyflakes>=2.5.0
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/codespell-project/codespell

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ codespell also works with `pre-commit`, using
     rev: v2.2.2
     hooks:
     - id: codespell
-    
+
 If one configures codespell using the `pyproject.toml` file instead use:
 
 .. code-block:: yaml

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -124,7 +124,7 @@ def _check_err_rep(
     ), f"error {err}: correction {rep!r} cannot start with whitespace"
     _check_aspell(err, f"error {err!r}", in_aspell[0], fname, languages[0])
     prefix = f"error {err}: correction {rep!r}"
-    for (regex, msg) in [
+    for regex, msg in [
         (start_comma, "%s starts with a comma"),
         (
             whitespace_comma,


### PR DESCRIPTION
% `pre-commit autoupdate && pre-commit run --all-files`

Updating https://github.com/psf/black ... updating 22.12.0 -> 23.1.0 for their `2023 stable style`.
* https://github.com/psf/black/blob/main/CHANGES.md#2310

> This is the first [psf/black] release of 2023, and following our stability policy, it comes with a number of improvements to our stable style…