### PR TITLE
Add prettier to pre-commit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,14 @@
 {
-    "name": "Codespell Development Environment",
-    "image": "mcr.microsoft.com/devcontainers/python:1-3",
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "github.vscode-github-actions",
-                "ms-python.python",
-                "ms-python.vscode-pylance"
-            ]
-        }
-    },
-    "postCreateCommand": "bash .devcontainer/post_create.sh"
+  "name": "Codespell Development Environment",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "github.vscode-github-actions",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post_create.sh"
 }

--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -20,16 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
-          - '3.12'
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
         no-toml:
-          - ''
+          - ""
         include:
-          - python-version: '3.10'
-            no-toml: 'no-toml'
+          - python-version: "3.10"
+            no-toml: "no-toml"
     name: ${{ matrix.python-version }} ${{ matrix.no-toml }}
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,6 @@ jobs:
       - run: codespell --check-filenames --skip="./.git/*,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
       # this file has an error
       - run: "! codespell codespell_lib/tests/test_basic.py"
-
 
   make-check-dictionaries:
     runs-on: ubuntu-latest

--- a/.github/workflows/codespell-windows.yml
+++ b/.github/workflows/codespell-windows.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,28 +18,28 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
-    - name: Build package
-      run: python -m build
-    - name: Check package
-      run: twine check --strict dist/*
-    - name: Check env vars
-      run: |
-        echo "Triggered by: ${{ github.event_name }}"
-    - uses: actions/upload-artifact@v4
-      with:
-        name: dist
-        path: dist
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build package
+        run: python -m build
+      - name: Check package
+        run: twine check --strict dist/*
+      - name: Check env vars
+        run: |
+          echo "Triggered by: ${{ github.event_name }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
 
   # PyPI on release
   pypi:
@@ -47,12 +47,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: dist
-        path: dist
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,10 @@ repos:
     hooks:
       - id: mdformat
         name: Format Markdown
-        entry: mdformat  # Executable to run, with fixed options
+        entry: mdformat # Executable to run, with fixed options
         language: python
         types: [markdown]
-        args: [--wrap, '75', --number]
+        args: [--wrap, "75", --number]
         additional_dependencies:
           - mdformat-toc
           - mdformat-beautysh
@@ -56,7 +56,7 @@ repos:
         args:
           - --no-warnings
           - -d
-          - '{extends: relaxed, rules: {line-length: {max: 90}}}'
+          - "{extends: relaxed, rules: {line-length: {max: 90}}}"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,11 @@ repos:
     hooks:
       - id: ruff
       - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [yaml, markdown, html, css, scss, javascript, json]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
--   id: codespell
-    name: codespell
-    description: Checks for common misspellings in text files.
-    entry: codespell
-    language: python
-    types: [text]
+- id: codespell
+  name: codespell
+  description: Checks for common misspellings in text files.
+  entry: codespell
+  language: python
+  types: [text]


### PR DESCRIPTION
This follows #3265 and addresses this [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=codespell-project%2Fcodespell&branch=master) issue:
* [PC180](https://learn.scientific-python.org/development/guides/style#PC180): Uses prettier
  Must have `https://github.com/pre-commit/mirrors-prettier` repo in `.pre-commit-config.yaml`

Partially fixes https://github.com/codespell-project/codespell/issues/3266.