### PR TITLE
Add Microsoft Mispelling

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -23882,6 +23882,7 @@ microprocesspr->microprocessor
 microprocessprs->microprocessors
 microseond->microsecond
 microseonds->microseconds
+Microsfoft->Microsoft
 Microsft->Microsoft
 microship->microchip
 microships->microchips


### PR DESCRIPTION
Added a misspelling of Microsoft that Codespell missed in our codebase.