### PR TITLE
While lambda is prevalent, Unicode uses lamda

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -24430,8 +24430,6 @@ laguagues->languages
 laguange->language
 laguanges->languages
 laiter->later
-lamda->lambda
-lamdas->lambdas
 lanaguage->language
 lanaguge->language
 lanaguges->languages

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -120,6 +120,8 @@ irregardless->regardless
 knifes->knives
 lama->llama
 lamas->llamas
+lamda->lambda
+lamdas->lambdas
 leaded->led, lead,
 leas->least, lease,
 lief->leaf, life,


### PR DESCRIPTION
* [Greek and Coptic](https://www.unicode.org/charts/PDF/U0370.pdf)
* [Mathematical Alphanumeric Symbols](https://www.unicode.org/charts/PDF/U1D400.pdf)

The only exception in Unicode is **ƛ**, “LATIN SMALL LETTER LAMBDA WITH STROKE” in the [Latin Extended-B](https://www.unicode.org/charts/PDF/U0180.pdf) chart, for historical reasons.

Fixes #2860.