### PR TITLE
Fix `no-commit-to-branch` Pre-Commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: no-commit-to-branch
-        args: [--branch, main]
+        args: [--branch, master]
       - id: check-yaml
         args: [--unsafe]
       - id: debug-statements


### PR DESCRIPTION
This check is currently configured to fail on the `main` branch, but this repo uses `master`. Updates this to fail when someone attempts to commit to the primary branch.