### PR TITLE
Add fixing consciousely typo

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8991,6 +8991,7 @@ consants->constants
 conscent->consent
 consciencious->conscientious
 consciouness->consciousness
+consciousely->consciously
 consctruct->construct
 consctructed->constructed
 consctructing->constructing


### PR DESCRIPTION
    ❯ grep consciousely scripts/freeze_versions
        # a conflict needed to be consciousely resolved (or -S ours used)

    ❯ codespell scripts/freeze_versions

    ❯ dict consciousely
    No definitions found for "consciousely", perhaps you mean:
    gcide:  Consciously
    wn:  consciously
    moby-thesaurus:  consciously

typo includes adding 'e' without need between s and l. Apparently I was very unique in having it since it is not yet known typo to codespell.