### PR TITLE
Move `dateset` to code

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -11504,8 +11504,6 @@ datecreatedd->datecreated
 datection->detection
 datections->detections
 datee->date
-dateset->dataset
-datesets->datasets
 datset->dataset
 datsets->datasets
 daty->data, date,

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -12,6 +12,8 @@ cloneable->clonable
 cmo->com
 copyable->copiable
 creat->create, crate,
+dateset->dataset
+datesets->datasets
 define'd->defined
 deque->dequeue
 doas->does, do as,


### PR DESCRIPTION
Although it's hardly a word, it appears to have been added to the _aspell_ dictionary.

Fixes #2897.