### PR TITLE
black → ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,17 +58,14 @@ repos:
           - -d
           - '{extends: relaxed, rules: {line-length: {max: 90}}}'
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.1.7
     hooks:
       - id: ruff
+      - id: ruff-format
   - repo:  https://github.com/PyCQA/autoflake
     rev: v2.2.1
     hooks:
       - id: autoflake
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
-    hooks:
-      - id: black
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ select = [
     "PLW",
     "S",
     "U",
+    "UP",
     "W",
     "YTT",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,21 @@ extend-ignore = [
     "ANN101",
     "B904",
     "PLW2901",
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
 ]
 line-length = 88
 select = [


### PR DESCRIPTION
Rationale:
- Use less tools, as we already use ruff.
- While black has always been very opinionated, ruff does provide a few options.

See for example https://github.com/pypa/setuptools/pull/4125#issuecomment-1822842090 and https://github.com/jaraco/skeleton/pull/99.

Also add new [pyupgrade (UP) ruff rules](https://docs.astral.sh/ruff/rules/#pyupgrade-up).