### PR TITLE
dict: Add instersection(s)->intersection(s)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21076,7 +21076,11 @@ insterad->instead
 insterrupts->interrupts
 instersction->intersection
 instersctions->intersections
+instersection->intersection
+instersectional->intersectional
+instersectionality->intersectionality
 instersectioned->intersection
+instersections->intersections
 instert->insert
 insterted->inserted
 instertion->insertion


### PR DESCRIPTION
Seen in Godot Engine:
```
$ rg instersection
core/math/rect2i.h
90:     // Returns the instersection between two Rect2is or an empty Rect2i if there is no intersection

core/math/rect2.h
147:    // Returns the instersection between two Rect2s or an empty Rect2 if there is no intersection
```