### PR TITLE
Add preperint typo

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32382,6 +32382,8 @@ prepere->prepare
 prepered->prepared
 preperes->prepares
 prepering->preparing
+preperint->preprint
+preperints->preprints
 preponderence->preponderance
 preppend->prepend
 preppended->prepended


### PR DESCRIPTION
Detected in neurolibre project: https://github.com/neurolibre/neurolibre/issues/47 in a few spots, so seems to be common, and has a few more hits throughout the github.