### PR TITLE
Add `alloccat*->allocat*`

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1733,6 +1733,10 @@ allocatoor->allocator
 allocatote->allocate
 allocatrd->allocated
 allocattion->allocation
+alloccate->allocate
+alloccated->allocated
+alloccates->allocates
+alloccating->allocating
 alloco->alloc
 allocos->allocs
 allocte->allocate


### PR DESCRIPTION
Typo seen at [1].

Link: https://lore.kernel.org/rust-for-linux/20230602101819.2134194-2-changxian.cqs@antgroup.com/ [1]