### PR TITLE
move 'astroid' to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3630,7 +3630,6 @@ astiimation->estimation
 astrix->asterisk
 astrixes->asterisks
 astrixs->asterisks
-astroid->asteroid
 asudo->sudo
 asume->assume
 asumed->assumed

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -2,6 +2,7 @@ agrv->argv
 alloced->allocated
 amin->main
 apoint->appoint
+astroid->asteroid
 atend->attend
 atending->attending
 bre->be, brie,


### PR DESCRIPTION
`astroid` is a [python package](https://pypi.org/project/astroid/) which powers the commonly used linter `pylint`.