### PR TITLE
Get rid of autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,10 +62,6 @@ repos:
     hooks:
       - id: ruff
       - id: ruff-format
-  - repo:  https://github.com/PyCQA/autoflake
-    rev: v2.2.1
-    hooks:
-      - id: autoflake
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,6 @@ codespell_lib = [
     "py.typed",
 ]
 
-[tool.autoflake]
-in-place = true
-recursive = true
-expand-star-imports = true
-
 # TODO: reintegrate codespell configuration after updating test cases
 #[tool.codespell]
 #builtin = ["clear","rare","informal","usage","code","names"]


### PR DESCRIPTION
We have already moved to [ruff](https://astral.sh/ruff), no need to keep [autoflake](https://github.com/PyCQA/autoflake) as far as I can see.

@cclauss Why did you keep autoflake in #2779? Doesn't ruff cover autoflake (https://github.com/astral-sh/ruff/issues/1647)?