### PR TITLE
Add `invirant{,s}->invariant{,s}`

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21966,6 +21966,8 @@ invididual->individual
 invidivual->individual
 invidual->individual
 invidually->individually
+invirant->invariant
+invirants->invariants
 invisble->invisible
 invisblity->invisibility
 invisiable->invisible


### PR DESCRIPTION
Typo seen at [1].

Link: https://lore.kernel.org/rust-for-linux/20230602101819.2134194-2-changxian.cqs@antgroup.com/ [1]