### PR TITLE
Ignore 'misspellings' due to string escapes

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -897,6 +897,19 @@ def parse_file(
             word = match.group()
             lword = word.lower()
             if lword in misspellings:
+                # Sometimes we find a 'misspelling' which is actually a valid word
+                # preceeded by a string escape sequence.  Ignore such cases as
+                # they're usually false alarms; see issue #17 among others.
+                char_before_idx = match.start() - 1
+                if (
+                    char_before_idx >= 0
+                    and line[char_before_idx] == "\\"
+                    # bell, backspace, formfeed, newline, carriage-return, tab, vtab.
+                    and word.startswith(("a", "b", "f", "n", "r", "t", "v"))
+                    and lword[1:] not in misspellings
+                ):
+                    continue
+
                 context_shown = False
                 fix = misspellings[lword].fix
                 fixword = fix_case(word, misspellings[lword].data)

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -898,7 +898,7 @@ def parse_file(
             lword = word.lower()
             if lword in misspellings:
                 # Sometimes we find a 'misspelling' which is actually a valid word
-                # preceeded by a string escape sequence.  Ignore such cases as
+                # preceded by a string escape sequence.  Ignore such cases as
                 # they're usually false alarms; see issue #17 among others.
                 char_before_idx = match.start() - 1
                 if (

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -98,6 +98,9 @@ def test_basic(
         f.write("this is a test file\n")
     assert cs.main(fname) == 0, "good"
     with fname.open("a") as f:
+        f.write("var = '\\nDoes not error on newline'\n")
+    assert cs.main(fname) == 0, "with string escape"
+    with fname.open("a") as f:
         f.write("abandonned\n")
     assert cs.main(fname) == 1, "bad"
     with fname.open("a") as f:


### PR DESCRIPTION
This issue has been reported _many_ times - #17, https://github.com/codespell-project/codespell/issues/111,  https://github.com/codespell-project/codespell/issues/233#issuecomment-451950067, https://github.com/codespell-project/codespell/issues/1421, https://github.com/codespell-project/codespell/issues/1774, https://github.com/codespell-project/codespell/issues/2508, https://github.com/codespell-project/codespell/issues/2809, and https://github.com/codespell-project/codespell/issues/2871 at least.  It would also let me enforce `codespell` at work, which would be nice!

Design:  in order to make this super-fast, we do an O(1) check _of each detected misspelling_, with no new configuration or dictionary entries.  If the match is preceeded by a backslash and begins with a letter which (with backslash) constitutes a common escape string, _and_ the remainder of the word is not a misspelling, we skip it; otherwise we report exactly as we would now, with no special handling for the escapes.  It's a minimalist change meant to address a common complaint, accepting a very few missed alarms in exchange for lower complexity for both maintainers and users.

Fixes #17, fixes #1774, and closes #174.