### PR TITLE
Add typos for knownledge->knowledge, analyzis->analysis and compialtion->compilation

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1400,6 +1400,14 @@ acknowleges->acknowledges
 acknowleging->acknowledging
 acknowlegment->acknowledgment
 acknowlegments->acknowledgments
+acknownledge->acknowledge
+acknownledged->acknowledged
+acknownledgement->acknowledgement
+acknownledgements->acknowledgements
+acknownledges->acknowledges
+acknownledging->acknowledging
+acknownledgment->acknowledgment
+acknownledgments->acknowledgments
 acknwoledge->acknowledge
 acknwoledged->acknowledged
 acknwoledges->acknowledges
@@ -3534,6 +3542,7 @@ analyzier->analyzer
 analyziers->analyzers
 analyzies->analysis, analyses, analyzes,
 analyziing->analyzing
+analyzis->analysis
 analzye->analyze
 analzyed->analyzed
 analzyer->analyzer
@@ -12582,6 +12591,8 @@ compexities->complexities
 compexity->complexity
 compfortable->comfortable
 comphrehensive->comprehensive
+compialtion->compilation, complication,
+compialtions->compilations, complications,
 compiant->compliant
 compicated->complicated
 compications->complications
@@ -32626,6 +32637,8 @@ knowned->known
 knowngly->knowingly
 knowning->knowing
 knowningly->knowingly
+knownledge->knowledge
+knownledgeable->knowledgeable
 knwo->know
 knwoing->knowing
 knwoingly->knowingly
@@ -55841,6 +55854,7 @@ unacceptible->unacceptable
 unaccesible->inaccessible
 unaccessable->inaccessible
 unacknowleged->unacknowledged
+unacknownledged->unacknowledged
 unacompanied->unaccompanied
 unadvertantly->inadvertently
 unadvertedly->inadvertently
@@ -56547,6 +56561,7 @@ unnessesary->unnecessary
 unnessessarily->unnecessarily
 unnessessary->unnecessary
 unning->running
+unnmatched->unmatched
 unnnecessarily->unnecessarily
 unnnecessary->unnecessary
 unnofficial->unofficial


### PR DESCRIPTION
Hello,
While proof-reading some documents, I stumbled upon `knownledge` (https://github.com/eosphoros-ai/DB-GPT/blob/1ad09c896f9d0db31894938a818415f8ad8efb6a/pilot/vector_store/extract_tovec.py#L16) and `Acknownledgement` (https://github.com/InfiniTimeOrg/InfiniTime/blob/9b8eb75f3480c16408f0d85f4a478826bf167f77/src/libs/mynewt-nimble/apps/blemesh_models_example_2/src/device_composition.c#L338). More misspelling can be found on https://github.com/search?q=knownledge&type=code . This Pull Request adds variations of `knownledge->knowledge`.

I also found `analyzis` and `compialtion` in some open-source projects. This Pull Request also adds these misspellings.