### PR TITLE
Add typo offsers

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -37686,6 +37686,7 @@ offsence->offence
 offsense->offense
 offsenses->offenses
 offser->offset
+offsers->offers
 offsest->offsets, offset,
 offseted->offsetted
 offseting->offsetting


### PR DESCRIPTION
A sharp eye of the @musvaage spotted it in
https://github.com/zenodo/zenodo/pull/2470 .
And indeed github search gives 460 hits ATM
https://github.com/search?q=offsers&type=code
and they look like legit typos.

Typo is really close to offser->offset one, but upon quick github search I never found offser to be a typo for offer. I think that spurious "s" in offsers is mechanical, and thus I did not bother adding second variant for "offser" typo to be offer