### PR TITLE
Add `twine` As Dev Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
+    "aspell-python-py3",
     "build",
     "chardet",
     "pytest",
@@ -39,7 +40,8 @@ dev = [
     "pytest-dependency",
     "Pygments",
     "ruff",
-    "tomli"
+    "tomli",
+    "twine"
 ]
 hard-encoding-detection = [
     "chardet"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "aspell-python-py3",
     "build",
     "chardet",
     "pytest",


### PR DESCRIPTION
This is needed to pass testing when Aspell is installed. Without Aspell installed, it has no impact.

Resolves https://github.com/codespell-project/codespell/issues/2896.