### PR TITLE
Add deffault(s|ed)->default(s|ed) correction

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11329,6 +11329,9 @@ deferencing->dereferencing
 deferentiating->differentiating
 defering->deferring
 deferreal->deferral
+deffault->default
+deffaulted->defaulted
+deffaults->defaults
 deffensively->defensively
 deffered->differed, deferred,
 defference->difference, deference,


### PR DESCRIPTION
See e.g.:
- https://grep.app/search?q=deffaults
- https://github.com/search?q=deffault&type=code

Note: Not 100% sure but `deffault` could be also an abbreviation for `default fault` or similar. But most i have seen seems more like typos.