### PR TITLE
dictionnary: persan can be persian.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -40293,7 +40293,7 @@ perposing->proposing, purposing,
 perpsective->perspective
 perpsectives->perspectives
 perrror->perror
-persan->person
+persan->person, persian,
 persciuos->precious
 persciuosly->preciously
 perscius->precious


### PR DESCRIPTION
Found a case where persan should be persian.