### PR TITLE
Move `keypair(s)->key pair(s)` to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22154,8 +22154,6 @@ keyosk->kiosk
 keyosks->kiosks
 keyoutch->keytouch
 keyowrd->keyword
-keypair->key pair
-keypairs->key pairs
 keystokes->keystrokes
 keyward->keyword
 keywoards->keywords

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -32,6 +32,8 @@ ifset->if set
 isenough->is enough
 ith->with
 jupyter->Jupiter
+keypair->key pair
+keypairs->key pairs
 lateset->latest
 lite->light
 movei->movie


### PR DESCRIPTION
In analogy with #2084, I'm seeing a large amount of false positives for `keypair->key pair` in GnuTLS. I'm not sure we should impose one spelling over the other at all, and perhaps the rule should be removed altogether. However, as a stopgap measure, I think at the very least it makes sense to move the fix to the code dictionary.

Thanks.