### PR TITLE
Add spelling correction for "exis".

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22938,6 +22938,7 @@ exipration->expiration
 exipre->expire
 exipred->expired
 exipres->expires
+exis->exist, exists, exit, exits, axis, lexis, exes,
 exising->existing
 exisit->exist
 exisited->existed


### PR DESCRIPTION
Did that typo myself recently so adding it. See also e.g. the following below from https://grep.app/search?q=exis&words=true:

> spec "err log should exist with null in cluster mode"

or:

> print("File ",weigths_filename," does not exis. Retraining... ")