### PR TITLE
Process files in sorted rather than arbitrary order

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1190,7 +1190,7 @@ def main(*args: str) -> int:
                     continue
                 if is_hidden(root, options.check_hidden):  # dir itself hidden
                     continue
-                for file_ in files:
+                for file_ in sorted(files):
                     # ignore hidden files in directories
                     if is_hidden(file_, options.check_hidden):
                         continue


### PR DESCRIPTION
It's easier to scan the output and work through it when its in sorted order rather than an arbitrary one.

# Before

```console
$ codespell peps
peps/pep-0521.rst:266: implementors ==> implementers
peps/pep-0284.rst:61: re-use ==> reuse
peps/pep-0694.rst:515: messasge ==> message, messages
peps/pep-0333.rst:1472: implementor ==> implementer
peps/pep-0482.rst:78: inferfaces ==> interfaces
peps/pep-0697.rst:424: intitializing ==> initializing
peps/pep-0495.rst:356: Implementors ==> Implementers
peps/pep-0481.rst:221: re-use ==> reuse
peps/pep-0480.rst:50: implementors ==> implementers
peps/pep-0480.rst:267: implementors ==> implementers
peps/pep-0480.rst:289: implementors ==> implementers
peps/pep-0457.rst:191: Implementor ==> Implementer
peps/pep-0730.rst:67: discernable ==> discernible
peps/pep-0724.rst:169: specificed ==> specified
peps/pep-0724.rst:263: unlikley ==> unlikely
peps/pep-0726.rst:282: overriden ==> overridden
peps/pep-0445.rst:20: re-use ==> reuse
peps/pep-0344.rst:378: implementors ==> implementers
peps/pep-0594.rst:165: astroid ==> asteroid
peps/pep-0543.rst:652: re-use ==> reuse
peps/pep-0543.rst:838: aNULL ==> annul
peps/pep-0582.rst:236: mdule ==> module
peps/pep-0637.rst:200: implementors ==> implementers
peps/pep-0637.rst:972: implementor ==> implementer
peps/pep-3115.rst:89: implementors ==> implementers
peps/pep-0568.rst:323: re-use ==> reuse
peps/pep-0554.rst:705: implementors ==> implementers
peps/pep-0554.rst:750: Insead ==> Instead
peps/pep-0554.rst:930: coverted ==> converted, covered, coveted
peps/pep-0554.rst:1362: re-use ==> reuse
peps/pep-0540.rst:69: Passthough ==> Passthrough, Pass though
peps/pep-0578.rst:110: implementors ==> implementers
peps/pep-0587.rst:1433: Re-use ==> Reuse
peps/pep-0632.rst:165: ccompiler ==> compiler, c compiler
peps/pep-0626.rst:34: implementions ==> implementations
peps/pep-0579.rst:109: re-use ==> reuse
peps/pep-0208.rst:93: implementor ==> implementer
peps/pep-0577.rst:735: re-usable ==> reusable
peps/pep-0574.rst:474: implementors ==> implementers
peps/pep-0574.rst:476: implementors ==> implementers
peps/pep-3134.rst:381: implementors ==> implementers
peps/pep-0207.rst:353: implementor ==> implementer
peps/pep-0377.rst:151: re-use ==> reuse
peps/pep-0377.rst:192: re-use ==> reuse
peps/pep-0606.rst:120: increamentally ==> incrementally
peps/pep-3333.rst:1589: implementor ==> implementer
peps/pep-0558.rst:1023: re-use ==> reuse
peps/pep-0572.rst:949: Groth ==> Growth
peps/pep-0413.rst:352: implementor ==> implementer
peps/pep-0639.rst:1046: Re-use ==> Reuse
peps/pep-0639.rst:1098: Re-Use ==> reuse
peps/pep-0272.rst:92: implementors ==> implementers
peps/pep-0272.rst:94: implementor ==> implementer
peps/pep-0272.rst:127: Implementors ==> Implementers
peps/pep-0702.rst:242: objecs ==> objects
peps/pep-0662.rst:186: re-use ==> reuse
peps/pep-8014.rst:135: measureable ==> measurable
peps/pep-3141.rst:407: implementors ==> implementers
peps/pep-3141.rst:410: Implementors ==> Implementers
peps/pep-0703.rst:74: Dota ==> Data
peps/pep-0703.rst:1164: re-use ==> reuse
peps/pep-0703.rst:1184: re-use ==> reuse
peps/pep-0703.rst:1188: re-use ==> reuse
peps/pep-0703.rst:1189: re-use ==> reuse
peps/pep-0517.rst:329: re-use ==> reuse
peps/pep-0517.rst:491: implementors ==> implementers
peps/pep-0660.rst:165: re-use ==> reuse
peps/pep-0506.rst:216: loath ==> loathe
peps/pep-0329.rst:109: re-use ==> reuse
peps/pep-0507.rst:224: re-use ==> reuse
peps/pep-0249.rst:1216: implementors ==> implementers
peps/pep-0249.rst:1265: implementors ==> implementers
peps/pep-0100.rst:374: implementors ==> implementers
peps/pep-0100.rst:618: implementors ==> implementers
peps/pep-0100.rst:622: Implementors ==> Implementers
peps/pep-0100.rst:698: implementors ==> implementers
peps/pep-0100.rst:792: accidentely ==> accidentally
peps/pep-0289.rst:75: re-use ==> reuse
peps/pep-0505/find-pep505.out:2224: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2228: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2232: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2236: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2240: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2244: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2248: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2252: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2256: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2260: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2264: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2268: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2272: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2276: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2280: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2284: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2288: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2292: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2296: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2300: ccompiler ==> compiler, c compiler
```

# After

```console
$ codespell peps
peps/pep-0100.rst:374: implementors ==> implementers
peps/pep-0100.rst:618: implementors ==> implementers
peps/pep-0100.rst:622: Implementors ==> Implementers
peps/pep-0100.rst:698: implementors ==> implementers
peps/pep-0100.rst:792: accidentely ==> accidentally
peps/pep-0207.rst:353: implementor ==> implementer
peps/pep-0208.rst:93: implementor ==> implementer
peps/pep-0249.rst:1216: implementors ==> implementers
peps/pep-0249.rst:1265: implementors ==> implementers
peps/pep-0272.rst:92: implementors ==> implementers
peps/pep-0272.rst:94: implementor ==> implementer
peps/pep-0272.rst:127: Implementors ==> Implementers
peps/pep-0284.rst:61: re-use ==> reuse
peps/pep-0289.rst:75: re-use ==> reuse
peps/pep-0329.rst:109: re-use ==> reuse
peps/pep-0333.rst:1472: implementor ==> implementer
peps/pep-0344.rst:378: implementors ==> implementers
peps/pep-0377.rst:151: re-use ==> reuse
peps/pep-0377.rst:192: re-use ==> reuse
peps/pep-0413.rst:352: implementor ==> implementer
peps/pep-0445.rst:20: re-use ==> reuse
peps/pep-0457.rst:191: Implementor ==> Implementer
peps/pep-0480.rst:50: implementors ==> implementers
peps/pep-0480.rst:267: implementors ==> implementers
peps/pep-0480.rst:289: implementors ==> implementers
peps/pep-0481.rst:221: re-use ==> reuse
peps/pep-0482.rst:78: inferfaces ==> interfaces
peps/pep-0495.rst:356: Implementors ==> Implementers
peps/pep-0506.rst:216: loath ==> loathe
peps/pep-0507.rst:224: re-use ==> reuse
peps/pep-0517.rst:329: re-use ==> reuse
peps/pep-0517.rst:491: implementors ==> implementers
peps/pep-0521.rst:266: implementors ==> implementers
peps/pep-0540.rst:69: Passthough ==> Passthrough, Pass though
peps/pep-0543.rst:652: re-use ==> reuse
peps/pep-0543.rst:838: aNULL ==> annul
peps/pep-0554.rst:705: implementors ==> implementers
peps/pep-0554.rst:750: Insead ==> Instead
peps/pep-0554.rst:930: coverted ==> converted, covered, coveted
peps/pep-0554.rst:1362: re-use ==> reuse
peps/pep-0558.rst:1023: re-use ==> reuse
peps/pep-0568.rst:323: re-use ==> reuse
peps/pep-0572.rst:949: Groth ==> Growth
peps/pep-0574.rst:474: implementors ==> implementers
peps/pep-0574.rst:476: implementors ==> implementers
peps/pep-0577.rst:735: re-usable ==> reusable
peps/pep-0578.rst:110: implementors ==> implementers
peps/pep-0579.rst:109: re-use ==> reuse
peps/pep-0582.rst:236: mdule ==> module
peps/pep-0587.rst:1433: Re-use ==> Reuse
peps/pep-0594.rst:165: astroid ==> asteroid
peps/pep-0606.rst:120: increamentally ==> incrementally
peps/pep-0626.rst:34: implementions ==> implementations
peps/pep-0632.rst:165: ccompiler ==> compiler, c compiler
peps/pep-0637.rst:200: implementors ==> implementers
peps/pep-0637.rst:972: implementor ==> implementer
peps/pep-0639.rst:1046: Re-use ==> Reuse
peps/pep-0639.rst:1098: Re-Use ==> reuse
peps/pep-0660.rst:165: re-use ==> reuse
peps/pep-0662.rst:186: re-use ==> reuse
peps/pep-0694.rst:515: messasge ==> message, messages
peps/pep-0697.rst:424: intitializing ==> initializing
peps/pep-0702.rst:242: objecs ==> objects
peps/pep-0703.rst:74: Dota ==> Data
peps/pep-0703.rst:1164: re-use ==> reuse
peps/pep-0703.rst:1184: re-use ==> reuse
peps/pep-0703.rst:1188: re-use ==> reuse
peps/pep-0703.rst:1189: re-use ==> reuse
peps/pep-0724.rst:169: specificed ==> specified
peps/pep-0724.rst:263: unlikley ==> unlikely
peps/pep-0726.rst:282: overriden ==> overridden
peps/pep-0730.rst:67: discernable ==> discernible
peps/pep-3115.rst:89: implementors ==> implementers
peps/pep-3134.rst:381: implementors ==> implementers
peps/pep-3141.rst:407: implementors ==> implementers
peps/pep-3141.rst:410: Implementors ==> Implementers
peps/pep-3333.rst:1589: implementor ==> implementer
peps/pep-8014.rst:135: measureable ==> measurable
peps/pep-0505/find-pep505.out:2224: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2228: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2232: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2236: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2240: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2244: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2248: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2252: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2256: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2260: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2264: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2268: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2272: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2276: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2280: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2284: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2288: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2292: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2296: ccompiler ==> compiler, c compiler
peps/pep-0505/find-pep505.out:2300: ccompiler ==> compiler, c compiler

```


# More info

https://stackoverflow.com/a/18282401/724176 says:

> `os.walk` uses `os.listdir`. Here is the docstring for `os.listdir`:
> 
> > listdir(path) -> list_of_strings
> > 
> > Return a list containing the names of the entries in the directory.
> > 
> >     path: path of directory to list
> > 
> > **The list is in arbitrary order**.  It does not include the special
> > entries '.' and '..' even if they are present in the directory.
> 
> (my emphasis).
> 
> You could, however, use `sort` to ensure the order you desire.
> 
>     for root, dirs, files in os.walk(path):
>        for dirname in sorted(dirs):
>             print(dirname)
