### PR TITLE
Unify multiple identities of luzpuz and Dimitri

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Dimitri Papadopoulos Orfanos <3234522+DimitriPapadopoulos@users.noreply.github.com>
+luzpaz <luzpaz@@users.noreply.github.com> <luzpaz@users.noreply.github.com>


### PR DESCRIPTION
Now top of git shortlog -sn would look like

    ❯ git shortlog -sn | head
       933	luzpaz
       644	Peter Newman
       577	Andrea Gelmini
       506	Paul Wise
       323	Eric Larson
       193	Sebastian Weber
       165	Dimitri Papadopoulos Orfanos
       162	Lucas De Marchi
       125	Christian Fischer
        90	Stefan Kangas

instead of

    ❯ git shortlog -sn | head -n 15
       644	Peter Newman
       621	luzpaz
       577	Andrea Gelmini
       506	Paul Wise
       323	Eric Larson
       197	luz.paz
       193	Sebastian Weber
       162	Lucas De Marchi
       125	Christian Fischer
       123	luz paz
        98	Dimitri Papadopoulos
        90	Stefan Kangas
        87	cfi-gb
        83	Jason Yuen
        67	Dimitri Papadopoulos Orfanos