### PR TITLE
Accept duplicate entries in INI config files

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -541,7 +541,7 @@ def parse_options(
     cfg_files = ["setup.cfg", ".codespellrc"]
     if options.config:
         cfg_files.append(options.config)
-    config = configparser.ConfigParser(interpolation=None)
+    config = configparser.ConfigParser(interpolation=None, strict=False)
 
     # Read toml before other config files.
     toml_files = []
@@ -571,7 +571,7 @@ def parse_options(
     # Collect which config files are going to be used
     used_cfg_files = []
     for cfg_file in cfg_files:
-        _cfg = configparser.ConfigParser()
+        _cfg = configparser.ConfigParser(interpolation=None, strict=False)
         _cfg.read(cfg_file)
         if _cfg.has_section("codespell"):
             used_cfg_files.append(cfg_file)


### PR DESCRIPTION
Rationale:
1. The `-D` command line option can be specified multiple times. It makes sense to be able to specify the respective config file option `dictionary` multiple times too.
2. While specifying an option multiple times might be an error, setting _strict_ to `True` catches duplicates only within a single INI file, not across multiple INI files. If we are serious about handling duplicate options, we should therefore handle that manually, distinguishing between options that can be duplicated or not.

Fixes #2727.