### PR TITLE
Enable lists in TOML config file

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -325,7 +325,11 @@ class NewlineHelpFormatter(argparse.HelpFormatter):
 
 def _toml_to_parseconfig(toml_dict: Dict[str, Any]) -> Dict[str, Any]:
     """Convert a dict read from a TOML file to the parseconfig.read_dict() format."""
-    return {k: "" if v is True else v for k, v in toml_dict.items() if v is not False}
+    return {
+        k: "" if v is True else ",".join(v) if isinstance(v, list) else v
+        for k, v in toml_dict.items()
+        if v is not False
+    }
 
 
 def _supports_ansi_colors() -> bool:

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1150,7 +1150,7 @@ def test_ill_formed_ini_config_file(
     assert "ill-formed config file" in stderr
 
 
-@pytest.mark.parametrize("kind", ("toml", "cfg"))
+@pytest.mark.parametrize("kind", ("cfg", "toml", "toml_list"))
 def test_config_toml(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1182,7 +1182,7 @@ skip = bad.txt, whatever.txt
 count =
 """
         )
-    else:
+    elif kind == "toml":
         assert kind == "toml"
         if sys.version_info < (3, 11):
             pytest.importorskip("tomli")
@@ -1192,6 +1192,20 @@ count =
             """\
 [tool.codespell]
 skip = 'bad.txt,whatever.txt'
+check-filenames = false
+count = true
+"""
+        )
+    else:
+        assert kind == "toml_list"
+        if sys.version_info < (3, 11):
+            pytest.importorskip("tomli")
+        tomlfile = tmp_path / "pyproject.toml"
+        args = ("--toml", tomlfile)
+        tomlfile.write_text(
+            """\
+[tool.codespell]
+skip = ['bad.txt', 'whatever.txt']
 check-filenames = false
 count = true
 """


### PR DESCRIPTION
Strings in a list are changed into a string containing comma-separated substrings. Of course, this means option arguments cannot contain a comma.

Fixes #3206.