### PR TITLE
Add spelling corrections for defaoult and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12454,6 +12454,10 @@ defailt->default
 defalt->default
 defalts->defaults
 defalut->default
+defaoult->default
+defaoulted->defaulted
+defaoulting->defaulting
+defaoults->defaults
 defargkey->defragkey
 defatult->default
 defaukt->default


### PR DESCRIPTION
See e.g.:
- https://github.com/search?q=defaoult&type=code
- https://grep.app/search?q=defaoult (Has less hits)