### PR TITLE
Add tox.ini file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+min_version = 4.0
+env_list = unitest,type,dictionaries
+
+[testenv:unitest]
+description = run unit tests
+extras = dev
+commands = pytest --cov=codespell_lib codespell_lib
+
+[testenv:type]
+description = run type checks
+extras = types
+commands = mypy codespell_lib
+
+[testenv:dictionaries]
+description = run dictionary checks
+skip_install = true
+allowlist_externals = make
+commands = make check-dictionaries


### PR DESCRIPTION
Currently, when testing codespell on a local system, it is necessary to first install the package manually.

Add a `tox` file to improve user experience and ensure each step runs in an isolated environment.

There are two changes, compared to the current workflow:
  - pytest runs with coverage enabled
  - the package is not installed in editable mode

Additionally, for convenience, there is a step testing the dictionaries.

Update `.coveragerc` to exclude the `.tox` directory.

## TODO

### `aspell-python`

`aspell-python-py` is not installed in the `tox` environment.  The reason is that `pyproject.toml` does not declare that dependence; it is only installed in the `codespell-private.yml` workflow

### `testenv:dictionaries`

In `testenv:dictionaries` I decided to run the dictionary checks by calling `make`.
However, on a Windows system, the user may receive an unfriendly error message (**not tested**).

This is my first `tox` file, but things seems to work correctly.