### PR TITLE
Add `annhilate` Mispelling

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2287,7 +2287,10 @@ annd->and
 annecessary->unnecessary, a necessary,
 annhilate->annihilate
 annhilated->annihilated
+annhilates->annihilates
 annhilating->annihilating
+annhilation->annihilation
+annhilations->annihilations
 anniversery->anniversary
 annnounce->announce
 annoation->annotation

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2285,6 +2285,9 @@ annaying->annoying
 annays->annoys, any,
 annd->and
 annecessary->unnecessary, a necessary,
+annhilate->annihilate
+annhilated->annihilated
+annhilating->annihilating
 anniversery->anniversary
 annnounce->announce
 annoation->annotation


### PR DESCRIPTION
Adds misspelling of "annihilate" and variants.