### PR TITLE
Add more variations of "except" and "exempt"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22405,9 +22405,13 @@ excentricity->eccentricity
 excentuating->accentuating
 exceopt->exempt, except,
 exceopted->exempted, excepted,
+exceopting->exempting, excepting,
+exceoption->exemption, exception,
+exceoptions->exemptions, exceptions,
 exceopts->exempts, excepts,
 exceot->except, exempt,
 exceoted->excepted, exempted,
+exceoting->excepting, exempting,
 exceotion->exception, exemption,
 exceotions->exceptions, exemptions,
 exceots->excepts, exempts,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22403,11 +22403,14 @@ excempts->exempts
 excentric->eccentric
 excentricity->eccentricity
 excentuating->accentuating
-exceopt->exempt
-exceopted->exempted
-exceopts->exempts
-exceotion->exemption
-exceotions->exemptions
+exceopt->exempt, except,
+exceopted->exempted, excepted,
+exceopts->exempts, excepts,
+exceot->except, exempt,
+exceoted->excepted, exempted,
+exceotion->exception, exemption,
+exceotions->exceptions, exemptions,
+exceots->excepts, exempts,
 excepetion->exception
 excepion->exception
 excepional->exceptional


### PR DESCRIPTION
"exception" (i.e. switcho from `p` to `o`) seems a lot more likely then "exemption", which is 2.5 letters distance.