### PR TITLE
CI: fix new ruff error B028

### DIFF
--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -25,7 +25,8 @@ except Exception as exp:  # probably ImportError, but maybe also language
     else:
         warnings.warn(
             "aspell not found, but not required, skipping aspell tests. Got "
-            "error during import:\n{}".format(exp)
+            "error during import:\n{}".format(exp),
+            stacklevel=2,
         )
 
 global_err_dicts: Dict[str, Dict[str, Any]] = {}


### PR DESCRIPTION
```
codespell_lib/tests/test_dictionary.py:26:9: B028 No explicit `stacklevel` keyword argument found
```

Caused by this recent addition to ruff:
	https://github.com/charliermarsh/ruff/pull/3550