### PR TITLE
Use large aspell dictionaries

### DIFF
--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -18,9 +18,11 @@ try:
     for lang in supported_languages:
         _wordlist = op.join(_test_data_dir, f"{lang}-additionnal.wordlist")
         if op.isfile(_wordlist):
-            spellers[lang] = aspell.Speller(("lang", lang), ("wordlists", _wordlist))
+            spellers[lang] = aspell.Speller(
+                ("lang", lang), ("size", "80"), ("wordlists", _wordlist)
+            )
         else:
-            spellers[lang] = aspell.Speller("lang", lang)
+            spellers[lang] = aspell.Speller(("lang", lang), ("size", "80"))
 except ImportError as exp:
     if os.getenv("REQUIRE_ASPELL", "false").lower() == "true":
         raise RuntimeError(


### PR DESCRIPTION
We have been using the default _aspell_ dictionary size in CI tests:
```
	60=med-large
```
This change will switch to larger dictionaries:
```
	80=huge
```
In practice, huge dictionaries are rot available, so the above size yields a large dictionary:
```
	70=large
```

http://aspell.net/man-html/How-Aspell-Selects-an-Appropriate-Dictionary.html