### PR TITLE
I cannot find installator in any dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22966,6 +22966,8 @@ installaters->installers
 installates->installs
 installating->installing
 installationa->installation
+installator->installer
+installators->installers
 installe->installer, installed, install,
 installes->installs
 installion->installation, installing,


### PR DESCRIPTION
Probably from native speakers of other European languages, such as French and German (installateur) or Danish, Norwegian, and Swedish (installatør).