### PR TITLE
fixing setuptool_scm dependency because the latest version is broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ repository = "https://github.com/codespell-project/codespell"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=64", "setuptools_scm[toml]>=7.1.0"]
+requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2, != 8.0.0"]
 
 [tool.setuptools_scm]
 write_to = "codespell_lib/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ repository = "https://github.com/codespell-project/codespell"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=64", "setuptools_scm[toml]>=7.1.0"]
 
 [tool.setuptools_scm]
 write_to = "codespell_lib/_version.py"


### PR DESCRIPTION
The upstream fix is not released yet. Pinning the version has been proposed as a workaround [here](https://github.com/pypa/setuptools_scm/issues/908#issue-1904797205).

Tested using `make check` and by invoking the pre-commit hook.