### PR TITLE
Remove whet from dictionary_rare

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -223,7 +223,6 @@ vise->vice
 want's->wants
 wee->we
 whats->what's
-whet->when, what, wet,
 whiling->while
 wight->weight, white, right, write,
 wights->weights, waits, whites, rights, writes,


### PR DESCRIPTION
"Whet your appetite" is a good and used phrase. It is incorrect to suggest incorrect fixing of it.

Ref: https://github.com/codespell-project/codespell/issues/1193