### PR TITLE
Apostrophes and possessives

### DIFF
--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -25,7 +25,6 @@ endcode->encode
 errorstring->error string
 exitst->exits, exists,
 falsy->falsely, false,
-files'->file's
 gadjet->gadget
 gadjets->gadgets
 gae->game, Gael, gale,
@@ -51,7 +50,6 @@ od->of
 outputof->output of, output-of,
 packat->packet
 postifx->postfix
-process'->process's
 protecten->protection, protected,
 pullrequenst->pull requests, pull request,
 pullrequest->pull request
@@ -79,7 +77,6 @@ storaged->storage, stored,
 storaget->storage
 stringly->strongly, stringy,
 subpatchs->subpatches
-subprocess'->subprocess's
 sur->sure, sir,
 tarceback->traceback
 tarcebacks->tracebacks


### PR DESCRIPTION
In [2008](https://www.govinfo.gov/app/details/GPO-STYLEMANUAL-2008/), the [U.S. Government Printing Office Style Manual](https://www.govinfo.gov/collection/gpo-style-manual) started suggesting just an apostrophe after singular nouns ending in _s_.
> #### Apostrophes and possessives
> 
> **8.3.** The possessive case of a singular or plural noun not ending in _s_ is formed by adding an apostrophe and _s_. The possessive case of a singular or plural noun ending in _s_ or with an _s_ sound is formed by adding an apostrophe only.

Also, `files` could be the plural of `file`.

Fixes #2928.