### PR TITLE
Add various spelling corrections for (in|ex)clude* and modify*

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -15617,6 +15617,10 @@ excisted->existed
 excisting->existing
 excitment->excitement
 exclamantion->exclamation
+excliude->exclude
+excliuded->excluded
+excliudes->excludes
+excliuding->excluding
 excludde->exclude
 excludind->excluding
 exclue->exclude
@@ -20013,6 +20017,10 @@ incldue->include
 incldued->included
 incldues->includes
 inclinaison->inclination
+incliude->include
+incliuded->included
+incliudes->includes
+incliuding->including
 inclode->include
 inclreased->increased
 includ->include
@@ -24187,6 +24195,10 @@ modifuable->modifiable
 modifued->modified
 modifx->modify
 modifyable->modifiable
+modifyed->modified
+modifyer->modifier
+modifyers->modifiers
+modifyes->modifies
 modiifier->modifier
 modiifiers->modifiers
 modiration->moderation


### PR DESCRIPTION
See e.g.:
- https://grep.app/search?q=modifyed&words=true
- https://grep.app/search?q=%28in%7Cex%29cliud%28e%7Ced%7Ces%7Cing%29&regexp=true
- greenbone/troubadix#490
- greenbone/gvmd#1904

Note that the GitHub search has quite a lot more hits:
- https://github.com/search?q=incliudes&type=code
- https://github.com/search?q=modifyed&type=code