### PR TITLE
Add schematrion->schematron

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -45990,6 +45990,7 @@ schedulier->scheduler
 schedulling->scheduling
 scheduluing->scheduling
 schem->scheme
+schematrio->schematron
 schematrion->schematron
 schemd->schemed
 schems->schemes

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -45990,6 +45990,7 @@ schedulier->scheduler
 schedulling->scheduling
 scheduluing->scheduling
 schem->scheme
+schematrion->schematron
 schemd->schemed
 schems->schemes
 schma->schema, schwa,


### PR DESCRIPTION
[`Schematron`](https://en.wikipedia.org/wiki/Schematron) is a schema language for XML.
I've found several instances of its typo, `Schematrion`, so thought it might be worth adding.

- xspec/xspec#1778
- https://github.com/apache/camel/blob/main/components/camel-schematron/src/main/docs/schematron-component.adoc#headers:~:text=The-,schematrion,-report%20body%20in
- https://stackoverflow.com/questions/38268457/schematrion-case-insensitive-sqfstringreplace#:~:text=for%20your%20Teams%3F-,Schematrion,-case%2Dinsensitive%20sqf
