### PR TITLE
test: remove warning when aspell is not installed

### DIFF
--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -3,7 +3,6 @@ import os
 import os.path as op
 import pathlib
 import re
-import warnings
 from typing import Any, Dict, Iterable, Optional, Set, Tuple
 
 import pytest
@@ -37,11 +36,6 @@ except ImportError as e:
             f"REQUIRE_ASPELL=true. Got error during import:\n{e}"
         )
         raise RuntimeError(msg) from e
-    warnings.warn(
-        "aspell not found, but not required, skipping aspell tests. Got "
-        f"error during import:\n{e}",
-        stacklevel=2,
-    )
 
 global_err_dicts: Dict[str, Dict[str, Any]] = {}
 global_pairs: Set[Tuple[str, str]] = set()


### PR DESCRIPTION
pytest already prints a skip message, so the warning is not necessary and instead may cause confusion.

### Environment
```console
platform linux -- Python 3.11.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/manlio/src/contrib/python/github.com/perillo/codespell
configfile: pyproject.toml
plugins: anyio-3.7.1, cov-4.1.0, dependency-0.5.1
```

### Current pytest output
```console
====================================================================== warnings summary ======================================================================
../../../../../../../../usr/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186
  /usr/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186: UserWarning: aspell not found, but not required, skipping aspell tests. Got error during import:
  No module named 'aspell'
    exec(co, module.__dict__)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----------------------------- generated xml file: /home/manlio/src/contrib/python/github.com/perillo/codespell/junit-results.xml -----------------------------
================================================================== short test summary info ===================================================================
SKIPPED [16] codespell_lib/tests/test_dictionary.py:229: requires aspell-en
==================================================== 1 failed, 68 passed, 16 skipped, 1 warning in 50.29s ====================================================
```