### PR TITLE
Fix AssertionError when opening with chardet

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -228,7 +228,6 @@ class FileOpener:
                     break
         self.encdetector.close()
         encoding = self.encdetector.result["encoding"]
-        assert encoding is not None  # noqa: S101
 
         try:
             f = open(filename, encoding=encoding, newline="")
@@ -245,7 +244,7 @@ class FileOpener:
             lines = f.readlines()
             f.close()
 
-        return lines, encoding
+        return lines, f.encoding
 
     def open_with_internal(self, filename: str) -> Tuple[List[str], str]:
         encoding = None

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -384,6 +384,16 @@ def test_encoding(
     assert "WARNING: Binary file" in stderr
 
 
+def test_unknown_encoding_chardet(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test opening a file with unknown encoding using chardet"""
+    fname = tmp_path / "tmp"
+    fname.touch()
+    assert cs.main("--hard-encoding-detection", fname) == 0
+
+
 def test_ignore(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
This PR fixes an AssertationError, when chardet is unable to detect the encoding.

Added in https://github.com/codespell-project/codespell/commit/8d0d82bcc07aaef5211127683aba7de67b923aac, it is checked if chardet has actually detected an encoding. If it's unable to detect one, an AssertationError is raised and codespell fails hard.

Example:
```
➜  ~ touch /tmp/empty_file
➜  ~ file /tmp/empty_file                 
/tmp/empty_file: empty
➜  ~ codespell /tmp/empty_file                                           
➜  ~ echo $?
0
➜  ~ codespell --hard-encoding-detection /tmp/empty_file                 
Traceback (most recent call last):
  File "/home/nthumann/.local/bin/codespell", line 8, in <module>
    sys.exit(_script_main())
  File "/home/nthumann/.local/lib/python3.10/site-packages/codespell_lib/_codespell.py", line 989, in _script_main
    return main(*sys.argv[1:])
  File "/home/nthumann/.local/lib/python3.10/site-packages/codespell_lib/_codespell.py", line 1178, in main
    bad_count += parse_file(
  File "/home/nthumann/.local/lib/python3.10/site-packages/codespell_lib/_codespell.py", line 871, in parse_file
    lines, encoding = file_opener.open(filename)
  File "/home/nthumann/.local/lib/python3.10/site-packages/codespell_lib/_codespell.py", line 218, in open
    return self.open_with_chardet(filename)
  File "/home/nthumann/.local/lib/python3.10/site-packages/codespell_lib/_codespell.py", line 231, in open_with_chardet
    assert encoding is not None
AssertionError
➜  ~ echo $?
1
```

With this patch we use always return `f.encoding` instead of `encoding`, which may be `None`, if chardet is unable to detect it. `f.encoding` either contains the encoding passed to `open` (if chardet detect it) or the encoding Python detected (if `encoding` is `None`).
Simply removing the assertation will make mypy unhappy, because the returned `encoding` can be `None`.