### PR TITLE
Add spelling corrections for sphere

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27821,6 +27821,8 @@ hemipshere->hemisphere
 hemipsheres->hemispheres
 hemishpere->hemisphere
 hemishperes->hemispheres
+hemispere->hemisphere
+hemisperes->hemispheres
 hemlholtz->Helmholtz
 hemmorhage->haemorrhage, hemorrhage,
 hemmorhaged->haemorrhaged, hemorrhaged,
@@ -51119,7 +51121,10 @@ speration->separation
 sperations->separations
 sperator->separator
 sperators->separators
+spere->sphere
+speres->spheres
 sperhical->spherical
+sperical->spherical
 spermatozoan->spermatozoon
 speshal->special
 speshally->specially, especially,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -51121,8 +51121,8 @@ speration->separation
 sperations->separations
 sperator->separator
 sperators->separators
-spere->sphere
-speres->spheres
+spere->sphere, spare, spire, spore,
+speres->spheres, spares, spires, spores,
 sperhical->spherical
 sperical->spherical
 spermatozoan->spermatozoon


### PR DESCRIPTION
https://github.com/search?q=hemispere&type=code => 640 hits
https://github.com/search?q=hemisperes&type=code => 137 hits
https://github.com/search?q=sperical&type=code => 5.3k hits
For `spere`/`speres` the search returns a lot of irrelevant hits so it's hard to count true hits...