### PR TITLE
Fix CI issues

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -587,7 +587,7 @@ def parse_options(
             cfg_args.append(f"--{key}")
             # If value is blank, skip.
             val = config["codespell"][key]
-            if val != "":
+            if val:
                 cfg_args.append(val)
 
         # Parse config file options.

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -141,7 +141,7 @@ def test_basic(
     assert isinstance(result, tuple)
     code, stdout, stderr = result
     assert code == 0
-    assert stdout == stderr == ""
+    assert not stdout and not stderr
     assert cs.main(tmp_path) == 0
 
     # empty directory
@@ -266,7 +266,7 @@ def test_summary(
     assert isinstance(result, tuple)
     code, stdout, stderr = result
     assert code == 0
-    assert stdout == stderr == "", "no output"
+    assert not stdout and not stderr, "no output"
     result = cs.main(fname, "--summary", std=True)
     assert isinstance(result, tuple)
     code, stdout, stderr = result
@@ -375,12 +375,12 @@ def test_encoding(
     assert isinstance(result, tuple)
     code, stdout, stderr = result
     assert code == 0
-    assert stdout == stderr == ""
+    assert not stdout and not stderr
     result = cs.main("-q", "0", fname, std=True, count=False)
     assert isinstance(result, tuple)
     code, stdout, stderr = result
     assert code == 0
-    assert stdout == ""
+    assert not stdout
     assert "WARNING: Binary file" in stderr
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ addopts = "--cov=codespell_lib -rs --cov-report= --tb=short --junit-xml=junit-re
 extend-ignore = [
     "ANN101",
     "B904",
-    "PLC1901",
     "PLW2901",
 ]
 line-length = 88


### PR DESCRIPTION
- Fix this warning:
  ```
  warning: `C4` has been remapped to `C40`.
  ```
- Fix PL[C1901](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/compare-to-empty-string.html), even if the rule is currently broken:
  https://github.com/charliermarsh/ruff/issues/3503