### PR TITLE
Add --stdin-single-line option

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -535,6 +535,11 @@ def parse_options(
         metavar="LINES",
         help="print LINES of surrounding context",
     )
+    parser.add_argument(
+        "--stdin-single-line",
+        action="store_true",
+        help="output just a single line for each misspelling in stdin mode",
+    )
     parser.add_argument("--config", type=str, help="path to config file.")
     parser.add_argument("--toml", type=str, help="path to a pyproject.toml file.")
     parser.add_argument("files", nargs="*", help="files or directories to check")
@@ -993,6 +998,8 @@ def parse_file(
                         f"{cfilename}:{cline}: {cwrongword} "
                         f"==> {crightword}{creason}"
                     )
+                elif options.stdin_single_line:
+                    print(f"{cline}: {cwrongword} ==> {crightword}{creason}")
                 else:
                     print(
                         f"{cline}: {line.strip()}\n\t{cwrongword} "

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1167,7 +1167,7 @@ def FakeStdin(text: str) -> Generator[None, None, None]:
 
 def run_codespell_stdin(
     text: str,
-    args: list[Any],
+    args: Tuple[Any, ...],
     cwd: Optional[Path] = None,
 ) -> int:
     """Run codespell in stdin mode and return number of lines in output."""
@@ -1192,9 +1192,9 @@ def test_stdin(tmp_path: Path) -> None:
     for _ in range(input_file_lines):
         text += "abandonned\n"
     for single_line_per_error in [True, False]:
-        args = []
+        args: Tuple[str, ...] = ()
         if single_line_per_error:
-            args.append("--stdin-single-line")
+            args = ("--stdin-single-line",)
         # we expect 'input_file_lines' number of lines with
         # --stdin-single-line and input_file_lines * 2 lines without it
         assert run_codespell_stdin(

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1163,3 +1163,40 @@ def FakeStdin(text: str) -> Generator[None, None, None]:
         yield
     finally:
         sys.stdin = oldin
+
+
+def run_codespell_stdin(
+    text: str,
+    args: list[Any],
+    cwd: Optional[Path] = None,
+) -> int:
+    """Run codespell in stdin mode and return number of lines in output."""
+    proc = subprocess.run(
+        ["codespell", *args, "-"],  # noqa: S603, S607
+        cwd=cwd,
+        input=text,
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+    output = proc.stdout
+    # get number of lines
+    count = output.count("\n")
+    return count
+
+
+def test_stdin(tmp_path: Path) -> None:
+    """Test running the codespell executable."""
+    input_file_lines = 4
+    text = ""
+    for _ in range(input_file_lines):
+        text += "abandonned\n"
+    for single_line_per_error in [True, False]:
+        args = []
+        if single_line_per_error:
+            args.append("--stdin-single-line")
+        # we expect 'input_file_lines' number of lines with
+        # --stdin-single-line and input_file_lines * 2 lines without it
+        assert run_codespell_stdin(
+            text, args=args, cwd=tmp_path
+        ) == input_file_lines * (2 - int(single_line_per_error))


### PR DESCRIPTION
Adds an option to output just a single line for each misspelling. Current only option with stdin outputs 2 lines per error which makes parsing difficult, e.g. here it requires extensive code to customize the parser to how codespell in stdin behaves: https://github.com/mfussenegger/nvim-lint/pull/457

Moreover current stdin behavior with output of 2 lines is not in line with the usual output of codespell, which normally outputs just a single line for each misspelling.

Suggested change does not change the default. Added logic is optional and useful.