### PR TITLE
Collection of typos

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -53951,6 +53951,7 @@ termplating->templating
 termporal->temporal
 termporaries->temporaries
 termporarily->temporarily
+termporarly->temporarily
 termporary->temporary
 ternament->tournament
 ternimal->terminal

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2974,7 +2974,8 @@ allignmenterror->alignmenterror
 allignments->alignments
 alligns->aligns
 alliviate->alleviate
-allk->all
+allk->all, ally
+alll->all, ally
 alllocate->allocate
 alllocated->allocated
 alllocates->allocates

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -19613,6 +19613,8 @@ disabing->disabling
 disabl->disable
 disablle->disable
 disadvantadge->disadvantage
+disaggretate->disaggregate
+disaggretated->disaggregated
 disagreeed->disagreed
 disagress->disagrees
 disalb->disable

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13225,6 +13225,8 @@ conesencus->consensus
 conet->connect
 coneted->connected
 conetent->content
+conetented->contented
+conetenting->contenting
 conetents->contents
 coneting->connecting
 conetion->connection
@@ -19617,6 +19619,8 @@ disablle->disable
 disadvantadge->disadvantage
 disaggretate->disaggregate
 disaggretated->disaggregated
+disaggretates->disaggregates
+disaggretating->disaggregating
 disagreeed->disagreed
 disagress->disagrees
 disalb->disable

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -42329,6 +42329,8 @@ procuded->produced
 procuder->producer, procurer,
 procudes->produces, procures,
 procuding->producing, procuring,
+procudure->procedure
+procudures->procedures
 prodce->produce
 prodced->produced, proceed,
 prodceding->proceeding

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -56996,6 +56996,7 @@ upated->updated
 upater->updater
 upates->updates
 upating->updating
+upccoming->upcoming
 upcomming->upcoming
 updae->update
 updaed->updated

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2974,8 +2974,8 @@ allignmenterror->alignmenterror
 allignments->alignments
 alligns->aligns
 alliviate->alleviate
-allk->all, ally
-alll->all, ally
+allk->all, ally,
+alll->all, ally,
 alllocate->allocate
 alllocated->allocated
 alllocates->allocates

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -13224,6 +13224,8 @@ conervative->conservative
 conesencus->consensus
 conet->connect
 coneted->connected
+conetent->content
+conetents->contents
 coneting->connecting
 conetion->connection
 conetions->connections


### PR DESCRIPTION
This is a collection of typos identified in code reviews by my team over the past few months. I've also attempted to add variants of these words to the best of my ability. Huge thank you to the maintainers of this project for solving a very real need for us! We're at the point where roughly 90% of typo-related errors are being caught automatically.

Additionally, I've updated the `allk` misspelling to possibly also correct to `ally`.