### PR TITLE
Add Pre-Commit as a dev dependency

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -10,3 +10,5 @@ pip install --upgrade \
     setuptools_scm \
     wheel
 pip install -e '.[dev]'
+
+pre-commit install --install-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dynamic = ["version"]
 dev = [
     "build",
     "chardet",
+    "pre-commit",
     "pytest",
     "pytest-cov",
     "pytest-dependency",


### PR DESCRIPTION
Also automatically installs Pre-Commit and all hooks at dev container startup.

Resolves https://github.com/codespell-project/codespell/issues/2957.