### PR TITLE
Add new typos for "load"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13904,6 +13904,8 @@ downlaoded->downloaded
 downlaodes->downloads
 downlaoding->downloading
 downlaods->downloads
+downloade->download
+downloades->downloads, downloaded,
 downloadmanger->downloadmanager
 downlod->download
 downloded->downloaded
@@ -23047,6 +23049,8 @@ loacally->locally
 loacation->location
 loaction->location
 loactions->locations
+loade->load
+loades->loads, loaded,
 loadig->loading
 loadin->loading
 loadning->loading
@@ -27102,6 +27106,8 @@ overlfow->overflow
 overlfowed->overflowed
 overlfowing->overflowing
 overlfows->overflows
+overloade->overload
+overloades->overloads, overloaded,
 overlodaded->overloaded
 overloded->overloaded
 overlodes->overloads
@@ -31849,6 +31855,7 @@ relly->really
 relm->realm, elm, helm, ream, rem,
 relms->realms, elms, helms, reams,
 reloade->reload
+reloades->reloads, reloaded,
 relocae->relocate
 relocaes->relocates
 relocaiing->relocating
@@ -33168,6 +33175,8 @@ reuplaoder->reuploader
 reuplaoders->reuploaders
 reuplaoding->reuploading
 reuplaods->reuploads
+reuploade->reupload
+reuploades->reuploads, reuploaded,
 reuplod->reupload
 reuplodad->reupload, reuploaded,
 reuploded->reuploaded
@@ -40462,6 +40471,8 @@ uplaodes->uploads
 uplaoding->uploading
 uplaods->uploads
 upliad->upload
+uploade->upload
+uploades->uploads, uploaded,
 uplod->upload
 uplodad->upload, uploaded,
 uplodaded->uploaded


### PR DESCRIPTION
`loade->load`, `loades->loads, loaded,`, and similar

`reloade->reload` already exists