### PR TITLE
Add spelling corrections for upperace and lowerace.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -23716,6 +23716,9 @@ losted->listed, lost, lasted,
 lotation->rotation, flotation,
 lotharingen->Lothringen
 lowd->load, low, loud,
+lowerace->lowercase
+loweraced->lowercased
+loweracing->lowercasing
 lozonya->lasagna
 lpatform->platform
 lsat->last, slat, sat,
@@ -41136,6 +41139,8 @@ updraging->upgrading
 updte->update
 uper->upper, super,
 upercase->uppercase
+upercased->uppercased
+upercasing->uppercasing
 uperclass->upperclass
 upgade->upgrade
 upgaded->upgraded
@@ -41197,6 +41202,9 @@ uploder->uploader
 uploders->uploaders
 uploding->uploading
 uplods->uploads
+upperace->uppercase
+upperaced->uppercased
+upperacing->uppercasing
 uppler->upper
 uppon->upon
 upported->supported


### PR DESCRIPTION
See e.g. (Note: `grep.app` search calls have less hits):
- https://github.com/search?q=upperace&type=code
- https://github.com/search?q=lowerace&type=code
- https://grep.app/search?q=upperace
- https://grep.app/search?q=lowerace