### PR TITLE
don't show stacktrace from KeyboardInterrupt #3217

### DIFF
--- a/codespell_lib/__main__.py
+++ b/codespell_lib/__main__.py
@@ -3,4 +3,7 @@ import sys
 from ._codespell import _script_main
 
 if __name__ == "__main__":
-    sys.exit(_script_main())
+    try:
+        sys.exit(_script_main())
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
This fixes #3217 where when pressing CTRL+C codespell shows a useless stack trace.