### PR TITLE
atalog typo (saw twice in a project)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3699,6 +3699,7 @@ atachment->attachment
 atachments->attachments
 atack->attack
 atain->attain
+atalog->catalog
 atatch->attach
 atatchable->attachable
 atatched->attached


### PR DESCRIPTION
analog is closeby word (one letter difference) but `t` and `n` far on keyboard so I think unlikely to happen. but can make it multi choice if someone thinks it is worth it