### PR TITLE
Fix CI mypy job

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -556,7 +556,7 @@ def parse_options(
             import tomllib  # type: ignore
         except ModuleNotFoundError:
             try:
-                import tomli as tomllib  # type: ignore
+                import tomli as tomllib
             except ImportError as e:
                 if tomllib_raise_error:
                     raise ImportError(


### PR DESCRIPTION
I guess mypy has been updated in CI images: it used to require `type: ignore` and now asks we remove it.