### PR TITLE
Replace local and CI workflow by pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ check-dist:
 	rm -rf $(TMP)
 
 ruff:
-	ruff .
+	pre-commit run --all-files ruff
 
 pytest:
 	@if command -v pytest > /dev/null; then \


### PR DESCRIPTION
Calling ruff through pre-commit, we use the stable, pinned down environment used by pre-commit. This helps consistency across the different workflows we use to run checks.

Fixes https://github.com/codespell-project/codespell/commit/aa08625f13ded8eb0f66fb5af56ec9194a81b1fa#r124051079.