### PR TITLE
Ruff: Ignore new rule PLC1901

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ addopts = "--cov=codespell_lib -rs --cov-report= --tb=short --junit-xml=junit-re
 extend-ignore = [
     "ANN101",
     "B904",
+    "PLC1901",
     "PLW2901",
 ]
 line-length = 88
@@ -112,7 +113,7 @@ select = [
     "A",
     "ANN",
     "B",
-    "C4",
+    "C40",
     "C9",
     "E",
     "F",


### PR DESCRIPTION
Fixes for:

% `ruff .`
```
warning: `C4` has been remapped to `C40`.
warning: `C4` has been remapped to `C40`.
warning: `C4` has been remapped to `C40`.
codespell_lib/_codespell.py:591:23: PLC1901 `val != ""` can be simplified to `not val` as an empty string is falsey
codespell_lib/tests/test_basic.py:144:32: PLC1901 `stderr == ""` can be simplified to `stderr` as an empty string is falsey
codespell_lib/tests/test_basic.py:269:32: PLC1901 `stderr == ""` can be simplified to `stderr` as an empty string is falsey
codespell_lib/tests/test_basic.py:378:32: PLC1901 `stderr == ""` can be simplified to `stderr` as an empty string is falsey
codespell_lib/tests/test_basic.py:383:22: PLC1901 `stdout == ""` can be simplified to `stdout` as an empty string is falsey
Found 5 errors.
```