### PR TITLE
Add `man-in-the-middle->adversary-in-the-middle` alternative

### DIFF
--- a/codespell_lib/data/dictionary_usage.txt
+++ b/codespell_lib/data/dictionary_usage.txt
@@ -9,7 +9,7 @@ dummy-value->placeholder value
 girlfriend-test->user test, acceptance test, validation test, ease-of-use test, friendliness test, useability test,
 man-hour->staff hour, volunteer hour, hour of effort, person-hour,
 man-hours->staff hours, volunteer hours, hours of effort, person-hours,
-man-in-the-middle->on-path attacker, interceptor, intermediary, machine-in-the-middle, person-in-the-middle,
+man-in-the-middle->on-path attacker, adversary-in-the-middle, interceptor, intermediary, machine-in-the-middle, person-in-the-middle,
 manned->crewed, staffed, monitored, human operated,
 master->primary, leader, active, writer, coordinator, parent, manager, main,
 masters->primaries, leaders, actives, writers, coordinators, parents, managers,


### PR DESCRIPTION
This adds the useful alternative `man-in-the-middle->adversary-in-the-middle`. It IMHO manages to actually be both less jargony and more clear at the same time.

It has been used in the wild:
https://git.savannah.gnu.org/gitweb/?p=emacs.git;a=commit;h=7e1c7db1cb5a33a66115bb767224bdc79a257266