### PR TITLE
Add spelling correction for siver->silver/sliver/diver

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -35158,6 +35158,7 @@ siutable->suitable
 siute->suite
 sive->sieve, save,
 sived->sieved, saved,
+siver->silver, sliver, diver,
 sives->sieves, saves,
 sivible->visible
 siving->sieving, saving,


### PR DESCRIPTION
See e.g. https://grep.app/search?q=siver&words=true

Note: There are names like "Kay Siver" but also various typos like e.g. the ones below so hope it is correct to add it like this.

https://github.com/heuermh/lick/blob/6b9b57a935c22d7c499ca5a9f926ef378f11d58d/lick/interval/Intervals.ck#L1148-L1149C14

https://github.com/astefanutti/kms-glsl/blob/f385a052b3a1495108b0e3e2702d446b00e2ef14/examples/subdivided_grid_truchet_parttern.glsl#L199