### PR TITLE
Use pre-commit to sort the dictionaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-files: ^(.*\.(py|json|md|sh|yaml|yml|in|cfg|txt|rst|toml|precommit-toml))$
+files: ^(.*\.(py|json|md|sh|yaml|yml|in|cfg|txt|rst|toml|precommit-toml|wordlist))$
 exclude: ^(\.[^/]*cache/.*)$
 repos:
   - repo: https://github.com/executablebooks/mdformat
@@ -47,7 +47,7 @@ repos:
       - id: check-case-conflict
       - id: check-toml
       - id: file-contents-sorter
-        files: dictionary.*\.txt$
+        files: dictionary.*\.txt$|\.wordlist$
         args: [--ignore-case]
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.32.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,9 @@ repos:
       - id: fix-byte-order-marker
       - id: check-case-conflict
       - id: check-toml
+      - id: file-contents-sorter
+        files: dictionary.*\.txt$
+        args: [--ignore-case]
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.32.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DICTIONARIES := codespell_lib/data/dictionary*.txt
+DICTIONARIES := codespell_lib/data/dictionary*.txt codespell_lib/tests/data/*.wordlist
 
 PHONY := all check check-dictionaries sort-dictionaries trim-dictionaries check-dist pytest pypi ruff clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SORT_ARGS := -f -b
-
 DICTIONARIES := codespell_lib/data/dictionary*.txt
 
 PHONY := all check check-dictionaries sort-dictionaries trim-dictionaries check-dist pytest pypi ruff clean

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,6 @@ codespell.1: codespell.1.include Makefile
 
 check-dictionaries:
 	@for dictionary in ${DICTIONARIES}; do \
-		if ! LC_ALL=C sort ${SORT_ARGS} -c $$dictionary; then \
-			echo "Dictionary $$dictionary not sorted. Sort with 'make sort-dictionaries'"; \
-			exit 1; \
-		fi; \
 		if grep -E -n "^\s*$$|\s$$|^\s" $$dictionary; then \
 			echo "Dictionary $$dictionary contains leading/trailing whitespace and/or blank lines.  Trim with 'make trim-dictionaries'"; \
 			exit 1; \
@@ -31,9 +27,7 @@ check-dictionaries:
 	fi
 
 sort-dictionaries:
-	@for dictionary in ${DICTIONARIES}; do \
-		LC_ALL=C sort ${SORT_ARGS} -u -o $$dictionary $$dictionary; \
-	done
+	pre-commit run --all-files file-contents-sorter
 
 trim-dictionaries:
 	@for dictionary in ${DICTIONARIES}; do \

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5,6 +5,9 @@
 3rt->3rd
 3st->3rd
 4rd->4th
+__attribyte__->__attribute__
+__cpluspus->__cplusplus
+__cpusplus->__cplusplus
 a-diaerers->a-diaereses
 aaccess->access
 aaccessibility->accessibility
@@ -8230,9 +8233,9 @@ cllouds->clouds
 cloack->cloak
 cloacks->cloaks
 cloberring->clobbering
+clock_getttime->clock_gettime
 clocksourc->clocksource
 clockwíse->clockwise
-clock_getttime->clock_gettime
 clodes->closed, clothes,
 cloding->closing
 cloes->close
@@ -11247,8 +11250,8 @@ cought->caught, cough, fought,
 coul->could
 could'nt->couldn't
 could't->couldn't
-couldent->couldn't
 coulden`t->couldn't
+couldent->couldn't
 couldn->could, couldn't,
 couldn;t->couldn't
 couldnt'->couldn't
@@ -31326,6 +31329,7 @@ phsyically->physically
 phsyics->physics
 phtread->pthread
 phtreads->pthreads
+phy_interace->phy_interface
 phyiscal->physical
 phyiscally->physically
 phyiscs->physics
@@ -31352,7 +31356,6 @@ physisions->physicians
 physisist->physicist
 phython->python
 phyton->python
-phy_interace->phy_interface
 piar->pair, pier, pliers,
 piars->pairs, piers, pliers,
 piblisher->publisher
@@ -47125,8 +47128,8 @@ woudl->would
 woudn't->wouldn't
 would'nt->wouldn't
 would't->wouldn't
-wouldent->wouldn't
 woulden`t->wouldn't
+wouldent->wouldn't
 wouldn;t->wouldn't
 wouldnt'->wouldn't
 wouldnt->wouldn't
@@ -47370,9 +47373,6 @@ zukeeni->zucchini
 zuser->user
 zylophone->xylophone
 zylophones->xylophones
-__attribyte__->__attribute__
-__cpluspus->__cplusplus
-__cpusplus->__cplusplus
 évaluate->evaluate
 сontain->contain
 сontained->contained

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -77,6 +77,21 @@ def test_dictionary_formatting(
         raise AssertionError("\n" + "\n".join(errors))
 
 
+@fname_params
+def test_dictionary_sorting(
+    fname: str,
+    in_aspell: Tuple[bool, bool],
+    in_dictionary: Tuple[Iterable[str], Iterable[str]],
+) -> None:
+    previous_line = None
+    with open(fname, encoding="utf-8") as file:
+        for current_line in file:
+            current_line = current_line.strip().lower()
+            if previous_line is not None:
+                assert previous_line < current_line, f"{fname} is not sorted"
+            previous_line = current_line
+
+
 def _check_aspell(
     phrase: str,
     msg: str,

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import os.path as op
+import pathlib
 import re
 import warnings
 from typing import Any, Dict, Iterable, Optional, Set, Tuple
@@ -10,6 +11,8 @@ import pytest
 from codespell_lib._codespell import _builtin_dictionaries, supported_languages
 
 spellers = {}
+
+root = pathlib.Path(__file__).parent.parent
 
 try:
     import aspell  # type: ignore[import]
@@ -77,18 +80,21 @@ def test_dictionary_formatting(
         raise AssertionError("\n" + "\n".join(errors))
 
 
-@fname_params
-def test_dictionary_sorting(
-    fname: str,
-    in_aspell: Tuple[bool, bool],
-    in_dictionary: Tuple[Iterable[str], Iterable[str]],
-) -> None:
+@pytest.mark.parametrize(
+    "filename",
+    [
+        *(root / "data").rglob("dictionary*.txt"),
+        *(root / "tests/data").rglob("*.wordlist"),
+    ],
+)
+def test_dictionary_sorting(filename: pathlib.Path) -> None:
+    relative_path = filename.relative_to(root)
     previous_line = None
-    with open(fname, encoding="utf-8") as file:
+    with filename.open(encoding="utf-8") as file:
         for current_line in file:
             current_line = current_line.strip().lower()
             if previous_line is not None:
-                assert previous_line < current_line, f"{fname} is not sorted"
+                assert previous_line < current_line, f"{relative_path} is not sorted"
             previous_line = current_line
 
 


### PR DESCRIPTION
This changes the sort order of specific characters (like `"_"`) but is cross-platform and can be fixed by pre-commit.ci.

Closes #2689