### PR TITLE
Ignore personal names Damon and Manuel

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -16538,7 +16538,6 @@ damge->damage
 daming->damning, damping, gaming, doming,
 dammage->damage
 dammages->damages
-damon->daemon, demon,
 damons->daemons, demons,
 danceing->dancing
 dandidates->candidates
@@ -33941,7 +33940,6 @@ manualls->manuals, manually,
 manualy->manually
 manualyl->manually
 manualyy->manually
-manuel->manual
 manuell->manual
 manuells->manuals
 manuelly->manually

--- a/codespell_lib/data/dictionary_names.txt
+++ b/codespell_lib/data/dictionary_names.txt
@@ -5,9 +5,11 @@ ba->by, be,
 bae->base
 bridget->bridged, bridge,
 chang->change
+damon->daemon, demon,
 fike->file
 forman->foreman
 liszt->list
+manuel->manual
 que->queue
 sargent->sergeant, argent,
 tim->time


### PR DESCRIPTION
Fixes https://github.com/codespell-project/codespell/issues/3202.

# Before

```console
$ codespell peps/pep-0703.rst peps/pep-0705.rst
peps/pep-0703.rst:74: Dota ==> Data
peps/pep-0703.rst:88: Manuel ==> Manual
peps/pep-0703.rst:312: Manuel ==> Manual
peps/pep-0703.rst:1164: re-use ==> reuse
peps/pep-0703.rst:1184: re-use ==> reuse
peps/pep-0703.rst:1188: re-use ==> reuse
peps/pep-0703.rst:1189: re-use ==> reuse
peps/pep-0705.rst:188: Damon ==> Daemon, Demon
peps/pep-0705.rst:189: Damon ==> Daemon, Demon
```

# After

```console
$ codespell peps/pep-0703.rst peps/pep-0705.rst
peps/pep-0703.rst:74: Dota ==> Data
peps/pep-0703.rst:1164: re-use ==> reuse
peps/pep-0703.rst:1184: re-use ==> reuse
peps/pep-0703.rst:1188: re-use ==> reuse
peps/pep-0703.rst:1189: re-use ==> reuse
```