### PR TITLE
Fix ruff lint error

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -190,10 +190,7 @@ class Summary:
         keys.sort()
 
         return "\n".join(
-            [
-                "{0}{1:{width}}".format(key, self.summary.get(key), width=15 - len(key))
-                for key in keys
-            ]
+            [f"{key}{self.summary.get(key):{15 - len(key)}}" for key in keys]
         )
 
 


### PR DESCRIPTION
Closes #3014. The new version of ruff threw an error on `"{0}{1:{width}}"`, so I changed it to an f-string. There should be no change in behaviour.

```py
>>> key='abc'; print("{0}{1:{width}}".format(key, 123, width=15 - len(key)))
abc         123
>>> key='abc'; print(f"{key}{123:{15 - len(key)}}")
abc         123
>>> key='a'*20; print("{0}{1:{width}}".format(key, 123, width=15 - len(key)))
aaaaaaaaaaaaaaaaaaaa  123
>>> key='a'*20; print(f"{key}{123:{15 - len(key)}}")
aaaaaaaaaaaaaaaaaaaa  123
```