### PR TITLE
Add alternative spelling corrections for "merget"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -23929,7 +23929,7 @@ merchantibility->merchantability
 merecat->meerkat
 merecats->meerkats
 mergable->mergeable
-merget->merge
+merget->merged, merger, merge,
 mergge->merge
 mergged->merged
 mergging->merging


### PR DESCRIPTION
It is more likely that `merget` is a typo of `merged` rather then some one have hit `t` in addition to `e` (as `r` is also in between). As `r` is close to `e` i have also added `merger` as an alternative correction.