### PR TITLE
Add two choices for verision typo fix

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -61756,6 +61756,8 @@ verions->versions
 veriosn->version
 veriosns->versions
 verious->various
+verision->version, revision, derision,
+verisions->versions, revisions,
 verison->version
 verisoned->versioned
 verisoner->versioner


### PR DESCRIPTION
Originally detected/fixed in
https://github.com/zenodo/zenodo/pull/2519

Apparently there is 13k hits on github:
https://github.com/search?q=verision&type=code

The other possible close match is derision, which is a legit word and is used in about of 45k hits on github: https://github.com/search?q=derision&type=code

'd' is nearby 'v', so even though unlikely, I have decided that best to have multiple choices here.