### PR TITLE
Add corrections for all *in->*ing words

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -54,6 +54,7 @@ abandonds->abandons
 abandone->abandon
 abandones->abandons
 abandonig->abandoning
+abandonin->abandoning
 abandonne->abandonment, abandon,
 abandonned->abandoned
 abandonnent->abandonment
@@ -63,6 +64,7 @@ abanonded->abandoned
 abanonding->abandoning
 abanondment->abandonment
 abanonds->abandons
+abasin->abasing
 abbbreviated->abbreviated
 abberation->aberration
 abberations->aberrations
@@ -124,6 +126,7 @@ abdominable->abdominal, abominable,
 abdomine->abdomen
 abdomnial->abdominal
 abdonimal->abdominal
+abductin->abducting
 aberation->aberration
 abigious->ambiguous
 abigiously->ambiguously
@@ -190,6 +193,7 @@ aboroginal->aboriginal
 aborption->absorption
 aborte->aborted, abort, aborts,
 abortificant->abortifacient
+abortin->aborting
 aboslute->absolute
 aboslutely->absolutely
 aboslutes->absolutes
@@ -251,6 +255,7 @@ absailing->abseiling
 absance->absence
 abscence->absence
 abscound->abscond
+abseilin->abseiling
 abselutely->absolutely
 abselutly->absolutely
 absense->absence
@@ -309,12 +314,14 @@ absoluute->absolute
 absoluutely->absolutely
 absoluve->absolute
 absoluvely->absolutely
+absolvin->absolving
 absolvte->absolve
 absoolute->absolute
 absoolutely->absolutely
 absoprtion->absorption
 absorbant->absorbent
 absorbes->absorbs
+absorbin->absorbing
 absorbsion->absorption
 absorbtion->absorption
 absorpsion->absorption
@@ -372,6 +379,7 @@ abstracly->abstractly
 abstracness->abstractness
 abstracor->abstractor
 abstracs->abstracts
+abstractin->abstracting
 abstracto->abstraction, abstract,
 abstrakt->abstract
 abstrakted->abstracted
@@ -443,6 +451,7 @@ abundunt->abundant
 aburpt->abrupt
 aburptly->abruptly
 abuseres->abusers
+abusin->abusing
 abusrd->absurd
 abusrdity->absurdity
 abusrdly->absurdly
@@ -595,6 +604,7 @@ accelerare->accelerate
 accelerater->accelerator, accelerated, accelerates, accelerate,
 acceleraters->accelerators, accelerates,
 acceleratie->accelerate
+acceleratin->accelerating
 acceleratio->acceleration, accelerator,
 accelerato->acceleration
 acceleratoin->acceleration
@@ -622,6 +632,7 @@ accended->ascended
 accending->ascending
 accends->ascends, accents,
 accension->accession, ascension,
+accentuatin->accentuating
 acceot->accept
 acceotable->acceptable
 acceotably->acceptably
@@ -685,6 +696,7 @@ acceptence->acceptance
 acceptes->accepts
 acceptible->acceptable
 acceptibly->acceptably
+acceptin->accepting
 acceptted->accepted
 accerelate->accelerate
 accerelated->accelerated
@@ -726,6 +738,7 @@ accessiblity->accessibility
 accessiibility->accessibility
 accessiiblity->accessibility
 accessile->accessible
+accessin->accessing
 accessintg->accessing
 accessisble->accessible
 accessment->assessment
@@ -864,6 +877,7 @@ accommidated->accommodated
 accommidates->accommodates
 accommidating->accommodating
 accommidation->accommodation
+accommodatin->accommodating
 accomodata->accommodate
 accomodate->accommodate
 accomodated->accommodated
@@ -885,6 +899,7 @@ accompagny->accompany
 accompagnying->accompanying
 accompained->accompanied
 accompanyed->accompanied
+accompanyin->accompanying
 accompianed->accompanied
 accompined->accompanied
 accompinied->accompanied
@@ -897,6 +912,7 @@ accomplishemnt->accomplishment
 accomplishemnts->accomplishments
 accomplishent->accomplishment
 accomplishents->accomplishments
+accomplishin->accomplishing
 accomplishs->accomplishes
 accomplising->accomplishing
 accomplisment->accomplishment
@@ -982,6 +998,7 @@ accountatns->accountants
 accountats->accountants
 accountent->accountant
 accountents->accountants
+accountin->accounting
 accountt->account, accountant,
 accourdance->accordance
 accourding->according
@@ -1040,6 +1057,7 @@ accrediated->accredited
 accrediation->accreditation
 accredidation->accreditation
 accreditied->accredited
+accreditin->accrediting
 accreditted->accredited
 accress->access
 accroding->according
@@ -1167,6 +1185,7 @@ accurring->occurring
 accurs->accurse, occurs,
 accusating->accusation
 accusato->accusation
+accusin->accusing
 accusition->accusation
 accussed->accused
 accustommed->accustomed
@@ -1271,6 +1290,7 @@ achievemnt->achievement
 achievemnts->achievements
 achievemts->achieves, achievements,
 achievents->achieves, achievements,
+achievin->achieving
 achievment->achievement
 achievments->achievements
 achievs->achieves
@@ -1278,6 +1298,7 @@ achillees->Achilles
 achilleos->Achilles
 achilleous->Achilles
 achilleus->Achilles
+achin->aching
 achitecture->architecture
 achitectures->architectures
 achivable->achievable
@@ -1386,6 +1407,7 @@ acknowledgeing->acknowledging
 acknowledgemnt->acknowledgement
 acknowledgemnts->acknowledgements
 acknowledget->acknowledgement
+acknowledgin->acknowledging
 acknowleding->acknowledging
 acknowlegde->acknowledge
 acknowlegded->acknowledged
@@ -1493,6 +1515,7 @@ acquaintaince->acquaintance
 acquaintainces->acquaintances
 acquaintence->acquaintance
 acquaintences->acquaintances
+acquaintin->acquainting
 acquaintince->acquaintance
 acquaintinces->acquaintances
 acquanitance->acquaintance
@@ -1508,6 +1531,7 @@ acquiantances->acquaintances
 acquianted->acquainted
 acquiantence->acquaintance
 acquiantences->acquaintances
+acquiescin->acquiescing
 acquiesence->acquiescence
 acquiess->acquiesce
 acquiessed->acquiesced
@@ -1515,6 +1539,7 @@ acquiesses->acquiesces
 acquiessing->acquiescing
 acquifer->aquifer, acquire,
 acquinated->acquainted
+acquirin->acquiring
 acquisation->acquisition
 acquisito->acquisition
 acquisiton->acquisition
@@ -1753,6 +1778,7 @@ adapte->adapter
 adaptee->adapted
 adaptes->adapters
 adaptibe->adaptive
+adaptin->adapting
 adaptove->adaptive, adoptive,
 adaquate->adequate
 adaquately->adequately
@@ -1828,6 +1854,7 @@ addiitonal->additional
 addiitonall->additional
 addiitonally->additionally
 addiitons->additions
+addin->adding
 addional->additional
 addionally->additionally
 addiotion->addition
@@ -1920,6 +1947,7 @@ addresse->addresses, address,
 addressess->addresses
 addressibility->addressability
 addressible->addressable
+addressin->addressing
 addressings->addressing
 addresss->address
 addresssed->addressed
@@ -1962,6 +1990,7 @@ adhearing->adhering
 adheasive->adhesive
 adheasives->adhesives
 adherance->adherence
+adherin->adhering
 adiacent->adjacent
 adiditon->addition
 adin->admin
@@ -2034,6 +2063,7 @@ adjustements->adjustments
 adjustes->adjusted, adjusts,
 adjustificat->justification
 adjustification->justification
+adjustin->adjusting
 adjustmant->adjustment
 adjustmants->adjustments
 adjustmenet->adjustment
@@ -2065,6 +2095,7 @@ administative->administrative
 administatively->administratively
 administator->administrator
 administators->administrators
+administerin->administering
 administor->administrator
 administors->administrators
 administraion->administration
@@ -2116,6 +2147,7 @@ admissable->admissible
 admited->admitted
 admitedly->admittedly
 admiting->admitting
+admittin->admitting
 admn->admin
 admnistrator->administrator
 admnistrators->administrators
@@ -2182,6 +2214,7 @@ advanatage->advantage
 advanatages->advantages
 advanatge->advantage
 advanatges->advantages
+advancin->advancing
 advandce->advance, advanced,
 advandced->advanced
 advandces->advances
@@ -2207,9 +2240,11 @@ adventages->advantages
 adventagous->advantageous
 adventagously->advantageously
 adventrous->adventurous
+adventurin->adventuring
 adverised->advertised
 advertice->advertise
 adverticed->advertised
+advertisin->advertising
 advertisment->advertisement
 advertisments->advertisements
 advertistment->advertisement
@@ -2225,6 +2260,7 @@ advicable->advisable
 adviced->advised
 advicing->advising
 adviseable->advisable
+advisin->advising
 advisoriy->advisory, advisories,
 advisoriyes->advisories
 advizable->advisable
@@ -2251,6 +2287,7 @@ aferwards->afterwards
 afetr->after
 affact->affect, effect,
 affecfted->affected
+affectin->affecting
 affekt->affect, effect,
 afficianado->aficionado
 afficianados->aficionados
@@ -2345,6 +2382,8 @@ aggragation->aggregation
 aggragations->aggregations
 aggragator->aggregator
 aggragators->aggregators
+aggrandisin->aggrandising
+aggrandizin->aggrandizing
 aggrate->aggregate, aggravate,
 aggrated->aggregated, aggravated,
 aggrates->aggregates, aggravates,
@@ -2353,6 +2392,7 @@ aggration->aggregation
 aggrations->aggregations
 aggrator->aggregator
 aggrators->aggregators
+aggravatin->aggravating
 aggreagate->aggregate
 aggreagated->aggregated
 aggreagates->aggregates
@@ -2382,6 +2422,7 @@ aggrees->agrees
 aggregater->aggregator, aggregated, aggregates, aggregate,
 aggregaters->aggregators, aggregates,
 aggregatet->aggregated
+aggregatin->aggregating
 aggregete->aggregate
 aggregeted->aggregated
 aggregetes->aggregates
@@ -2430,6 +2471,7 @@ agianst->against
 agin->again
 agina->again, angina,
 aginst->against
+agitatin->agitating
 aglorithm->algorithm
 aglorithmic->algorithmic
 aglorithms->algorithms
@@ -2459,6 +2501,7 @@ agreeeing->agreeing
 agreeement->agreement
 agreeements->agreements
 agreees->agrees
+agreein->agreeing
 agreemnet->agreement
 agreemnets->agreements
 agreemnt->agreement
@@ -2515,6 +2558,7 @@ ahving->having
 aicraft->aircraft
 aiffer->differ
 ailgn->align
+ailin->ailing
 aiport->airport
 airator->aerator
 airators->aerators
@@ -2864,7 +2908,9 @@ alhpabets->alphabets
 aliagn->align
 aliasas->aliases
 aliase->aliases, alias,
+aliasin->aliasing
 aliasses->aliases
+alienatin->alienating
 alientating->alienating
 aliged->aligned
 aligh->align, alight,
@@ -2879,6 +2925,7 @@ alighnment->alignment
 alighnments->alignments
 alighns->aligns, alights,
 alighs->aligns, alights,
+alightin->alighting
 aligin->align
 aligined->aligned
 aliging->aligning
@@ -2901,6 +2948,7 @@ alignemnt->alignment
 alignemnts->alignments
 alignemt->alignment
 alignes->aligns
+alignin->aligning
 alignmant->alignment
 alignmen->alignment
 alignmenet->alignment
@@ -2962,6 +3010,7 @@ allegedy->allegedly
 allegely->allegedly
 allegence->allegiance
 allegience->allegiance
+alleviatin->alleviating
 allias->alias
 alliased->aliased
 alliases->aliases
@@ -3020,6 +3069,7 @@ allocateing->allocating
 allocateng->allocating
 allocater->allocator, allocated, allocates, allocate,
 allocaters->allocators, allocates,
+allocatin->allocating
 allocationg->allocating, allocation,
 allocaton->allocation
 allocatoor->allocator
@@ -3054,6 +3104,7 @@ allowe->allowed, allow, allows,
 allowence->allowance
 allowences->allowances
 allowes->allows, allowed,
+allowin->allowing
 allpication->application
 allpications->applications
 allready->already, all ready,
@@ -3223,6 +3274,7 @@ alterating->altering, alternating,
 alterative->alternative
 alteratively->alternatively
 alteratives->alternatives
+alterin->altering
 alterior->ulterior
 alternaive->alternative
 alternaively->alternatively
@@ -3236,6 +3288,7 @@ alternaties->alternatives, alternates,
 alternatiev->alternative
 alternatievly->alternatively
 alternatievs->alternatives
+alternatin->alternating
 alternativ->alternative
 alternativey->alternatively
 alternativley->alternatively
@@ -3312,6 +3365,7 @@ amature->amateur, armature, a mature,
 amatures->amateurs, armatures,
 amaturs->amateurs
 amazaing->amazing
+amazin->amazing
 ambadexterous->ambidextrous
 ambadexterouseness->ambidextrousness
 ambadexterously->ambidextrously
@@ -3378,7 +3432,9 @@ amelearator->ameliorator
 amelearators->ameliorators
 ameliorater->ameliorator, ameliorated, ameliorates, ameliorate,
 amelioraters->ameliorators, ameliorates,
+amelioratin->ameliorating
 amendement->amendment
+amendin->amending
 amendmant->amendment
 amened->amended, amend,
 Amercia->America
@@ -3419,10 +3475,12 @@ amongs->among
 amonst->amongst
 amont->among, amount,
 amonut->amount
+amortizin->amortizing
 amound->amount
 amounds->amounts
 amoung->among
 amoungst->amongst
+amountin->amounting
 amout->amount
 amoutn->amount
 amoutns->amounts
@@ -3528,6 +3586,7 @@ analysiers->analysers
 analysies->analyses, analysis,
 analysiing->analysing
 analysiis->analysis
+analysin->analysing
 analysises->analyses
 analystic->analytic
 analystical->analytical
@@ -3546,6 +3605,7 @@ analyzier->analyzer
 analyziers->analyzers
 analyzies->analysis, analyses, analyzes,
 analyziing->analyzing
+analyzin->analyzing
 analyzis->analysis
 analzye->analyze
 analzyed->analyzed
@@ -3626,6 +3686,7 @@ ancestory->ancestry
 anchestor->ancestor
 anchestors->ancestors
 anchord->anchored
+anchorin->anchoring
 ancilliary->ancillary
 anconda->anaconda
 ancondas->anacondas
@@ -3711,6 +3772,7 @@ animaties->animates
 animatiing->animating
 animatiion->animation
 animatiions->animations
+animatin->animating
 animatior->animator, animation,
 animatiors->animators, animations,
 animatng->animating
@@ -3795,6 +3857,7 @@ annayed->annoyed
 annaying->annoying
 annays->annoys, any,
 annd->and
+annealin->annealing
 annecessary->unnecessary, a necessary,
 annhilate->annihilate
 annhilated->annihilated
@@ -3802,6 +3865,7 @@ annhilates->annihilates
 annhilating->annihilating
 annhilation->annihilation
 annhilations->annihilations
+annihilatin->annihilating
 anniversery->anniversary
 annnotate->annotate
 annnotated->annotated
@@ -3858,6 +3922,7 @@ annotaion->annotation
 annotaions->annotations
 annotaor->annotator
 annotaors->annotators
+annotatin->annotating
 annote->annotate
 annoted->annotated
 annotes->annotates
@@ -3874,6 +3939,7 @@ annoucements->announcements
 annouces->announces
 annoucing->announcing
 annouing->annoying
+announcin->announcing
 announcment->announcement
 announcments->announcements
 announed->announced
@@ -3881,13 +3947,16 @@ announement->announcement
 announements->announcements
 annoyence->annoyance
 annoyences->annoyances
+annoyin->annoying
 annoymous->anonymous
 annoyn->annoy, annoying,
 annoyning->annoying
 annoyningly->annoyingly
 annoyying->annoying
+annualizin->annualizing
 annualy->annually
 annuled->annulled
+annullin->annulling
 annyo->annoy
 annyoance->annoyance
 annyoances->annoyances
@@ -3897,6 +3966,7 @@ annyoingly->annoyingly
 annyos->annoys
 anoher->another
 anohter->another
+anointin->anointing
 anologon->analogon
 anologous->analogous
 anomally->anomaly
@@ -3978,6 +4048,7 @@ ansester->ancestor
 ansesters->ancestors
 ansestor->ancestor
 ansestors->ancestors
+answerin->answering
 answhare->answer
 answhared->answered
 answhareing->answering
@@ -3998,6 +4069,7 @@ anthromorphization->anthropomorphization
 anthropolgist->anthropologist
 anthropolgy->anthropology
 antialialised->antialiased
+antialiasin->antialiasing
 antialising->antialiasing
 antiapartheid->anti-apartheid
 anticdote->anecdote, antidote,
@@ -4183,6 +4255,8 @@ apoints->appoints
 apolegetic->apologetic
 apolegetics->apologetics
 apollstree->upholstery
+apologisin->apologising
+apologizin->apologizing
 apon->upon, apron,
 aportionable->apportionable
 apostrafes->apostrophes
@@ -4191,6 +4265,7 @@ apostrafy->apostrophe
 apostrophie->apostrophe
 apostrophies->apostrophes
 appache->apache
+appallin->appalling
 appar->appear
 apparance->appearance
 apparances->appearances
@@ -4199,6 +4274,8 @@ apparantly->apparently
 appareance->appearance
 appareances->appearances
 appared->appeared
+apparelin->appareling
+apparellin->apparelling
 apparen->apparent
 apparence->appearance
 apparences->appearances
@@ -4223,6 +4300,7 @@ appartments->apartments
 appathetic->apathetic
 appature->aperture
 appatures->apertures
+appealin->appealing
 appealling->appealing, appalling,
 appearaing->appearing
 appearant->apparent
@@ -4233,6 +4311,7 @@ appearences->appearances
 appearent->apparent
 appearently->apparently
 appeares->appears
+appearin->appearing
 appearning->appearing
 appearrs->appears
 appeciate->appreciate
@@ -4250,6 +4329,7 @@ appendent->appended
 appendex->appendix
 appendig->appending
 appendign->appending
+appendin->appending
 appendt->append
 appened->append, appended, happened,
 appeneded->appended
@@ -4356,6 +4436,7 @@ applyications->applications
 applyied->applied
 applyies->applies
 applyig->applying
+applyin->applying
 applys->applies
 applyting->applying
 appned->append
@@ -4372,6 +4453,7 @@ appoach->approach
 appoached->approached
 appoaches->approaches
 appoaching->approaching
+appointin->appointing
 appologies->apologies
 appologise->apologise
 appologised->apologised
@@ -4494,6 +4576,7 @@ apprecaites->appreciates
 apprecaiting->appreciating
 apprecaition->appreciation
 apprecaitive->appreciative
+appreciatin->appreciating
 appreicate->appreciate
 appreicated->appreciated
 appreicates->appreciates
@@ -4543,6 +4626,7 @@ appriximates->approximates
 appriximating->approximating
 appriximation->approximation
 appriximations->approximations
+approachin->approaching
 approachs->approaches
 approbiate->appropriate
 approbiately->appropriately
@@ -4594,6 +4678,7 @@ appropriat->appropriate
 appropriatedly->appropriately
 appropriatee->appropriate
 appropriateely->appropriately
+appropriatin->appropriating
 appropriatly->appropriately
 appropriatness->appropriateness
 appropriete->appropriate
@@ -4631,6 +4716,7 @@ approuved->approved
 approuves->approves
 approuving->approving
 approvement->approval
+approvin->approving
 approxamate->approximate
 approxamated->approximated
 approxamately->approximately
@@ -4655,6 +4741,7 @@ approxiating->approximating
 approxiation->approximation
 approxiations->approximations
 approximat->approximate
+approximatin->approximating
 approximatively->approximately
 approximatly->approximately
 approxime->approximate
@@ -4985,6 +5072,7 @@ architures->architectures
 archiv->archive
 archivd->archived
 archivel->archival
+archivin->archiving
 archivr->archiver
 archivrs->archivers
 archivs->archives
@@ -5069,6 +5157,7 @@ arguemtn->argument
 arguemtns->arguments
 arguent->argument
 arguents->arguments
+arguin->arguing
 argumant->argument
 argumants->arguments
 argumeent->argument
@@ -5147,6 +5236,7 @@ armistace->armistice
 armistis->armistice
 armistises->armistices
 armonic->harmonic
+armorin->armoring
 armorment->armament
 armorments->armaments
 arn't->aren't
@@ -5218,6 +5308,7 @@ arrangemenet->arrangement
 arrangemenets->arrangements
 arrangent->arrangement
 arrangents->arrangements
+arrangin->arranging
 arrangmeent->arrangement
 arrangmeents->arrangements
 arrangmenet->arrangement
@@ -5269,6 +5360,7 @@ arrivie->arrive
 arrivied->arrived
 arrivies->arrives
 arriviing->arriving
+arrivin->arriving
 arro->arrow
 arros->arrows
 arround->around
@@ -5342,6 +5434,7 @@ asbtractors->abstractors
 asbtracts->abstracts
 ascconciated->associated
 asceding->ascending
+ascendin->ascending
 ascic->ASCII, aspic, ascetic,
 ascpect->aspect
 ascpects->aspects
@@ -5410,6 +5503,7 @@ asisting->assisting
 asists->assists
 aske->ask
 askes->asks
+askin->asking
 aslo->also
 asnwer->answer
 asnwered->answered
@@ -5434,6 +5528,7 @@ asolute->absolute
 asorbed->absorbed
 aspected->expected
 aspestus->asbestos
+asphaltin->asphalting
 asphyxation->asphyxiation
 assasin->assassin
 assasinate->assassinate
@@ -5483,6 +5578,7 @@ assembe->assemble
 assembed->assembled
 assembeld->assembled
 assember->assembler
+assemblin->assembling
 assemblys->assemblies
 assemby->assembly
 assemly->assembly
@@ -5505,6 +5601,7 @@ assersive->assertive
 assersively->assertively
 assertation->assertion
 assertations->assertions
+assertin->asserting
 assertino->assertion
 assertinos->assertions
 assertio->assertion
@@ -5518,6 +5615,7 @@ asserttively->assertively
 assesmenet->assessment
 assesment->assessment
 assesments->assessments
+assessin->assessing
 assessmant->assessment
 assessmants->assessments
 assfalt->asphalt
@@ -5589,6 +5687,7 @@ assignenmentes->assignments
 assignenments->assignments
 assignenmet->assignment
 assignes->assigns
+assignin->assigning
 assignmen->assignment, assign men,
 assignmenet->assignment
 assignmenets->assignments
@@ -5618,6 +5717,7 @@ assihns->assigns
 assime->assume
 assimed->assumed
 assimes->assumes
+assimilatin->assimilating
 assiming->assuming
 assimption->assumption
 assimptions->assumptions
@@ -5676,6 +5776,7 @@ assissts->assists
 assistence->assistance
 assistent->assistant
 assistents->assistants
+assistin->assisting
 assit->assist
 assitance->assistance
 assitant->assistant
@@ -5753,6 +5854,7 @@ associateive->associative
 associatie->associate, associative,
 associatied->associated
 associaties->associates
+associatin->associating
 associats->associates
 associcate->associate
 associcated->associated
@@ -5900,6 +6002,7 @@ assumbes->assumes
 assumbing->assuming
 assumend->assumed
 assumimg->assuming
+assumin->assuming
 assumking->assuming
 assumme->assume
 assummed->assumed
@@ -6153,6 +6256,7 @@ attachemnt->attachment
 attachemnts->attachments
 attachen->attach
 attachged->attached
+attachin->attaching
 attachmant->attachment
 attachmants->attachments
 attachs->attaches
@@ -6162,6 +6266,7 @@ attachtes->attaches
 attachting->attaching
 attachtment->attachment
 attachtments->attachments
+attackin->attacking
 attacs->attacks
 attacthed->attached
 attaindre->attainder, attained,
@@ -6199,6 +6304,7 @@ attemping->attempting
 attemppt->attempt
 attemps->attempts
 attemptes->attempts
+attemptin->attempting
 attemptting->attempting
 attemt->attempt
 attemted->attempted
@@ -6213,12 +6319,14 @@ attemts->attempts
 attendence->attendance
 attendent->attendant
 attendents->attendants
+attendin->attending
 attened->attended
 attennuation->attenuation
 attension->attention
 attented->attended
 attentuation->attenuation
 attentuations->attenuations
+attenuatin->attenuating
 attepmpt->attempt
 attept->attempt
 attepted->attempted
@@ -6310,6 +6418,7 @@ attribut->attribute
 attributei->attribute
 attributen->attribute
 attributess->attributes
+attributin->attributing
 attributre->attribute
 attributred->attributed
 attributres->attributes
@@ -6405,6 +6514,7 @@ audeince->audience
 audiance->audience
 aufter->after
 augest->August
+augmentin->augmenting
 augmnet->augment
 augmnetation->augmentation
 augmneted->augmented
@@ -6616,6 +6726,7 @@ authenticaors->authenticators
 authenticateion->authentication
 authenticater->authenticator, authenticated, authenticates, authenticate,
 authenticaters->authenticators, authenticates,
+authenticatin->authenticating
 authenticaton->authentication
 authenticte->authenticate
 authenticted->authenticated
@@ -6707,12 +6818,15 @@ authoratitative->authoritative
 authoratitatively->authoritatively
 authorative->authoritative
 authorded->authored
+authorin->authoring
+authorisin->authorising
 authorites->authorities
 authorithy->authority
 authoritiers->authorities
 authorititive->authoritative
 authoritive->authoritative
 authorizeed->authorized
+authorizin->authorizing
 authos->authors, autos,
 authro->author
 authroed->authored
@@ -6765,8 +6879,10 @@ autmaton->automaton
 autmobile->automobile
 autmobiles->automobiles
 autmotive->automotive
+auto-deletin->auto-deleting
 auto-dependancies->auto-dependencies
 auto-destrcut->auto-destruct
+auto-detectin->auto-detecting
 auto-detet->auto-detect, auto-delete,
 auto-deteted->auto-detected, auto-deleted,
 auto-detetes->auto-deletes, auto-detects,
@@ -6831,6 +6947,8 @@ autocmpleted->autocompleted
 autocmpletes->autocompletes
 autocmpleting->autocompleting
 autocommiting->autocommitting
+autocommittin->autocommitting
+autocompletin->autocompleting
 autoconplete->autocomplete
 autoconpleted->autocompleted
 autoconpletes->autocompletes
@@ -6842,10 +6960,12 @@ autoeselect->autoselect
 autofilt->autofilter
 autofomat->autoformat
 autoformating->autoformatting
+autoformattin->autoformatting
 autogenrated->autogenerated
 autogenratet->autogenerated
 autogenration->autogeneration
 autogroping->autogrouping
+autogroupin->autogrouping
 autohorized->authorized
 autoincrememnt->autoincrement
 autoincrementive->autoincrement
@@ -6864,6 +6984,7 @@ automaticalyl->automatically
 automaticalyy->automatically
 automaticlly->automatically
 automaticly->automatically
+automatin->automating
 autometic->automatic
 autometically->automatically
 automibile->automobile
@@ -6946,6 +7067,7 @@ autosae->autosave
 autosavegs->autosaves
 autosaveperodical->autosaveperiodical
 autosence->autosense
+autospacin->autospacing
 autotorium->auditorium
 autotoriums->auditoriums
 autum->autumn
@@ -7095,6 +7217,7 @@ avdisoriyes->advisories
 avdisory->advisory
 avengence->a vengeance
 averageed->averaged
+averagin->averaging
 averagine->averaging
 averload->overload
 averloaded->overloaded
@@ -7122,6 +7245,7 @@ avoded->avoided
 avoding->avoiding
 avods->avoids
 avoidence->avoidance
+avoidin->avoiding
 avoind->avoid
 avoinded->avoided
 avoinding->avoiding
@@ -7143,6 +7267,7 @@ awfuly->awfully
 awkard->awkward
 awming->awning
 awmings->awnings
+awnin->awning
 awnser->answer
 awnsered->answered
 awnsers->answers
@@ -7234,6 +7359,7 @@ backkgrounds->backgrounds
 backlght->backlight
 backlghting->backlighting
 backlghts->backlights
+backlightin->backlighting
 backned->backend
 backneds->backends
 backound->background
@@ -7250,6 +7376,7 @@ backslases->backslashes
 backslashs->backslashes
 backtic->backtick
 backtics->backticks
+backtrackin->backtracking
 backupped->backed-up, backed up,
 backwad->backwards
 backwar->backward
@@ -7281,6 +7408,7 @@ bahavior->behavior
 bahavioral->behavioral
 bahaviors->behaviors
 bahaviour->behaviour
+bailin->bailing
 bais->bias, basis, bails, baits,
 baisc->basic
 baiscally->basically
@@ -7288,6 +7416,7 @@ baiscs->basics
 baised->raised, biased, braised, bailed, baited,
 baises->raises, biases, braises,
 baising->raising, biasing, braising, bailing, baiting,
+baitin->baiting
 bakc->back
 bakcend->backend
 bakcends->backends
@@ -7312,6 +7441,7 @@ balacer->balancer
 balacers->balancers
 balaces->balances
 balacing->balancing
+balancin->balancing
 balaster->baluster
 balasters->balusters
 balck->black, balk,
@@ -7391,6 +7521,7 @@ bassic->basic
 bassically->basically
 bassics->basics
 bassis->basis
+bastardizin->bastardizing
 bastract->abstract
 bastracted->abstracted
 bastracter->abstracter
@@ -7443,6 +7574,7 @@ beastiaries->bestiaries
 beastiary->bestiary
 beatiful->beautiful
 beatifully->beautifully
+beatin->beating
 beauquet->bouquet
 beauquets->bouquets
 beauracracy->bureaucracy
@@ -7495,6 +7627,7 @@ bechmarking->benchmarking
 bechmarks->benchmarks
 becoem->become
 becomeing->becoming
+becomin->becoming
 becomme->become
 becommes->becomes
 becomming->becoming
@@ -7507,6 +7640,7 @@ becuase->because
 becuse->because
 becuz->because
 becxause->because
+beddin->bedding
 beding->bedding, begging,
 bedore->before
 beecause->because
@@ -7587,6 +7721,7 @@ behaivour->behaviour
 behaivoural->behavioural
 behaivours->behaviours
 behavies->behaves
+behavin->behaving
 behavio->behavior
 behavioal->behavioral
 behavios->behaviors
@@ -7636,6 +7771,7 @@ behvioural->behavioural
 behviours->behaviours
 beigin->begin
 beiginning->beginning
+bein->being
 beind->behind, being,
 beinning->beginning
 bejond->beyond
@@ -7670,6 +7806,7 @@ beliefe->believe, belief,
 beliefed->believed
 beliefes->beliefs, believes,
 beliefing->believing
+believin->believing
 beligum->belgium
 beling->belong
 beliv->believe, belief,
@@ -7688,6 +7825,7 @@ belog->belong
 beloging->belonging
 belogs->belongs
 belond->belong
+belongin->belonging
 beloning->belonging
 belove->below, beloved,
 belowe->below
@@ -7706,6 +7844,8 @@ benchamrk->benchmark
 benchamrked->benchmarked
 benchamrking->benchmarking
 benchamrks->benchmarks
+benchin->benching
+benchmarkin->benchmarking
 benchmkar->benchmark
 benchmkared->benchmarked
 benchmkaring->benchmarking
@@ -7724,6 +7864,7 @@ benefical->beneficial
 beneficary->beneficiary
 benefied->benefited
 benefitial->beneficial
+benefitin->benefiting
 beneits->benefits
 benerate->generate, venerate,
 benetif->benefit
@@ -7771,6 +7912,7 @@ beseiging->besieging
 besic->basic
 besically->basically
 besics->basics
+besiegin->besieging
 besure->be sure
 beteeen->between
 beteen->between
@@ -7821,6 +7963,9 @@ bi-langual->bi-lingual
 bianries->binaries
 bianry->binary
 biappicative->biapplicative
+biasin->biasing
+bicyclin->bicycling
+biddin->bidding
 biddings->bidding
 bidimentionnal->bidimensional
 bidings->bindings, bidding,
@@ -7851,7 +7996,10 @@ binanaries->binaries
 binanary->binary
 binar->binary
 binay->binary
+bindin->binding
 bindins->bindings
+bingein->bingeing
+bingin->binging
 binidng->binding
 binominal->binomial
 binraries->binaries
@@ -7883,12 +8031,14 @@ bitamps->bitmaps
 bitap->bitmap
 bitfileld->bitfield
 bitfilelds->bitfields
+bitin->biting
 bitis->bits
 bitmast->bitmask
 bitnaps->bitmaps
 bittorent->BitTorrent
 bitween->between
 bitwiedh->bitwidth
+bitwise-orin->bitwise-oring
 bitwise-orring->bitwise-oring
 biuld->build
 biulder->builder
@@ -7899,6 +8049,7 @@ biulds->builds
 biult->built, build,
 bivouaced->bivouacked
 bivouacing->bivouacking
+bivouackin->bivouacking
 bivwack->bivouac
 biyou->bayou
 biyous->bayous
@@ -7933,7 +8084,9 @@ blcokers->blockers
 blcoking->blocking
 blcoks->blocks
 bleading->bleeding
+bleedin->bleeding
 blessd->blessed
+blessin->blessing
 blessure->blessing
 bletooth->Bluetooth
 bleutooth->Bluetooth
@@ -8001,11 +8154,13 @@ bnecause->because
 bnndler->bundler
 boads->boards
 boardcast->broadcast
+boardin->boarding
 boaut->bout, boat, about,
 bobard->board, bombard,
 bocome->become
 boddy->body
 bodiese->bodies
+bodin->boding
 bodydbuilder->bodybuilder
 boelean->boolean
 boeleans->booleans
@@ -8023,6 +8178,7 @@ boleen->boolean
 bolor->color
 bombardement->bombardment
 bombarment->bombardment
+bombin->bombing
 bondary->boundary
 Bonnano->Bonanno
 bood->boot
@@ -8036,6 +8192,7 @@ boofays->buffets
 bookeeping->bookkeeping
 bookkeeing->bookkeeping
 bookkeeiping->bookkeeping
+bookkeepin->bookkeeping
 bookkepp->bookkeep
 bookmakr->bookmark
 bookmar->bookmark
@@ -8118,6 +8275,7 @@ bootstraped->bootstrapped
 bootstraper->bootstrapper
 bootstrapers->bootstrappers
 bootstraping->bootstrapping
+bootstrappin->bootstrapping
 bootstras->bootstraps
 bootup->boot up, boot-up,
 booundaries->boundaries
@@ -8200,6 +8358,7 @@ bounaries->boundaries
 bounary->boundary
 bounbdaries->boundaries
 bounbdary->boundary
+bouncin->bouncing
 boundares->boundaries
 boundaryi->boundary
 boundarys->boundaries
@@ -8264,6 +8423,7 @@ brach->branch
 brached->branched, breached,
 braches->branches, breaches,
 braching->branching, breaching,
+bracin->bracing
 brackeds->brackets
 bracketwith->bracket with
 brackground->background
@@ -8272,6 +8432,7 @@ bracnhed->branched
 bracnhes->branches
 bracnhing->branching
 bradcast->broadcast
+braisin->braising
 braket->bracket, brake,
 brakets->brackets, brakes,
 brakpoint->breakpoint
@@ -8284,6 +8445,7 @@ branchces->branches
 branche->branch, branches, branched,
 branchesonly->branches only
 brancheswith->branches with
+branchin->branching
 branchs->branches
 branchsi->branches
 brancing->branching, bracing,
@@ -8298,6 +8460,7 @@ braodcasts->broadcasts
 Brasillian->Brazilian
 brazeer->brassiere
 brazillian->Brazilian
+breachin->breaching
 breack->break, brake,
 breacket->bracket
 breackets->brackets
@@ -8309,6 +8472,7 @@ breackthrough->breakthrough
 breackthroughs->breakthroughs
 breaked->broken
 breakes->breaks
+breakin->breaking
 breakthough->breakthrough
 breakthoughs->breakthroughs
 breakthrought->breakthrough
@@ -8317,6 +8481,7 @@ breakthruogh->breakthrough
 breakthruoghs->breakthroughs
 breal->break
 breanches->branches
+breathin->breathing
 breating->breathing, beating,
 breef->brief, beef,
 breefly->briefly
@@ -8348,6 +8513,7 @@ brigher->brighter
 brighest->brightest
 brighly->brightly
 brighness->brightness
+brightenin->brightening
 brightnesss->brightness
 brigth->bright
 brigthen->brighten
@@ -8386,6 +8552,7 @@ broadacasting->broadcasting
 broadcas->broadcast
 broadcase->broadcast
 broadcasti->broadcast
+broadcastin->broadcasting
 broadcat->broadcast
 broady->broadly
 broardcast->broadcast
@@ -8431,6 +8598,7 @@ brower->browser
 browers->browsers
 browing->browsing
 browseable->browsable
+browsin->browsing
 browswable->browsable
 browswe->browse
 browswed->browsed
@@ -8439,6 +8607,7 @@ browswers->browsers
 browswing->browsing
 bruse->bruise
 bruses->bruises
+brushin->brushing
 brusk->brusque
 brutaly->brutally
 brwosable->browsable
@@ -8460,6 +8629,7 @@ bufers->buffers
 buffereed->buffered
 bufferent->buffered
 bufferes->buffers, buffered,
+bufferin->buffering
 bufferred->buffered
 bufferring->buffering
 buffeur->buffer
@@ -8510,6 +8680,7 @@ buildding->building
 builddings->buildings
 buildds->builds
 builded->built
+buildin->building
 buildpackge->buildpackage
 buildpackges->buildpackages
 buildt->built, build,
@@ -8580,6 +8751,7 @@ bumber->bumper, bomber, bummer, number,
 bumbing->bumping, bombing,
 bumby->bumpy
 bumpded->bumped
+bumpin->bumping
 bumpt->bump
 bumpted->bumped
 bumpter->bumper
@@ -8598,6 +8770,7 @@ bundeles->bundles
 bundeling->bundling
 bundels->bundles
 bunding->binding, bundling, bounding,
+bundlin->bundling
 bunds->binds, bounds,
 bunji->bungee
 bunlde->bundle
@@ -8610,11 +8783,13 @@ bureauracy->bureaucracy
 buring->burying, burning, burin, during,
 burjun->burgeon
 burjuns->burgeons
+burnin->burning
 buro->bureau, burro,
 burocratic->bureaucratic
 buros->bureaus, burros,
 burried->buried
 burtst->burst
+buryin->burying
 burzwah->bourgeois
 busines->business
 busineses->business, businesses,
@@ -8657,6 +8832,7 @@ byciclist->bicyclist
 bypas->bypass
 bypased->bypassed
 bypasing->bypassing
+bypassin->bypassing
 byte-comiler->byte-compiler
 byte-compilier->byte-compiler
 byte-complier->byte-compiler
@@ -8685,6 +8861,7 @@ cach->catch, cache,
 cachable->cacheable
 cacheed->cached
 cacheing->caching
+cachin->caching
 cachline->cacheline
 cachse->cache, caches,
 cachup->catchup
@@ -8956,6 +9133,7 @@ calfs->calves
 caliased->aliased
 calibraiton->calibration
 calibraitons->calibrations
+calibratin->calibrating
 calibrte->calibrate
 calibrtion->calibration
 caligraphy->calligraphy
@@ -9001,6 +9179,7 @@ callibri->calibri
 calliflower->cauliflower
 calliflowers->cauliflowers
 callig->calling
+callin->calling
 callint->calling
 callis->callus
 calll->call
@@ -9092,6 +9271,7 @@ camoflague->camouflage
 camoflagued->camouflaged
 camoflagues->camouflages
 camoflaguing->camouflaging
+camouflagin->camouflaging
 campagin->campaign
 campagins->campaigns
 campain->campaign
@@ -9133,8 +9313,10 @@ cancelation->cancellation
 cancelations->cancellations
 cancele->cancel, cancels,
 canceles->cancels
+cancelin->canceling
 cancell->cancel
 cancelles->cancels
+cancellin->cancelling
 cancelllation->cancellation
 cancelllations->cancellations
 cancellled->cancelled
@@ -9186,6 +9368,8 @@ cannabilyzing->cannibalizing
 cannel->channel, cancel, canal,
 canneled->channeled, canceled,
 cannels->channels, cancels, canals,
+cannibalisin->cannibalising
+cannibalizin->cannibalizing
 cannister->canister
 cannisters->canisters
 cannnot->cannot
@@ -9243,6 +9427,7 @@ canoncicalizes->canonicalizes
 canoncicalizing->canonicalizing
 canoncically->canonically
 canonicalizations->canonicalization
+canonicalizin->canonicalizing
 canonival->canonical
 canonivalization->canonicalization
 canonivalize->canonicalize
@@ -9341,6 +9526,8 @@ capicitance->capacitance
 capicitor->capacitor
 capicitors->capacitors
 capicity->capacity
+capitalisin->capitalising
+capitalizin->capitalizing
 capitalsation->capitalisation
 capitalse->capitalise
 capitalsed->capitalised
@@ -9414,6 +9601,7 @@ captued->captured
 captues->captures
 captuing->capturing
 capturd->captured
+capturin->capturing
 caputre->capture
 caputred->captured
 caputres->captures
@@ -9485,6 +9673,7 @@ carimonial->ceremonial
 carimonially->ceremonially
 carimonies->ceremonies
 carimony->ceremony
+carin->caring
 carinomial->ceremonial
 carinomially->ceremonially
 carinomies->ceremonies
@@ -9536,6 +9725,7 @@ carridge->carriage, cartridge,
 carrien->carrier
 carrige->carriage
 carrrier->carrier
+carryin->carrying
 carryintg->carrying
 carryng->carrying
 cartain->certain
@@ -9651,6 +9841,7 @@ catastrphic->catastrophic
 catche->catch
 catched->caught
 catchi->catch
+catchin->catching
 catchip->ketchup
 catchs->catches
 categogical->categorical
@@ -9668,6 +9859,8 @@ categoizes->categorizes
 categoizing->categorizing
 categor->category
 categorie->category, categories,
+categorisin->categorising
+categorizin->categorizing
 categoy->category
 categroies->categories
 categroy->category
@@ -9748,6 +9941,7 @@ cauing->causing
 causeed->caused
 causees->causes
 causeing->causing
+causin->causing
 causion->caution
 causioned->cautioned
 causions->cautions
@@ -9782,6 +9976,7 @@ Ceasar->Caesar
 ceasars->Caesars
 ceaser->Caesar
 ceasers->Caesars
+ceasin->ceasing
 ceasser->Caesar
 ceassers->Caesars
 ceate->create
@@ -9826,6 +10021,7 @@ cehcks->checks
 cehcksum->checksum
 cehcksums->checksums
 Celcius->Celsius
+celebratin->celebrating
 cellabrate->celebrate
 cellabrated->celebrated
 cellabrates->celebrates
@@ -9847,11 +10043,13 @@ celllar->cellular, cellar,
 celllars->cellars
 cellls->cells
 celllular->cellular
+cellpaddin->cellpadding
 cellpading->cellpadding
 cellst->cells
 cellxs->cells
 celsuis->celsius
 cementary->cemetery
+cementin->cementing
 cemetarey->cemetery
 cemetaries->cemeteries
 cemetary->cemetery
@@ -9882,6 +10080,7 @@ centisencond->centisecond
 centisenconds->centiseconds
 centrafuge->centrifuge
 centrafuges->centrifuges
+centralizin->centralizing
 centrifigual->centrifugal
 centrifugeable->centrifugable
 centrigrade->centigrade
@@ -10022,6 +10221,7 @@ certifificate->certificate
 certifificated->certificated
 certifificates->certificates
 certifification->certification
+certifyin->certifying
 certiticate->certificate
 certiticated->certificated
 certiticates->certificates
@@ -10100,6 +10300,7 @@ chainged->changed, chained,
 chainges->changes
 chainging->changing, chaining,
 chaings->chains
+chainin->chaining
 chalenge->challenge
 chalenged->challenged
 chalenger->challenger
@@ -10124,6 +10325,7 @@ challened->challenged
 challener->challenger
 challeners->challengers
 challenes->challenges
+challengin->challenging
 challening->challenging
 chambre->chamber
 chambres->chambers
@@ -10170,6 +10372,7 @@ changee->changed, changes, change,
 changeed->changed
 changees->changes
 changeing->changing
+changelin->changeling
 changge->change
 changged->changed
 changgeling->changeling
@@ -10238,6 +10441,7 @@ characterisic->characteristic
 characterisically->characteristically
 characterisicly->characteristically
 characterisics->characteristics
+characterisin->characterising
 characterisitic->characteristic
 characterisitics->characteristics
 characteristicly->characteristically
@@ -10245,6 +10449,7 @@ characteritic->characteristic
 characteritics->characteristics
 characteritisc->characteristic
 characteritiscs->characteristics
+characterizin->characterizing
 charactersistic->characteristic
 charactersistically->characteristically
 charactersistics->characteristics
@@ -10331,6 +10536,7 @@ charctors->characters
 charecter->character
 charecters->characters
 charector->character
+chargin->charging
 chargind->charging
 charicter->character
 charicters->characters
@@ -10342,6 +10548,7 @@ charizma->charisma
 chartroose->chartreuse
 chasim->chasm
 chasims->chasms
+chasin->chasing
 chasnge->change, changes,
 chasr->chaser, chase,
 chassim->chasm
@@ -10398,6 +10605,7 @@ chcks->checks
 chcksum->checksum
 chcksums->checksums
 cheapeast->cheapest
+cheatin->cheating
 cheatta->cheetah
 chec->check
 checbox->checkbox
@@ -10498,6 +10706,7 @@ checkes->checks
 checkesum->checksum
 checkesums->checksums
 checket->checked
+checkin->checking
 checkk->check
 checkkbox->checkbox
 checkkboxes->checkboxes
@@ -10540,6 +10749,7 @@ checkstums->checksums
 checksume->checksum
 checksumed->checksummed
 checksuming->checksumming
+checksummin->checksumming
 checkt->checked
 checkts->checked, checks,
 checkum->checksum
@@ -10594,6 +10804,7 @@ cheecks->checks, cheeks,
 cheecksum->checksum
 cheecksums->checksums
 cheeper->cheaper
+cheerin->cheering
 cheet->cheat, sheet, chest, cheer, cheek,
 cheeta->cheetah
 cheeted->cheated, cheered,
@@ -10716,6 +10927,7 @@ chipertexts->ciphertexts
 chipet->chipset
 chipslect->chipselect
 chipstes->chipsets
+chiselin->chiseling
 chisell->chisel
 chiselle->chisel
 chiselles->chisels
@@ -10787,7 +10999,9 @@ chooose->choose
 choos->choose
 choosed->chose, chosen,
 choosen->chosen
+choosin->choosing
 chopipng->chopping
+choppin->chopping
 chopy->choppy, chop,
 choronological->chronological
 chosed->chose
@@ -10800,6 +11014,7 @@ chosses->chooses
 chossing->choosing
 chould->should, could,
 chouse->choose, chose, choux,
+chowin->chowing
 chowse->chose, choose,
 chowsing->choosing
 chracter->character
@@ -10813,6 +11028,7 @@ chrashing->crashing, thrashing, trashing,
 chrashs->crashes, thrashes, trashes,
 chrminance->chrominance
 chromum->chromium
+chroniclin->chronicling
 chuch->church
 chuks->chunks
 chunaks->chunks
@@ -10824,6 +11040,8 @@ chuncks->chunks
 chuncksize->chunksize
 chuncs->chunks
 chuned->chunked
+chunkin->chunking
+churchin->churching
 churchs->churches
 cick->click
 cicle->cycle, circle, icicle,
@@ -10930,6 +11148,7 @@ ciphrs->ciphers
 cips->chips
 circit->circuit
 circits->circuits
+circlin->circling
 circluar->circular
 circluarly->circularly
 circluars->circulars
@@ -10952,6 +11171,7 @@ circumstnce->circumstance
 circumstnces->circumstances
 circumstncial->circumstantial
 circumstntial->circumstantial
+circumventin->circumventing
 circumvernt->circumvent
 circunference->circumference
 circunferences->circumferences
@@ -11100,6 +11320,7 @@ claerly->clearly
 claibscale->calibscale
 claime->claim
 claimes->claims
+claimin->claiming
 clairvoiant->clairvoyant
 clairvoiantes->clairvoyants
 clairvoiants->clairvoyants
@@ -11113,6 +11334,7 @@ claravoyants->clairvoyants
 claread->cleared
 clared->cleared
 clarety->clarity
+clarifyin->clarifying
 claring->clearing
 clases->classes, clashes, cases,
 clasic->classic
@@ -11156,6 +11378,7 @@ classifiiers->classifiers
 classifiies->classifies
 classifiy->classify
 classifiying->classifying
+classifyin->classifying
 classrom->classroom
 classroms->classrooms
 classs->class
@@ -11199,6 +11422,7 @@ cleands->cleans
 cleandup->cleanup
 cleandups->cleanups
 cleaness->cleanness
+cleanin->cleaning
 cleann->clean
 cleanned->cleaned
 cleanner->cleaner
@@ -11210,6 +11434,7 @@ cleannups->cleanups
 cleanp->cleanup, clean up,
 cleanpu->cleanup
 cleanpus->cleanups
+cleansin->cleansing
 cleantup->cleanup
 cleare->cleared, clear,
 cleareance->clearance
@@ -11221,6 +11446,7 @@ clearified->clarified
 clearifies->clarifies
 clearify->clarify
 clearifying->clarifying
+clearin->clearing
 clearity->clarity
 clearling->clearing
 clearnance->clearance
@@ -11264,6 +11490,7 @@ cliboard->clipboard
 cliboards->clipboards
 clibpoard->clipboard
 clibpoards->clipboards
+clickin->clicking
 cliens->clients
 cliensite->client-side
 clienta->client
@@ -11271,6 +11498,7 @@ cliente->client, clientele,
 clientelle->clientele
 clik->click
 cliks->clicks
+climbin->climbing
 climer->climber
 climers->climbers
 climing->climbing
@@ -11286,6 +11514,7 @@ cliping->clipping
 clipoard->clipboard
 clipoards->clipboards
 clipoing->clipping
+clippin->clipping
 clishay->cliché
 clishays->clichés
 clishey->cliché
@@ -11306,6 +11535,7 @@ cllouding->clouding
 cllouds->clouds
 cloack->cloak
 cloacks->cloaks
+clobberin->clobbering
 cloberring->clobbering
 clock_getttime->clock_gettime
 clocksourc->clocksource
@@ -11328,6 +11558,7 @@ cloesst->closest
 cloisonay->cloisonné
 cloisonays->cloisonnés
 clonez->clones, cloner,
+clonin->cloning
 clonne->clone
 clonned->cloned, clowned, conned,
 clonnes->clones
@@ -11345,6 +11576,7 @@ closeing->closing
 closesly->closely
 closests->closest, closets,
 closig->closing
+closin->closing
 closse->close
 clossed->closed
 clossely->closely
@@ -11356,10 +11588,12 @@ clossion->collision
 clossions->collisions
 cloude->cloud
 cloudes->clouds
+cloudin->clouding
 cloumn->column
 cloumns->columns
 cloure->closure, clojure,
 clousre->closure
+clownin->clowning
 clsoe->close
 clsoed->closed
 clsoely->closely
@@ -11414,11 +11648,13 @@ cnosoles->consoles
 cntain->contain
 cntains->contains
 cnter->center
+co-existin->co-existing
 co-incided->coincided
 co-opearte->co-operate
 co-opeartes->co-operates
 co-ordinate->coordinate
 co-ordinates->coordinates
+coachin->coaching
 coalace->coalesce
 coalacece->coalesce, coalescence,
 coalaced->coalesced
@@ -11439,6 +11675,7 @@ coalasing->coalescing
 coalcece->coalescence
 coalcence->coalescence
 coalesc->coalesce
+coalescin->coalescing
 coalescsing->coalescing
 coalese->coalesce
 coalesed->coalesced
@@ -11513,12 +11750,14 @@ codde->code, coded, coddle,
 codder->coder, coddler,
 codders->coders, coddlers,
 coddes->codes, coddles,
+coddlin->coddling
 codeen->codeine
 codeing->coding
 codepoitn->codepoint
 codesc->codecs
 codespel->codespell
 codesream->codestream
+codin->coding
 codition->condition
 coditional->conditional
 coditionally->conditionally
@@ -11552,6 +11791,7 @@ coeficients->coefficients
 coelesce->coalesce
 coercable->coercible
 coerceion->coercion
+coercin->coercing
 coersion->coercion, conversion,
 coexhist->coexist, co-exist,
 coexhistance->coexistence, co-existence,
@@ -11563,6 +11803,7 @@ coexinst->coexist, co-existence,
 coexinstence->coexistence, co-existence,
 coexinsts->coexists, co-existence,
 coexistance->coexistence, co-existence,
+coexistin->coexisting
 coexsit->coexist, co-exist,
 coexsitance->coexistence, co-existence,
 coexsited->coexisted, co-existed,
@@ -11607,12 +11848,14 @@ cofusion->confusion
 cogniscent->cognizant, cognisant,
 cognizent->cognizant, cognisant,
 cohabitating->cohabiting
+cohabitin->cohabiting
 coherance->coherence
 coherancy->coherency
 coherant->coherent
 coherantly->coherently
 coice->choice
 coincedentally->coincidentally
+coincidin->coinciding
 coinitailize->coinitialize
 coinside->coincide
 coinsided->coincided
@@ -11667,6 +11910,7 @@ collaction->collection
 collaobrative->collaborative
 collaps->collapse
 collapsable->collapsible
+collapsin->collapsing
 collapted->collapsed, collated, collapse, coapted,
 collasion->collision
 collaspe->collapse
@@ -11674,6 +11918,7 @@ collasped->collapsed
 collaspes->collapses
 collaspible->collapsible
 collasping->collapsing
+collatin->collating
 collationg->collation
 collborative->collaborative
 colleage->colleague
@@ -11757,6 +12002,7 @@ colomns->columns
 colon-seperated->colon-separated
 colonizators->colonizers
 colorfull->colorful, colorfully,
+colorin->coloring
 coloringh->coloring
 colorizoer->colorizer
 colorpsace->colorspace
@@ -11889,6 +12135,7 @@ combier->combiner
 combiers->combiners
 combies->combines, zombies,
 combiing->combining, combing,
+combin->combing
 combinatation->combination
 combinatations->combinations
 combinatator->combinator
@@ -11932,6 +12179,7 @@ combiniator->combinator
 combiniatorial->combinatorial
 combiniatorics->combinatorics
 combiniators->combinators
+combinin->combining
 combinination->combination
 combininations->combinations
 combininator->combinator
@@ -11999,6 +12247,7 @@ comformance->conformance
 comformed->conformed, comforted,
 comforming->conforming, comforting,
 comforms->conforms, comforts,
+comfortin->comforting
 comfterble->comfortable
 comfterbly->comfortably
 comfuse->confuse
@@ -12014,6 +12263,7 @@ comiler->compiler
 comilers->compilers
 comiles->compiles
 comiling->compiling
+comin->coming
 comination->combination
 cominations->combinations
 cominator->combinator
@@ -12096,6 +12346,7 @@ commads->commands
 comman->command, common, comma, commas,
 comman-line->command-line
 commandi->command
+commandin->commanding
 commandoes->commandos
 commanline->commandline
 commannd->command
@@ -12123,7 +12374,10 @@ commedic->comedic
 commemerative->commemorative
 commemmorate->commemorate
 commemmorating->commemorating
+commemoratin->commemorating
 commen->commend, comment, common,
+commencin->commencing
+commendin->commending
 commene->comment, commend, commence, commune,
 commened->commented, commended, commend, commenced, communed,
 commenes->comments, commends, commences, communes,
@@ -12133,6 +12387,7 @@ commeneted->commented
 commening->commenting, commending, commencing, communing,
 commens->comments, commons, commends,
 commenstatus->commentstatus
+commentin->commenting
 commerical->commercial
 commerically->commercially
 commericial->commercial
@@ -12156,6 +12411,7 @@ commisioned->commissioned
 commisioner->commissioner
 commisioning->commissioning
 commisions->commissions
+commissionin->commissioning
 commisssion->commission
 commisssioned->commissioned
 commisssioner->commissioner
@@ -12177,6 +12433,7 @@ committ->commit
 committe->committee
 committes->committees
 committi->committee
+committin->committing
 committis->committees
 committment->commitment
 committments->commitments
@@ -12322,9 +12579,11 @@ communciation->communication
 communiation->communication
 communicaion->communication
 communicatie->communication
+communicatin->communicating
 communicaton->communication
 communikay->communiqué
 communikays->communiqués
+communin->communing
 communisim->communism
 communisit->communist
 communisits->communists
@@ -12344,6 +12603,7 @@ communty->community
 communuication->communication
 commutated->commuted
 commutating->commuting
+commutin->commuting
 commutive->commutative
 comnmand->command
 comnnected->connected
@@ -12429,6 +12689,7 @@ comparign->comparing
 comparigon->comparison
 comparigons->comparisons
 compariing->comparing
+comparin->comparing
 comparion->comparison
 comparions->comparisons
 comparios->comparison
@@ -12582,6 +12843,7 @@ compelxity->complexity
 compenent->component, competent,
 compenents->components, competence,
 compensantion->compensation
+compensatin->compensating
 compenstate->compensate
 compenstated->compensated
 compenstates->compensates
@@ -12596,6 +12858,7 @@ competetively->competitively
 competetiveness->competitiveness
 competetor->competitor
 competetors->competitors
+competin->competing
 competion->competition, completion,
 competions->completions, competitions,
 competitiion->competition
@@ -12646,6 +12909,7 @@ compilied->compiled
 compilier->compiler
 compiliers->compilers
 compilies->compiles
+compilin->compiling
 compillation->compilation
 compillations->compilations
 compille->compile
@@ -12663,6 +12927,7 @@ compitent->competent
 compitible->compatible
 complaince->compliance, complaints,
 complaing->complaining
+complainin->complaining
 complanied->complained
 complate->complete
 complated->completed
@@ -12716,6 +12981,7 @@ completess->completes, completeness,
 completetion->completion
 completetly->completely
 completey->completely
+completin->completing
 completiom->completion
 completition->completion, competition,
 completitions->completions, competitions,
@@ -12733,6 +12999,7 @@ compliace->compliance
 complianse->compliance
 compliation->compilation, complication,
 compliations->compilations, complications,
+complicatin->complicating
 complie->compile, complice, complied,
 complied-in->compiled-in
 complience->compliance
@@ -12801,9 +13068,11 @@ composistes->composites
 composistion->composition
 composistions->compositions
 composit->composite
+compositin->compositing
 compositong->compositing
 composits->composites
 composte->composite, compose, composed, compost, composted,
+compoundin->compounding
 compount->compound
 comppatible->compatible
 comppiler->compiler
@@ -12826,6 +13095,7 @@ compresors->compressors
 compressable->compressible
 compresser->compressor
 compressers->compressors
+compressin->compressing
 compresss->compress
 compresssed->compressed
 compresssion->compression
@@ -12857,6 +13127,7 @@ compunds->compounds
 computaion->computation
 computarized->computerized
 computaton->computation
+computin->computing
 computs->computes, computus,
 computtaion->computation
 computtaions->computations
@@ -12970,6 +13241,7 @@ concatenaes->concatenates
 concatenaing->concatenating
 concatenaion->concatenation
 concatenaions->concatenations
+concatenatin->concatenating
 concatene->concatenate
 concatened->concatenated
 concatenes->concatenates
@@ -13012,6 +13284,7 @@ concentates->concentrates
 concentating->concentrating
 concentation->concentration
 concentic->concentric
+concentratin->concentrating
 concentraze->concentrate
 conceous->conscious
 conceousally->consciously
@@ -13022,6 +13295,7 @@ concequences->consequences
 concered->concerned
 concerened->concerned
 concering->concerning
+concernin->concerning
 concerntrating->concentrating
 concerte->concrete, concerts, concert, concerto, concerted,
 conchance->conscience
@@ -13045,6 +13319,7 @@ concieved->conceived
 concious->conscious
 conciously->consciously
 conciousness->consciousness
+concludin->concluding
 concret->concrete, concert,
 concretly->concretely
 concrets->concrete, concerts,
@@ -13059,6 +13334,7 @@ concures->concurs, conquers,
 concuring->concurring, conquering,
 concurrect->concurrent
 concurrectly->concurrently
+concurrin->concurring
 condamned->condemned
 condem->condemn
 condemmed->condemned
@@ -13122,6 +13398,7 @@ conditianal->conditional
 conditianally->conditionally
 conditianaly->conditionally
 conditionaly->conditionally
+conditionin->conditioning
 conditionn->condition
 conditionnal->conditional
 conditionnally->conditionally
@@ -13141,6 +13418,7 @@ conditonally->conditionally
 conditonals->conditionals
 conditons->conditions
 condntional->conditional
+condolin->condoling
 condtiion->condition
 condtiions->conditions
 condtion->condition
@@ -13155,6 +13433,7 @@ condtitionals->conditionals
 condtitions->conditions
 conducter->conductor, conducted,
 conducters->conductors
+conductin->conducting
 conductuve->conductive, conducive,
 conecct->connect
 coneccted->connected
@@ -13258,9 +13537,11 @@ conetxts->contexts, connects,
 conexant->connexant
 conext->context, connect, connects,
 conexts->contexts, connects,
+conferencin->conferencing
 conferene->conference
 conferrencing->conferencing
 confert->convert
+confessin->confessing
 confety->confetti
 conffig->config
 conffigs->configs
@@ -13417,6 +13698,7 @@ configurees->configures
 configureing->configuring
 configuretion->configuration
 configuretions->configurations
+configurin->configuring
 configurrable->configurable
 configurration->configuration
 configurrations->configurations
@@ -13477,6 +13759,7 @@ confingure->configure
 confingured->configured
 confingures->configures
 confinguring->configuring
+confinin->confining
 confiramtion->confirmation
 confirmacion->confirmation
 confirmaed->confirmed
@@ -13486,6 +13769,7 @@ confirmatinon->confirmation
 confirmd->confirmed
 confirmedd->confirmed
 confirmeed->confirmed
+confirmin->confirming
 confirmming->confirming
 confiug->config
 confiugrable->configurable
@@ -13510,6 +13794,7 @@ confiure->configure
 confiured->configured
 confiures->configures
 confiuring->configuring
+conflatin->conflating
 conflcit->conflict
 conflcited->conflicted
 conflciting->conflicting
@@ -13537,6 +13822,7 @@ confogure->configure
 confogured->configured
 confogures->configures
 confoguring->configuring
+conformin->conforming
 confort->comfort
 confortable->comfortable
 confrim->confirm
@@ -13605,6 +13891,7 @@ confurse->confuse
 confursed->confused
 confurses->confuses
 confursing->confusing
+confusin->confusing
 confuss->confuse, confess, confuses,
 confussed->confused, confessed,
 confusses->confuses, confesses,
@@ -13662,6 +13949,7 @@ congratualtes->congratulates
 congratualting->congratulating
 congratualtion->congratulation
 congratualtions->congratulations
+congratulatin->congratulating
 congresional->congressional
 conider->consider, conifer,
 coniderable->considerable
@@ -13819,6 +14107,7 @@ connetions->connections
 connetor->connector
 connetors->connectors
 connexion->connection
+connin->conning
 connnect->connect
 connnected->connected
 connnecting->connecting
@@ -13892,6 +14181,7 @@ conpressed->compressed
 conquerd->conquered
 conquerer->conqueror
 conquerers->conquerors
+conquerin->conquering
 conqured->conquered
 conrete->concrete
 conribute->contribute
@@ -13964,6 +14254,7 @@ conseeded->conceded
 conseeds->concedes
 consenquently->consequently
 consensis->consensus
+consentin->consenting
 consentious->conscientious
 consentiously->conscientiously
 consentrate->concentrate
@@ -13982,6 +14273,7 @@ consern->concern
 conserned->concerned
 conserning->concerning
 conservativeky->conservatively
+conservin->conserving
 conservitive->conservative
 consestently->consistently
 consevible->conceivable
@@ -13996,6 +14288,7 @@ considerd->considered
 considere->consider, considered,
 consideren->considered
 consideres->considered, considers,
+considerin->considering
 considerion->consideration
 considerions->considerations
 considert->considered, consider,
@@ -14026,6 +14319,7 @@ consistenly->consistently
 consistensy->consistency
 consisteny->consistency, consistent,
 consistes->consists, consisted,
+consistin->consisting
 consistuency->constituency, consistency,
 consistuent->constituent, consistent,
 consistuently->consistently
@@ -14069,6 +14363,7 @@ consntant->constant
 consntantly->constantly
 consntants->constants
 consol->console
+consolin->consoling
 consolodate->consolidate
 consolodated->consolidated
 consonent->consonant
@@ -14148,6 +14443,7 @@ constituion->constitution
 constituional->constitutional
 constitutent->constituent
 constitutents->constituents
+constitutin->constituting
 constly->costly
 constract->construct
 constracted->constructed
@@ -14156,6 +14452,7 @@ constractions->constrictions, constructions, contractions,
 constractor->constructor
 constractors->constructors
 constraing->constraining, constraint,
+constrainin->constraining
 constrainst->constraint, constraints,
 constrainsts->constraints
 constrainted->constrained
@@ -14200,6 +14497,7 @@ constribution->contribution
 constributions->contributions
 constributor->contributor
 constributors->contributors
+constrictin->constricting
 constrint->constraint
 constrints->constraints
 constrol->control
@@ -14225,6 +14523,7 @@ constructcor->constructor
 constructer->constructor
 constructers->constructors
 constructes->constructs
+constructin->constructing
 constructiong->constructing, construction,
 constructr->constructor
 constructred->constructed
@@ -14239,6 +14538,7 @@ constructued->constructed
 constructur->constructor
 constructure->constructor
 constructurs->constructors
+construin->construing
 construktor->constructor
 construnctor->constructor
 construrtors->constructors
@@ -14283,12 +14583,15 @@ consumate->consummate
 consumated->consummated
 consumating->consummating
 consumation->consumption, consummation,
+consumin->consuming
+consummatin->consummating
 consummed->consumed
 consummer->consumer
 consummers->consumers
 consumsion->consumption
 consumtion->consumption
 contacentaion->concatenation
+contactin->contacting
 contagen->contagion
 contaied->contained
 contaienr->container
@@ -14330,6 +14633,7 @@ containuations->continuations
 contais->contains
 contaisn->contains
 contaiun->contain
+contaminatin->contaminating
 contamporaries->contemporaries
 contamporary->contemporary
 contan->contain
@@ -14415,6 +14719,7 @@ content-negotitation->content-negotiation
 content-negotition->content-negotiation
 content-negoziation->content-negotiation
 contentended->contended
+contentin->contenting
 contentn->content
 contentss->contents
 conter->counter, conteur,
@@ -14488,6 +14793,7 @@ continuem->continuum
 continueous->continuous
 continueously->continuously
 continuesly->continuously
+continuin->continuing
 continuos->continuous
 continuosly->continuously
 continure->continue
@@ -14578,7 +14884,9 @@ contraint->constraint
 contrainted->constrained
 contraints->constraints
 contraitns->constraints
+contrastin->contrasting
 contraveining->contravening
+contravenin->contravening
 contravercial->controversial
 contravercies->controversies
 contravercy->controversy
@@ -14644,6 +14952,7 @@ controles->controls, controllers,
 controling->controlling
 controll->control
 controllerd->controlled
+controllin->controlling
 controllled->controlled
 controlller->controller
 controlllers->controllers
@@ -14732,6 +15041,7 @@ conveniance->convenience
 conveniant->convenient
 conveniantly->conveniently
 conveniece->convenience
+convenin->convening
 convenince->convenience
 conveninent->convenient
 convense->convince
@@ -14755,12 +15065,14 @@ converations->conversations
 convered->converted, covered, converged, conveyed,
 convereted->converted
 convergance->convergence
+convergin->converging
 convering->converting, covering, converging, conveying,
 converion->conversion
 converions->conversions
 converison->conversion
 converitble->convertible
 convers->converse, converts, convert, covers, conveys, confers,
+conversin->conversing
 conversly->conversely
 conversoin->conversion
 converson->conversion
@@ -14781,6 +15093,7 @@ convertation->conversation, conversion,
 convertations->conversations, conversions,
 converterd->converted, converter,
 convertet->converted
+convertin->converting
 convertion->conversion
 convertions->conversions
 convervable->conservable
@@ -14810,10 +15123,12 @@ convetions->conventions
 convets->converts
 convexe->convex, convexes,
 conveyer->conveyor
+conveyin->conveying
 convice->convince, convict,
 conviced->convinced, convicted,
 convices->convinces, convicts,
 convicing->convincing, convicting,
+convictin->convicting
 convienant->convenient
 convience->convince, convenience,
 conviencece->convenience
@@ -14835,6 +15150,7 @@ convigures->configures
 conviguring->configuring
 convination->combination
 convinations->combinations
+convincin->convincing
 convine->combine, convince, confine, convene,
 convineance->convenience
 convineances->conveniences
@@ -14860,6 +15176,8 @@ convinving->convincing
 convirted->converted
 convirting->converting
 convised->convinced
+convolutin->convoluting
+convolvin->convolving
 convoultion->convolution
 convoultions->convolutions
 convovle->convolve
@@ -14887,6 +15205,7 @@ cooefficients->coefficients
 cooger->cougar
 cookoo->cuckoo
 coolent->coolant
+coolin->cooling
 coolot->culotte
 coolots->culottes
 coomand->command
@@ -14933,6 +15252,7 @@ cooordinate->coordinate
 cooordinates->coordinates
 coopearte->cooperate
 coopeartes->cooperates
+cooperatin->cooperating
 cooporative->cooperative
 coordanate->coordinate
 coordanates->coordinates
@@ -14945,6 +15265,7 @@ coordiate->coordinate
 coordiates->coordinates
 coordiinates->coordinates
 coordinatess->coordinates
+coordinatin->coordinating
 coordinats->coordinates
 coordindate->coordinate
 coordindates->coordinates
@@ -15018,6 +15339,7 @@ copiler->compiler, copier,
 copilers->compilers, copiers,
 copiles->compiles, copies,
 copiling->compiling
+copin->coping
 coplete->complete
 copleted->completed
 copletely->completely
@@ -15061,6 +15383,7 @@ coprright->copyright
 coprrighted->copyrighted
 coprrights->copyrights
 copstruction->construction
+copulatin->copulating
 copuright->copyright
 copurighted->copyrighted
 copurights->copyrights
@@ -15074,6 +15397,7 @@ copyeight->copyright
 copyeighted->copyrighted
 copyeights->copyrights
 copyied->copied
+copyin->copying
 copyirght->copyright
 copyirghted->copyrighted
 copyirghts->copyrights
@@ -15225,6 +15549,7 @@ correcteions->corrections
 correctely->correctly
 correcteness->correctness
 correcters->correctors
+correctin->correcting
 correctlly->correctly
 correctnes->correctness
 correcton->correction
@@ -15250,6 +15575,7 @@ correespondingly->correspondingly
 correesponds->corresponds
 correlasion->correlation
 correlatd->correlated
+correlatin->correlating
 correllate->correlate
 correllation->correlation
 correllations->correlations
@@ -15381,6 +15707,7 @@ correspondg->corresponding
 correspondgly->correspondingly
 correspondig->corresponding
 correspondigly->correspondingly
+correspondin->corresponding
 correspondind->corresponding
 correspondindly->correspondingly
 correspondnce->correspondence
@@ -15704,6 +16031,7 @@ counpound->compound
 counpounds->compounds
 counries->countries, counties,
 counry->country, county,
+counsellin->counselling
 counsil->counsel
 counsils->counsels
 countain->contain
@@ -15721,6 +16049,7 @@ counterpar->counterpart
 counterpoart->counterpart
 counterpoarts->counterparts
 countie's->counties, counties', county's,
+countin->counting
 countinual->continual
 countinually->continually
 countinuation->continuation
@@ -15743,6 +16072,7 @@ cource->course, coerce, source,
 courced->coerced, sourced, coursed,
 cources->courses, coerces, sources,
 courcing->coercing, sourcing, coursing,
+coursin->coursing
 courtesey->courtesy
 coururier->courier, couturier,
 couse->course, cause,
@@ -15785,6 +16115,7 @@ coveres->covers
 coverge->coverage, converge,
 covergence->convergence
 coverges->coverages, converges,
+coverin->covering
 coverred->covered
 coversation->conversation
 coversations->conversations
@@ -15795,6 +16126,7 @@ coverted->converted, covered, coveted,
 coverter->converter
 coverters->converters
 coverting->converting, covering, coveting,
+covetin->coveting
 covince->convince
 covinced->convinced
 covinces->convinces
@@ -15847,6 +16179,7 @@ craches->crashes, caches, coaches, crutches, crèches,
 craching->crashing, caching, cracking, coaching,
 crachs->cracks, crashes,
 cracing->gracing
+crackin->cracking
 craete->create, crate,
 craeted->created, crated,
 craetes->creates, crates,
@@ -15866,8 +16199,10 @@ crasheed->crashed
 crashees->crashes
 crashess->crashes
 crashign->crashing
+crashin->crashing
 crashs->crashes
 cratashous->cretaceous
+cratin->crating
 cration->creation, ration, nation,
 crationalism->rationalism, nationalism,
 crationalist->rationalist, nationalist,
@@ -15903,6 +16238,9 @@ creaetor->creator
 creaetors->creators
 creaets->creates
 creaing->creating, creasing, creaking, creaming,
+creakin->creaking
+creamin->creaming
+creasin->creasing
 creasoat->creosote
 creastor->creator
 creatation->creation
@@ -16009,7 +16347,9 @@ criticall->critical, critically,
 criticial->critical
 criticially->critically
 criticials->criticals
+criticisin->criticising
 criticists->critics
+criticizin->criticizing
 critiera->criteria
 critieria->criteria
 critierion->criterion
@@ -16017,6 +16357,7 @@ critieron->criterion
 critiical->critical
 critiically->critically
 critiicals->criticals
+critiquin->critiquing
 critising->criticising, criticizing,
 critisising->criticising
 critisism->criticism
@@ -16040,6 +16381,7 @@ croozed->cruised
 croozer->cruiser
 croozes->cruises
 croozing->cruising
+croppin->cropping
 croppped->cropped
 cros->cross
 cros-site->cross-site
@@ -16049,6 +16391,7 @@ crosreference->cross-reference
 crosreferenced->cross-referenced
 crosreferences->cross-references
 cross-commpilation->cross-compilation
+cross-compilin->cross-compiling
 cross-orgin->cross-origin
 crossgne->crossgen
 crossin->crossing
@@ -16087,6 +16430,8 @@ crticals->criticals
 crticised->criticised
 crucialy->crucially
 crucifiction->crucifixion
+cruisin->cruising
+crunchin->crunching
 cruncing->crunching
 crurrent->current
 crusies->cruises
@@ -16114,6 +16459,8 @@ crystalize->crystallize
 crystalized->crystallized
 crystalizes->crystallizes
 crystalizing->crystallizing
+crystallisin->crystallising
+crystallizin->crystallizing
 cryto->crypto
 crytocurrencies->cryptocurrencies
 crytocurrency->cryptocurrency
@@ -16156,6 +16503,8 @@ culiminate->culminate
 culiminated->culminated
 culiminates->culminates
 culiminating->culminating
+cullin->culling
+culminatin->culminating
 culmulate->cumulate, culminate,
 culmulated->cumulated, culminated,
 culmulates->cumulates, culminates,
@@ -16171,6 +16520,7 @@ cummunicate->communicate
 cumpus->compass
 cumpuses->compasses
 cumulatative->cumulative
+cumulatin->cumulating
 cumulattive->cumulative
 cuncurency->concurrency
 cunted->counted, hunted,
@@ -16347,10 +16697,12 @@ customie->customize
 customied->customized
 customisaton->customisation
 customisatons->customisations
+customisin->customising
 customizaton->customization
 customizatons->customizations
 customizeable->customizable
 customizeble->customizable
+customizin->customizing
 customn->custom
 customns->customs
 customsiable->customisable
@@ -16459,6 +16811,7 @@ cuztomizing->customizing
 cvignore->cvsignore
 cxan->cyan
 cycic->cyclic
+cyclin->cycling
 cyclinder->cylinder
 cyclinders->cylinders
 cyclindrical->cylindrical
@@ -16546,6 +16899,8 @@ dadlock->deadlock
 daed->dead
 dael->deal, dial, dahl,
 daemonified->daemonised, daemonized,
+daemonisin->daemonising
+daemonizin->daemonizing
 dafault->default
 dafaults->defaults
 dafaut->default
@@ -16558,6 +16913,7 @@ daita->data
 dake->take
 dalmation->Dalmatian
 dalta->delta
+damagin->damaging
 damamge->damage
 damamged->damaged
 damamges->damages
@@ -16573,9 +16929,13 @@ damge->damage
 daming->damning, damping, gaming, doming,
 dammage->damage
 dammages->damages
+damnin->damning
 damons->daemons, demons,
+dampin->damping
 danceing->dancing
+dancin->dancing
 dandidates->candidates
+dandlin->dandling
 dangereous->dangerous
 daplicating->duplicating
 Dardenelles->Dardanelles
@@ -16649,6 +17009,7 @@ datecreatedd->datecreated
 datection->detection
 datections->detections
 datee->date
+datin->dating
 datset->dataset
 datsets->datasets
 daty->data, date,
@@ -16709,6 +17070,7 @@ deacitvated->deactivated
 deacriptor->descriptor, decryptor,
 deacriptors->descriptors, decryptors,
 deactivatiion->deactivation
+deactivatin->deactivating
 deactive->deactivate
 deactiveate->deactivate
 deactived->deactivated
@@ -16731,6 +17093,7 @@ deaktivate->deactivate
 deaktivated->deactivated
 dealed->dealt
 dealilng->dealing
+dealin->dealing
 dealloacte->deallocate
 deallocaed->deallocated
 dealocate->deallocate
@@ -16765,6 +17128,7 @@ deamons->daemons
 deapth->depth
 deapths->depths
 deassering->deasserting
+deassertin->deasserting
 deatch->detach
 deatched->detached
 deatches->detaches
@@ -16806,12 +17170,14 @@ debia->Debian
 debiab->Debian
 debians->Debian's
 debina->Debian
+deblockin->deblocking
 debloking->deblocking
 debnia->Debian
 debouce->debounce
 debouced->debounced
 debouces->debounces
 deboucing->debouncing
+debouncin->debouncing
 debth->depth
 debths->depths
 debudg->debug
@@ -16857,6 +17223,7 @@ decalre->declare
 decalred->declared
 decalres->declares
 decalring->declaring
+decapsulatin->decapsulating
 decapsulting->decapsulating
 decathalon->decathlon
 deccelerate->decelerate
@@ -16867,9 +17234,12 @@ decceleration->deceleration
 deccrement->decrement
 deccremented->decremented
 deccrements->decrements
+deceasin->deceasing
 deceber->December
+deceivin->deceiving
 decelaration->declaration, deceleration,
 decelarations->declarations, decelerations,
+deceleratin->decelerating
 Decemer->December
 decend->descend
 decendant->descendant
@@ -16880,6 +17250,7 @@ decendentant->descendant
 decendentants->descendants
 decendents->descendents, descendants,
 decending->descending
+decentralizin->decentralizing
 decern->discern
 decerned->discerned
 decerning->discerning
@@ -16895,6 +17266,7 @@ decidated->dedicated
 decidates->dedicates
 decideable->decidable
 decidely->decidedly
+decidin->deciding
 decie->decide
 decied->decide, decided,
 deciedd->decided
@@ -16933,6 +17305,7 @@ declarayion->declaration
 declarayions->declarations
 declard->declared
 declarded->declared
+declarin->declaring
 declaritive->declarative
 declaritively->declaratively
 declarnig->declaring
@@ -17003,12 +17376,15 @@ decocdings->decodings
 decodded->decoded
 decodding->decoding
 decodeing->decoding
+decodin->decoding
 decomissioned->decommissioned
 decomissioning->decommissioning
+decommissionin->decommissioning
 decommissionn->decommission
 decommissionned->decommissioned
 decommpress->decompress
 decomoposition->decomposition
+decomposin->decomposing
 decomposion->decomposition
 decomposit->decompose
 decomposited->decomposed
@@ -17027,6 +17403,7 @@ decompresion->decompression
 decompresor->decompressor
 decompressd->decompressed
 decompresser->decompressor
+decompressin->decompressing
 decompresssion->decompression
 decompse->decompose
 decond->decode
@@ -17076,6 +17453,7 @@ decrasing->decreasing, deceasing,
 decration->decoration
 decreace->decrease
 decreas->decrease
+decreasin->decreasing
 decreate->decrease, discrete, destroy, desecrate,
 decremeant->decrement
 decremeantal->decremental
@@ -17085,6 +17463,7 @@ decremeants->decrements
 decremenet->decrement
 decremenetd->decremented
 decremeneted->decremented
+decrementin->decrementing
 decrese->decrease
 decresing->decreasing, deceasing,
 decress->decrees
@@ -17152,6 +17531,7 @@ dedidates->dedicates
 dedly->deadly
 deductable->deductible
 deductables->deductibles
+deductin->deducting
 deduplacate->deduplicate
 deduplacated->deduplicated
 deduplacates->deduplicates
@@ -17175,6 +17555,7 @@ deeep->deep
 deelte->delete
 deendencies->dependencies
 deendency->dependency
+deepenin->deepening
 deepo->depot
 deepos->depots
 deesil->diesel
@@ -17224,6 +17605,7 @@ defaulrts->defaults
 defauls->default, defaults,
 defaulst->defaults, default,
 defaultet->defaulted
+defaultin->defaulting
 defaulty->default
 defauly->default
 defaulys->defaults
@@ -17245,6 +17627,7 @@ defeaulted->defaulted
 defeaulting->defaulting
 defeaults->defaults
 defecit->deficit
+defectin->defecting
 defeine->define
 defeines->defines
 defenate->definite
@@ -17272,6 +17655,7 @@ deferentiator->differentiator
 deferentiators->differentiators
 defering->deferring
 deferreal->deferral
+deferrin->deferring
 deffault->default
 deffaulted->defaulted
 deffaults->defaults
@@ -17334,6 +17718,7 @@ definied->defined
 definiet->definite
 definietly->definitely
 definifiton->definition
+definin->defining
 definine->define, definite,
 definined->defined
 defininely->definitely
@@ -17398,6 +17783,7 @@ defishantly->deficiently
 defition->definition
 defitions->definitions
 deflaut->default
+deflectin->deflecting
 defned->defend, defined,
 defninition->definition
 defninitions->definitions
@@ -17417,6 +17803,7 @@ defult->default
 defulted->defaulted
 defulting->defaulting
 defults->defaults
+defusin->defusing
 degenarate->degenerate
 degenarated->degenerated
 degenarates->degenerates
@@ -17426,6 +17813,7 @@ degenerage->degenerate
 degeneraged->degenerated
 degenerages->degenerates
 degeneraging->degenerating
+degeneratin->degenerating
 degenracy->degeneracy
 degenrate->degenerate
 degenrated->degenerated
@@ -17460,9 +17848,11 @@ deinitailze->deinitialize
 deinitalized->deinitialized
 deinite->definite
 deinitely->definitely
+deinitializin->deinitializing
 deinition->definition
 deinitions->definitions
 deinstantating->deinstantiating
+deinstantiatin->deinstantiating
 deintialize->deinitialize
 deintialized->deinitialized
 deintializing->deinitializing
@@ -17520,6 +17910,7 @@ delection->detection, deletion, selection,
 delections->detections, deletions, selections,
 delegater->delegator, delegated, delegates, delegate,
 delegaters->delegators, delegates,
+delegatin->delegating
 delele->delete
 delelete->delete
 deleleted->deleted
@@ -17541,6 +17932,7 @@ deletetes->deletes
 deleteting->deleting
 deletetion->deletion
 deletetions->deletions
+deletin->deleting
 deletiong->deletion, deleting,
 delets->deletes
 delevop->develop
@@ -17592,6 +17984,7 @@ delimitier->delimiter
 delimitiers->delimiters
 delimitiing->delimiting
 delimitimg->delimiting
+delimitin->delimiting
 delimition->delimitation
 delimitions->delimitations
 delimitis->delimits
@@ -17616,6 +18009,7 @@ delivared->delivered
 delivative->derivative
 delivatives->derivatives
 deliverate->deliberate
+deliverin->delivering
 delivermode->deliverymode
 deliverying->delivering
 deliverys->deliveries, delivers,
@@ -17636,6 +18030,7 @@ delvery->delivery
 demagog->demagogue
 demagogs->demagogues
 demaind->demand
+demandin->demanding
 demaned->demand, demeaned,
 demenor->demeanor
 demension->dimension
@@ -17650,6 +18045,7 @@ demolishon->demolition
 demolision->demolition
 demoninator->denominator
 demoninators->denominators
+demonizin->demonizing
 demonstate->demonstrate
 demonstated->demonstrated
 demonstates->demonstrates
@@ -17663,6 +18059,7 @@ demonstratable->demonstrable
 demonstratably->demonstrably
 demonstrater->demonstrator, demonstrated, demonstrates, demonstrate,
 demonstraters->demonstrators, demonstrates,
+demonstratin->demonstrating
 demonstrats->demonstrates
 demorcracy->democracy
 demostrate->demonstrate
@@ -17672,6 +18069,7 @@ demostrating->demonstrating
 demostration->demonstration
 demudulator->demodulator
 denegrating->denigrating
+denigratin->denigrating
 denine->define, adenine, dentine,
 denined->denied, defined,
 denines->defines, denies,
@@ -17869,6 +18267,7 @@ dependices->dependencies, dependences,
 dependicies->dependencies
 dependicy->dependency
 dependig->depending
+dependin->depending
 dependnce->dependence
 dependnces->dependences
 dependncies->dependencies
@@ -17940,6 +18339,7 @@ deploiments->deployments
 deployd->deploy, deployed,
 deployement->deployment
 deployements->deployments
+deployin->deploying
 deploymenet->deployment
 deploymenets->deployments
 deply->deploy, deeply,
@@ -17979,6 +18379,7 @@ depolyment->deployment
 depolyments->deployments
 depolys->deploys
 deporarily->temporarily
+deposin->deposing
 deposint->deposing
 depoy->deploy, depot, decoy,
 depoyed->deployed
@@ -18003,11 +18404,13 @@ depreates->deprecates
 depreating->deprecating
 depreation->deprecation
 deprecatedf->deprecated
+deprecatin->deprecating
 depreceate->deprecate, depreciate,
 depreceated->deprecated, depreciated,
 depreceates->deprecates, depreciates,
 depreceating->depreciating, deprecating,
 depreceation->depreciation, deprecation,
+depreciatin->depreciating
 deprectae->deprecate
 deprectaed->deprecated
 deprectaes->deprecates
@@ -18039,7 +18442,9 @@ deprication->deprecation, deprivation,
 dequed->dequeued
 dequeing->dequeuing
 deques->dequeues
+dequeuin->dequeuing
 derageable->dirigible
+derailin->derailing
 deram->dram, dream,
 derect->direct, detect, defect, erect,
 derected->directed, detected, defected, erected,
@@ -18067,6 +18472,7 @@ dereferencce->dereference
 dereferencced->dereferenced
 dereferencces->dereferences
 dereferenccing->dereferencing
+dereferencin->dereferencing
 derefernce->dereference
 derefernced->dereferenced
 dereferncence->dereference
@@ -18116,6 +18522,7 @@ derivativ->derivative
 derivativs->derivatives
 deriver->derive, driver,
 deriviated->derived
+derivin->deriving
 derivitive->derivative
 derivitives->derivatives
 derivitivs->derivatives
@@ -18170,6 +18577,7 @@ descendands->descendants
 descendat->descendant
 descendats->descendants
 descendend->descended, descendent, descendant,
+descendin->descending
 descentences->descendants, descendents,
 descibe->describe
 descibed->described
@@ -18223,6 +18631,7 @@ descrete->discrete
 describ->describe
 describbed->described
 describibg->describing
+describin->describing
 describng->describing
 describs->describes, describe,
 describtion->description
@@ -18373,6 +18782,7 @@ deselctable->deselectable
 deselctables->deselectable
 deselcted->deselected
 deselcting->deselecting
+deselectin->deselecting
 desepears->disappears
 deserailisation->deserialisation
 deserailise->deserialise
@@ -18399,11 +18809,13 @@ deserialisaed->deserialised
 deserialisaes->deserialises
 deserialisaing->deserialising
 deserialisazion->deserialisation
+deserialisin->deserialising
 deserializae->deserialize
 deserializaed->deserialized
 deserializaes->deserializes
 deserializaing->deserializing
 deserializazion->deserialization
+deserializin->deserializing
 deserialsiation->deserialisation
 deserialsie->deserialise
 deserialsied->deserialised
@@ -18445,6 +18857,7 @@ desiging->designing, desiring,
 desigining->designing
 desigins->designs
 designd->designed
+designin->designing
 desigs->designs
 desination->destination
 desinations->destinations
@@ -18469,6 +18882,7 @@ desintegration->disintegration
 desinty->density, destiny,
 desipite->despite
 desireable->desirable
+desirin->desiring
 desision->decision
 desisions->decisions
 desitable->desirable
@@ -18516,6 +18930,7 @@ despiration->desperation
 desplay->display
 desplayed->displayed
 desplays->displays
+despondin->desponding
 desposit->deposit, deposition,
 desposition->disposition
 desrciption->description
@@ -18626,9 +19041,11 @@ destroing->destroying
 destrois->destroys
 destroyd->destroyed, destroys,
 destroyes->destroys
+destroyin->destroying
 destruciton->destruction
 destructer->destructor, destruct,
 destructers->destructors, destructs,
+destructin->destructing
 destructro->destructor
 destructros->destructors
 destruktor->destructor
@@ -18657,9 +19074,11 @@ desturtors->destructors
 desychronize->desynchronize
 desychronized->desynchronized
 detabase->database
+detachin->detaching
 detachs->detaches
 detahced->detached
 detaild->detailed
+detailin->detailing
 detaill->detail
 detailled->detailed
 detailling->detailing
@@ -18704,6 +19123,7 @@ detecter->detector, detected,
 detecters->detectors
 detectes->detects
 detectetd->detected
+detectin->detecting
 detectiona->detection, detections,
 detectsion->detection
 detectsions->detections
@@ -18732,6 +19152,7 @@ deteriate->deteriorate
 deterimine->determine
 deterimined->determined
 deterine->determine
+deterioratin->deteriorating
 deterioriating->deteriorating
 determaine->determine
 determenant->determinant
@@ -18747,6 +19168,7 @@ determindes->determines, determined,
 determinee->determine
 determineing->determining
 determing->determining, determine,
+determinin->determining
 determinining->determining
 determinisitic->deterministic
 determinisitically->deterministically
@@ -18802,6 +19224,7 @@ deubug->debug
 deubuging->debugging
 deug->debug
 deugging->debugging
+devastatin->devastating
 devasted->devastated
 devation->deviation
 devault->default
@@ -18826,6 +19249,7 @@ developement->development
 developements->developments
 developemnt->development
 developemnts->developments
+developin->developing
 developme->development, develop me,
 developmemt->development
 developmet->development
@@ -18884,6 +19308,7 @@ devestating->devastating
 devfine->define
 devfined->defined
 devfines->defines
+deviatin->deviating
 devic->device
 devicde->device
 devicdes->devices
@@ -18996,6 +19421,7 @@ diagnoal->diagonal
 diagnoals->diagonals
 diagnol->diagonal
 diagnosics->diagnostics
+diagnosin->diagnosing
 diagnositc->diagnostic
 diagnositcs->diagnostics
 diagnostioc->diagnostic
@@ -19009,6 +19435,7 @@ diagonaly->diagonally
 diagrama->diagram
 diagramas->diagrams
 diagramm->diagram
+diagrammin->diagramming
 diagramms->diagrams
 diagronalization->diagonalization
 diagronalizations->diagonalizations
@@ -19018,6 +19445,7 @@ dialgo->dialog
 dialgos->dialogs
 dialig->dialog
 dialigs->dialogs
+dialin->dialing
 dialoge->dialog, dialogue,
 dialoges->dialogs, dialogues,
 dialouge->dialogue
@@ -19233,6 +19661,7 @@ differenciates->differentiates
 differenciating->differentiating
 differenciation->differentiation
 differencies->differences
+differencin->differencing
 differenct->different
 differend->different
 differene->difference
@@ -19244,6 +19673,7 @@ differentes->differences, difference, different,
 differentiater->differentiator, differentiated, differentiates, differentiate,
 differentiaters->differentiators, differentiates,
 differentiatiations->differentiations
+differentiatin->differentiating
 differentiaton->differentiation
 differentl->differently
 differents->different, difference,
@@ -19255,6 +19685,7 @@ differientiate->differentiate
 differientiated->differentiated
 differientiates->differentiates
 differientiating->differentiating
+differin->differing
 differnce->difference
 differnces->differences
 differnciate->differentiate
@@ -19319,6 +19750,7 @@ diffuculties->difficulties
 diffuculty->difficulty
 diffues->diffuse, defuse,
 diffult->difficult
+diffusin->diffusing
 diffussion->diffusion
 diffussive->diffusive
 dificult->difficult
@@ -19342,6 +19774,7 @@ difusion->diffusion
 difusive->diffusive
 difussion->diffusion
 difussive->diffusive
+digestin->digesting
 digesty->digest
 diggest->digest, biggest,
 diggested->digested
@@ -19360,6 +19793,7 @@ digitalize->digitize
 digitalizing->digitizing
 digitial->digital
 digitis->digits
+digitizin->digitizing
 dignose->diagnose
 dignosed->diagnosed
 dignoses->diagnoses
@@ -19413,6 +19847,7 @@ dimensionaility->dimensionality
 dimensionailties->dimensionalities
 dimensionailty->dimensionality
 dimensiones->dimensions
+dimensionin->dimensioning
 dimenson->dimension
 dimensonal->dimensional
 dimensonalities->dimensionalities
@@ -19633,8 +20068,10 @@ disabiltities->disabilities
 disabiltitiy->disability
 disabing->disabling
 disabl->disable
+disablin->disabling
 disablle->disable
 disadvantadge->disadvantage
+disaggregatin->disaggregating
 disaggretate->disaggregate
 disaggretated->disaggregated
 disaggretates->disaggregates
@@ -19648,6 +20085,7 @@ disalbes->disables
 disalbing->disabling
 disale->disable
 disaled->disabled
+disallowin->disallowing
 disalow->disallow
 disambigouate->disambiguate
 disambiguaiton->disambiguation
@@ -19681,6 +20119,7 @@ disapparing->disappearing
 disappars->disappears
 disappearaing->disappearing
 disappeard->disappeared
+disappearin->disappearing
 disappearred->disappeared
 disapper->disappear
 disapperar->disappear
@@ -19695,6 +20134,7 @@ disapplined->disciplined
 disapplines->disciplines
 disapplining->disciplining
 disapplins->disciplines
+disappointin->disappointing
 disapporval->disapproval
 disapporve->disapprove
 disapporved->disapproved
@@ -19705,14 +20145,17 @@ disapprouve->disapprove
 disapprouved->disapproved
 disapprouves->disapproves
 disapprouving->disapproving
+disapprovin->disapproving
 disaproval->disapproval
 disard->discard
 disariable->desirable
 disasembler->disassembler
 disassebled->disassembled
+disassemblin->disassembling
 disassocate->disassociate
 disassocation->disassociation
 disassocations->disassociations
+disassociatin->disassociating
 disasssembler->disassembler
 disasterous->disastrous
 disatisfaction->dissatisfaction
@@ -19728,6 +20171,7 @@ disble->disable
 disbled->disabled
 disbles->disables
 disbling->disabling
+discardin->discarding
 discared->discarded, discard,
 discareded->discarded
 discarge->discharge
@@ -19768,10 +20212,13 @@ disccussing->discussing
 disccussion->discussion
 disccussions->discussions
 discernable->discernible
+discernin->discerning
 dischare->discharge
 discimenation->dissemination
+disciplinin->disciplining
 disciplins->disciplines
 disclamer->disclaimer
+disclosin->disclosing
 disconecct->disconnect
 disconeccted->disconnected
 disconeccting->disconnecting
@@ -19804,6 +20251,7 @@ disconetions->disconnections
 disconets->disconnects
 disconnec->disconnect
 disconneced->disconnected
+disconnectin->disconnecting
 disconnet->disconnect
 disconneted->disconnected
 disconneting->disconnecting
@@ -19828,6 +20276,7 @@ discoved->discovered
 discoverd->discovered
 discovereability->discoverability
 discoveribility->discoverability
+discoverin->discovering
 discovey->discovery
 discovr->discover
 discovred->discovered
@@ -19851,6 +20300,7 @@ discribes->describes
 discribing->describing
 discriminater->discriminator, discriminated, discriminates, discriminate,
 discriminaters->discriminators, discriminates,
+discriminatin->discriminating
 discription->description
 discriptions->descriptions
 discriptive->descriptive
@@ -19869,6 +20319,7 @@ discused->discussed
 discusion->discussion
 discusions->discussions
 discussd->discussed
+discussin->discussing
 discusson->discussion
 discussons->discussions
 discusss->discuss, discusses,
@@ -19901,8 +20352,11 @@ disgning->designing
 disgnostic->diagnostic
 disgnostics->diagnostics
 disgns->designs
+disgracin->disgracing
 disguisting->disgusting
+disgustin->disgusting
 disharge->discharge
+dishonorin->dishonoring
 disign->design
 disignated->designated
 disingenous->disingenuous
@@ -19934,10 +20388,12 @@ dislpay->display
 dislpayed->displayed
 dislpaying->displaying
 dislpays->displays
+dismantlin->dismantling
 dismatch->mismatch, dispatch,
 dismatched->mismatched, dispatched,
 dismatches->mismatches, dispatches,
 dismatching->mismatching, dispatching,
+dismissin->dismissing
 disnabilities->disabilities
 disnability->disability
 disnable->disable
@@ -19973,6 +20429,7 @@ dispalys->displays
 disparingly->disparagingly
 disparite->disparate
 dispatcgh->dispatch
+dispatchin->dispatching
 dispatchs->dispatches
 dispath->dispatch
 dispathed->dispatched
@@ -19989,6 +20446,7 @@ dispell->dispel
 dispence->dispense
 dispenced->dispensed
 dispencing->dispensing
+dispensin->dispensing
 dispertion->dispersion
 dispicable->despicable
 dispite->despite
@@ -20003,6 +20461,7 @@ displayd->displayed
 displayes->displays, displayed,
 displayied->displayed
 displayig->displaying
+displayin->displaying
 disply->display
 displyed->displayed
 displying->displaying
@@ -20014,6 +20473,7 @@ disporved->disproved
 disporves->disproves
 disporving->disproving
 disposel->disposal
+disposin->disposing
 dispossable->disposable
 dispossal->disposal
 disposse->dispose
@@ -20024,6 +20484,7 @@ dispostion->disposition
 dispprove->disprove, disapprove,
 disproportiate->disproportionate
 disproportionatly->disproportionately
+disprovin->disproving
 disputandem->disputandum
 disregrad->disregard
 disrepancies->discrepancies
@@ -20042,6 +20503,7 @@ disributor->distributor
 disributors->distributors
 disricts->districts
 disrm->disarm
+disruptin->disrupting
 dissable->disable
 dissabled->disabled
 dissables->disables
@@ -20159,6 +20621,7 @@ disscussion->discussion
 disscussions->discussions
 dissecter->dissector, dissenter, dissected, dissect,
 dissecters->dissectors, dissenters, dissects,
+dissectin->dissecting
 disshearteningly->dishearteningly
 dissimialr->dissimilar
 dissimialrity->dissimilarity
@@ -20182,6 +20645,7 @@ dissimliarly->dissimilarly
 dissimmetric->dissymmetric
 dissimmetrical->dissymmetrical
 dissimmetry->dissymmetry
+dissipatin->dissipating
 dissmantle->dismantle
 dissmantled->dismantled
 dissmantles->dismantles
@@ -20198,6 +20662,7 @@ dissobediance->disobedience
 dissobediant->disobedient
 dissobedience->disobedience
 dissobedient->disobedient
+dissociatin->dissociating
 dissplay->display
 dissrupt->disrupt
 dissrupted->disrupted
@@ -20218,6 +20683,7 @@ distace->distance, distaste,
 distaced->distanced
 distaces->distances, distastes,
 distancef->distanced, distances, distance,
+distancin->distancing
 distange->distance
 distanse->distance
 distantce->distance
@@ -20252,6 +20718,7 @@ distingquished->distinguished
 distinguise->distinguish
 distinguised->distinguished
 distinguises->distinguishes
+distinguishin->distinguishing
 distinguising->distinguishing
 distingush->distinguish
 distingushed->distinguished
@@ -20319,6 +20786,7 @@ distribuitng->distributing
 distribure->distribute
 distributer->distributor, distributed, distributes, distribute,
 distributers->distributors, distributes,
+distributin->distributing
 districct->district
 distrobute->distribute
 distrobuted->distributed
@@ -20358,6 +20826,7 @@ distructive->destructive
 distructor->destructor
 distructors->destructors
 distuingish->distinguish
+disturbin->disturbing
 disuade->dissuade
 disucss->discuss
 disucssed->discussed
@@ -20371,6 +20840,7 @@ disucusses->discusses
 disucussing->discussing
 disucussion->discussion
 disucussions->discussions
+disusin->disusing
 disuss->discuss, disuse,
 disussed->discussed, disused,
 disusses->discusses, disuses,
@@ -20400,8 +20870,10 @@ diviced->divided
 divicer->divider
 divices->devices, divides,
 divicing->dividing
+dividin->dividing
 dividor->divider, divisor,
 dividors->dividers, divisors,
+divinin->divining
 divinition->definition, divination,
 divion->division
 divisability->divisibility
@@ -20438,6 +20910,7 @@ doccumented->documented
 doccumenting->documenting
 doccuments->documents
 dockefile->Dockerfile
+dockin->docking
 dockson->dachshund
 docmenetation->documentation
 docment->document
@@ -20529,6 +21002,7 @@ documentatons->documentations
 documentes->documents
 documentiation->documentation
 documentiations->documentations
+documentin->documenting
 documention->documentation
 documentions->documentations
 documentstion->documentation
@@ -20588,6 +21062,7 @@ doess->does
 doestn't->doesn't
 doign->doing
 doiing->doing
+doin->doing
 doiuble->double
 doiubled->doubled
 dokc->dock
@@ -20609,11 +21084,13 @@ domension->dimension
 domensions->dimensions
 domian->domain
 domians->domains
+domin->doming
 dominante->dominant, dominate,
 dominanted->dominated
 dominantes->dominants, dominates,
 dominanting->dominating
 dominantion->domination
+dominatin->dominating
 dominaton->domination
 dominent->dominant
 dominiant->dominant
@@ -20626,6 +21103,7 @@ donain->domain
 donains->domains
 donejun->dungeon
 donejuns->dungeons
+donglin->dongling
 donig->doing
 donn't->don't
 donn->done, don,
@@ -20667,6 +21145,7 @@ dosen->dozen, dose, doesn,
 dosens->dozens
 dosent'->doesn't
 dosent->doesn't
+dosin->dosing
 dosn't->doesn't
 dosnt->doesn't
 dosposing->disposing
@@ -20702,10 +21181,12 @@ doubldes->doubles
 doubleclick->double-click
 doublely->doubly
 doubletquote->doublequote
+doublin->doubling
 doubth->doubt
 doubthed->doubted
 doubthing->doubting
 doubths->doubts
+doubtin->doubting
 doucment->document
 doucmentated->documented
 doucmentation->documentation
@@ -20764,6 +21245,7 @@ downgradded->downgraded
 downgraddes->downgrades
 downgradding->downgrading
 downgradei->downgrade
+downgradin->downgrading
 downgradingn->downgrading
 downgrate->downgrade
 downgrated->downgraded
@@ -20782,6 +21264,7 @@ downloa->download
 downloadbale->downloadable
 downloade->download
 downloades->downloads, downloaded,
+downloadin->downloading
 downloadmanger->downloadmanager
 downloaed->downloaded, download,
 downloaing->downloading
@@ -20822,10 +21305,12 @@ downsteramer->downstreamer
 downsteramers->downstreamers
 downsteraming->downstreaming
 downsterams->downstreams
+downstreamin->downstreaming
 dows->does
 dowt->doubt
 doxgen->doxygen
 doygen->doxygen
+dozin->dozing
 dpeend->depend
 dpeended->depended
 dpeendence->dependence
@@ -20877,11 +21362,14 @@ dpubles->doubles
 draconain->draconian
 dragable->draggable
 draged->dragged
+draggin->dragging
 draging->dragging
 draing->drawing, drain, draining, draping,
+drainin->draining
 drammatic->dramatic
 dramtic->dramatic
 dran->drawn
+drapin->draping
 drastical->drastically
 drasticaly->drastically
 drats->drafts
@@ -20891,6 +21379,7 @@ draview->drawview
 drawack->drawback
 drawacks->drawbacks
 drawed->drew, drawn, had drawn,
+drawin->drawing
 drawm->drawn
 drawng->drawing
 dreasm->dreams
@@ -20901,6 +21390,7 @@ dregree->degree
 dregrees->degrees
 drescription->description
 drescriptions->descriptions
+dressin->dressing
 driagram->diagram
 driagrammed->diagrammed
 driagramming->diagramming
@@ -20910,6 +21400,7 @@ dribbeld->dribbled
 dribbeled->dribbled
 dribbeling->dribbling
 dribbels->dribbles
+dribblin->dribbling
 driect->direct
 driected->directed
 driecting->directing
@@ -20925,6 +21416,7 @@ driects->directs
 drity->dirty
 drived->derived, drove, driven,
 driveing->driving
+drivin->driving
 drivr->driver
 drnik->drink
 drob->drop
@@ -20933,6 +21425,7 @@ dropable->droppable
 droped->dropped
 droping->dropping
 droppend->dropped
+droppin->dropping
 droppped->dropped
 dropse->drops
 droput->dropout
@@ -20940,6 +21433,7 @@ drowt->drought
 drowts->droughts
 druing->during
 druming->drumming
+drummin->drumming
 drummless->drumless
 drvier->driver
 drwaing->drawing
@@ -20990,6 +21484,7 @@ ducumenting->documenting
 ducuments->documents
 dudo->sudo
 dueing->doing, during, dueling,
+duelin->dueling
 duirng->during
 dulicate->duplicate, delicate,
 dulicated->duplicated
@@ -21074,6 +21569,7 @@ dupliation->duplication
 dupliations->duplications
 duplicat->duplicate
 duplicatd->duplicated
+duplicatin->duplicating
 duplicats->duplicates
 duplicte->duplicate
 duplicted->duplicated
@@ -21092,6 +21588,7 @@ durectories->directories
 durectory->directory
 dureing->during
 durig->during
+durin->during
 durining->during
 durning->during
 durring->during
@@ -21106,6 +21603,8 @@ dyanmic->dynamic
 dyanmically->dynamically
 dyanmics->dynamics
 dyas->dryas
+dyein->dyeing
+dyin->dying
 dymamic->dynamic
 dymamically->dynamically
 dymamics->dynamics
@@ -21171,6 +21670,7 @@ earliear->earlier
 earlies->earliest
 earlist->earliest
 earlyer->earlier
+earnin->earning
 earnt->earned
 earpeice->earpiece
 eary->early, easy, eerie,
@@ -21191,6 +21691,7 @@ easyest->easiest
 easyly->easily
 eather->either, rather, weather, feather, leather, ether, eat her, eater,
 eaturn->return, eaten, Saturn,
+eavesdroppin->eavesdropping
 eaxct->exact
 eaxctly->exactly
 eazier->easier
@@ -21256,6 +21757,7 @@ eddits->edits
 ede->edge
 edeycat->etiquette
 edeycats->etiquettes
+edgin->edging
 ediable->editable
 edige->edge
 ediges->edges
@@ -21275,6 +21777,7 @@ editers->editors, edits,
 editiable->editable
 editied->edited
 editiing->editing
+editin->editing
 editior->editor
 editiors->editors
 editoro->editor
@@ -21293,6 +21796,7 @@ ednpoint->endpoint
 ednpoints->endpoints
 edtion->edition
 edtions->editions
+educatin->educating
 educte->educate
 educted->educated, deducted,
 eductes->educates
@@ -21443,6 +21947,7 @@ einstance->instance
 eisntance->instance
 eiter->either
 eith->with
+ejectin->ejecting
 elagance->elegance
 elagant->elegant
 elagantly->elegantly
@@ -21450,6 +21955,7 @@ elamentaries->elementaries
 elamentary->elementary
 elamentries->elementaries
 elamentry->elementary
+elapsin->elapsing
 elaspe->elapse
 elasped->elapsed
 elaspes->elapses
@@ -21470,6 +21976,7 @@ eleases->releases
 eleate->relate
 electic->eclectic, electric,
 electical->electrical
+electin->electing
 electirc->electric
 electircal->electrical
 electon->election, electron,
@@ -21560,6 +22067,7 @@ elimiated->eliminated
 elimiates->eliminates
 elimiating->eliminating
 elimiation->elimination
+eliminatin->eliminating
 eliminetaion->elimination
 elimintate->eliminate
 eliminte->eliminate
@@ -21616,6 +22124,7 @@ emabled->enabled
 emables->enables
 emabling->enabling
 emai->email
+emailin->emailing
 emailling->emailing
 emasc->emacs
 embalance->imbalance
@@ -21640,6 +22149,7 @@ embarrased->embarrassed
 embarrasing->embarrassing
 embarrasingly->embarrassingly
 embarrasment->embarrassment
+embarrassin->embarrassing
 embbed->embed, ebbed,
 embbedded->embedded
 embbedder->embedder
@@ -21666,6 +22176,7 @@ embeddder->embedder
 embeddders->embedders
 embeddding->embedding
 embeddeding->embedding
+embeddin->embedding
 embedds->embeds
 embeded->embedded
 embededded->embedded
@@ -21680,6 +22191,7 @@ embeedding->embedding
 embezelled->embezzled
 emblamatic->emblematic
 embold->embolden
+embracin->embracing
 embrio->embryo
 embrios->embryos
 embrodery->embroidery
@@ -21702,6 +22214,7 @@ emissed->amassed, amiss,
 emited->emitted
 emiting->emitting
 emition->emission, emotion,
+emittin->emitting
 emlation->emulation
 emmediately->immediately
 emmigrated->emigrated, immigrated,
@@ -21737,6 +22250,8 @@ emphaise->emphasise
 emphaised->emphasised
 emphaises->emphasises
 emphaising->emphasising
+emphasisin->emphasising
+emphasizin->emphasizing
 emphazise->emphasize
 emphazised->emphasized
 emphazises->emphasizes
@@ -21748,6 +22263,7 @@ empirial->empirical, imperial,
 empiricaly->empirically
 emplied->implied, emptied,
 emplies->implies, empties,
+employin->employing
 emply->employ, empty, imply,
 emplyed->employed
 emplyee->employee
@@ -21776,6 +22292,7 @@ empted->emptied
 emptniess->emptiness
 emptry->empty
 emptyed->emptied
+emptyin->emptying
 emptyy->empty
 empy->empty
 emtied->emptied
@@ -21802,10 +22319,12 @@ enabing->enabling
 enabledi->enabled
 enableing->enabling
 enablen->enabled
+enablin->enabling
 enalbe->enable
 enalbed->enabled
 enalbes->enables
 enameld->enameled
+enamorin->enamoring
 enaugh->enough
 enbable->enable
 enbabled->enabled
@@ -21829,6 +22348,7 @@ encapsualted->encapsulated
 encapsualtes->encapsulates
 encapsualting->encapsulating
 encapsualtion->encapsulation
+encapsulatin->encapsulating
 encapsulatzion->encapsulation
 encapsulte->encapsulate
 encapsulted->encapsulated
@@ -21846,6 +22366,8 @@ enchancement->enhancement, enchantment,
 enchancements->enhancements, enchantments,
 enchances->enhances, enchants,
 enchancing->enhancing, enchanting,
+enchantin->enchanting
+enclosin->enclosing
 enclosng->enclosing
 enclosue->enclosure
 enclosung->enclosing
@@ -21860,6 +22382,7 @@ encocders->encoders
 encocdes->encodes
 encocding->encoding
 encocdings->encodings
+encodin->encoding
 encodingt->encoding
 encodning->encoding
 encodnings->encodings
@@ -21874,6 +22397,7 @@ encompas->encompass
 encompased->encompassed
 encompases->encompasses
 encompasing->encompassing
+encompassin->encompassing
 encompus->encompass
 encompused->encompassed
 encompuses->encompasses
@@ -21907,12 +22431,14 @@ encosings->enclosings, encodings,
 encosure->enclosure
 encounted->encountered, encounter,
 encounterd->encountered
+encounterin->encountering
 encounting->encountering
 encountre->encounter, encountered,
 encountres->encounters
 encourae->encourage
 encouraed->encouraged
 encouraes->encourages
+encouragin->encouraging
 encouraing->encouraging
 encourge->encourage
 encourged->encouraged
@@ -21961,6 +22487,7 @@ encrypiton->encryption
 encrypte->encrypted, encrypt,
 encryptiing->encrypting
 encryptiion->encryption
+encryptin->encrypting
 encryptio->encryption
 encryptiong->encryption, encrypting,
 encryt->encrypt
@@ -21994,6 +22521,8 @@ endcoding->encoding
 endcodings->encodings
 endding->ending
 ende->end
+endeavorin->endeavoring
+endeavourin->endeavouring
 endever->endeavor
 endevered->endeavored
 endeveres->endeavors
@@ -22011,6 +22540,7 @@ endien->endian, indian,
 endiens->endians, indians,
 endig->ending
 endiif->endif
+endin->ending
 endiness->endianness
 endnoden->endnode
 endoint->endpoint
@@ -22061,6 +22591,7 @@ enew->new
 enflamed->inflamed
 enforcable->enforceable
 enforceing->enforcing
+enforcin->enforcing
 enforcmement->enforcement
 enforcment->enforcement
 enfore->enforce
@@ -22092,6 +22623,7 @@ enginee->engine, engineer,
 engineeer->engineer
 engineeering->engineering
 engineeers->engineers
+engineerin->engineering
 enginees->engines, engineers,
 enginge->engine
 enginges->engines
@@ -22112,6 +22644,7 @@ enhacements->enhancements
 enhaces->enhances
 enhacing->enhancing
 enhancd->enhanced
+enhancin->enhancing
 enhancment->enhancement
 enhancments->enhancements
 enhane->enhance, ethane,
@@ -22199,6 +22732,8 @@ enpoint->endpoint
 enpoints->endpoints
 enque->enqueue
 enqueing->enqueuing
+enqueuin->enqueuing
+enquirin->enquiring
 enrties->entries
 enrtries->entries
 enrtry->entry
@@ -22225,10 +22760,12 @@ entereing->entering
 enterie->entry
 enteries->entries
 enterily->entirely
+enterin->entering
 enternal->internal, external, eternal,
 enternally->internally, externally, eternally,
 enterprice->enterprise
 enterprices->enterprises
+entertainin->entertaining
 entery->entry
 enteties->entities
 entety->entity
@@ -22312,12 +22849,14 @@ enumearate->enumerate
 enumearation->enumeration
 enumerater->enumerator, enumerated, enumerates, enumerate,
 enumeraters->enumerators, enumerates,
+enumeratin->enumerating
 enumeratior->enumerator
 enumeratiors->enumerators
 enumerble->enumerable
 enumertaion->enumeration
 enusre->ensure
 envaluation->evaluation
+envelopin->enveloping
 enveloppe->envelope
 envelopped->enveloped
 enveloppes->envelopes
@@ -22498,10 +23037,12 @@ equaivalent->equivalent
 equaivalently->equivalently
 equaivalents->equivalents
 equalibrium->equilibrium
+equalizin->equalizing
 equall->equal, equally,
 equallity->equality
 equalls->equals
 equaly->equally
+equatin->equating
 equavalence->equivalence
 equavalent->equivalent
 equavalently->equivalently
@@ -22541,6 +23082,7 @@ equilvalents->equivalents
 equiped->equipped
 equipmentd->equipment
 equipments->equipment
+equippin->equipping
 equippment->equipment
 equiptment->equipment
 equire->require, enquire, equine, esquire,
@@ -22607,6 +23149,7 @@ erasuer->erasure, eraser,
 eratic->erratic
 eratically->erratically
 eraticly->erratically
+erectin->erecting
 erested->arrested, erected,
 erformance->performance
 ergnomic->ergonomic
@@ -22635,6 +23178,7 @@ erronoeus->erroneous
 erronoeusly->erroneously
 erronous->erroneous
 erronously->erroneously
+errorin->erroring
 errorneous->erroneous
 errorneously->erroneously
 errorneus->erroneous
@@ -22671,6 +23215,7 @@ ervices->services, cervices,
 esacpe->escape
 esacped->escaped
 esacpes->escapes
+escalatin->escalating
 escalte->escalate
 escalted->escalated
 escaltes->escalates
@@ -22678,6 +23223,7 @@ escalting->escalating
 escaltion->escalation
 escapeable->escapable
 escapemant->escapement
+escapin->escaping
 escartment->escarpment
 escartments->escarpments
 escased->escaped
@@ -22814,6 +23360,7 @@ establis->establish
 establised->established
 establises->establishes
 establishd->established
+establishin->establishing
 establishs->establishes
 establising->establishing
 establsihed->established
@@ -22822,6 +23369,7 @@ estimage->estimate
 estimages->estimates
 estimater->estimator, estimated, estimates, estimate,
 estimaters->estimators, estimates,
+estimatin->estimating
 estiomator->estimator
 estiomators->estimators
 estuwarries->estuaries
@@ -22899,6 +23447,7 @@ evaluatates->evaluates
 evaluatating->evaluating
 evaluater->evaluator, evaluated, evaluates, evaluate,
 evaluaters->evaluators, evaluates,
+evaluatin->evaluating
 evalueate->evaluate
 evalueated->evaluated
 evaluete->evaluate
@@ -23006,9 +23555,11 @@ eveyrthing->everything
 eveyrwhere->everywhere
 eveything->everything
 eveywhere->everywhere
+evictin->evicting
 evidentally->evidently
 evironment->environment
 evironments->environments
+evisceratin->eviscerating
 eviserate->eviscerate
 eviserated->eviscerated
 eviserates->eviscerates
@@ -23025,12 +23576,14 @@ evluator->evaluator
 evluators->evaluators
 evnet->event
 evnts->events
+evokin->evoking
 evoluate->evaluate
 evoluated->evaluated
 evoluates->evaluates
 evoluation->evaluation, evolution,
 evoluations->evaluations, evolutions,
 evoluton->evolution
+evolvin->evolving
 evovler->evolver
 evovling->evolving
 evrithing->everything
@@ -23047,6 +23600,7 @@ ewhwer->where
 exaclty->exactly
 exacly->exactly
 exactely->exactly
+exactin->exacting
 exactlly->exactly
 exacty->exactly
 exacutable->executable
@@ -23069,6 +23623,7 @@ exagerrate->exaggerate
 exagerrated->exaggerated
 exagerrates->exaggerates
 exagerrating->exaggerating
+exaggeratin->exaggerating
 exameple->example
 exameples->examples
 examied->examined
@@ -23078,6 +23633,7 @@ examinated->examined
 examinates->examines
 examinating->examining
 examing->examining
+examinin->examining
 examinining->examining
 examle->example
 examles->examples
@@ -23207,6 +23763,7 @@ excedeed->exceeded
 excedes->exceeds
 exceding->exceeding
 exceds->exceeds
+exceedin->exceeding
 exceeed->exceed
 exceeeded->exceeded
 exceeeding->exceeding
@@ -23350,6 +23907,7 @@ exchane->exchange
 exchaned->exchanged
 exchanes->exchanges
 exchangable->exchangeable
+exchangin->exchanging
 exchaning->exchanging
 exchaust->exhaust
 exchausted->exhausted
@@ -23376,11 +23934,13 @@ exciation->excitation
 excipt->except
 exciption->exception
 exciptions->exceptions
+excisin->excising
 excist->exist, excise,
 excisted->existed, excised,
 excistence->existence
 excisting->existing, excising,
 excists->exists, excises,
+excitin->exciting
 excitment->excitement
 exclaimation->exclamation
 exclaimations->exclamations
@@ -23391,6 +23951,7 @@ excliuded->excluded
 excliudes->excludes
 excliuding->excluding
 excludde->exclude
+excludin->excluding
 excludind->excluding
 excludle->exclude
 excludled->excluded
@@ -23445,6 +24006,7 @@ exculding->excluding
 exculsive->exclusive
 exculsively->exclusively
 exculsivly->exclusively
+excusin->excusing
 excutable->executable
 excutables->executables
 excute->execute
@@ -23600,6 +24162,7 @@ executeable->executable
 executeables->executables
 executible->executable
 executign->executing
+executin->executing
 executiong->execution, executing,
 executng->executing
 executon->execution, executor,
@@ -23640,6 +24203,8 @@ exempel->example
 exempels->examples
 exemple->example
 exemples->examples
+exemplifyin->exemplifying
+exemptin->exempting
 exended->extended
 exension->extension
 exensions->extensions
@@ -23675,6 +24240,7 @@ exerciesed->exercised
 exercieses->exercises
 exerciesing->exercising
 exerciess->exercises
+exercisin->exercising
 exercize->exercise
 exercized->exercised
 exercizes->exercises
@@ -23709,6 +24275,7 @@ exersized->exercised
 exersizes->exercises
 exersizing->exercising
 exerternal->external
+exertin->exerting
 exeuctable->executable
 exeuctables->executables
 exeucte->execute
@@ -23742,6 +24309,7 @@ exhausion->exhaustion
 exhausive->exhaustive
 exhausively->exhaustively
 exhausiveness->exhaustiveness
+exhaustin->exhausting
 exhauted->exhausted
 exhauting->exhausting
 exhaution->exhaustion
@@ -23751,7 +24319,9 @@ exhautiveness->exhaustiveness
 exhautivity->exhaustivity
 exhcuast->exhaust
 exhcuasted->exhausted
+exhibitin->exhibiting
 exhibtion->exhibition
+exhilaratin->exhilarating
 exhilerate->exhilarate
 exhilerated->exhilarated
 exhilerates->exhilarates
@@ -23764,6 +24334,7 @@ exhisting->existing
 exhists->exists
 exhorbitent->exorbitant
 exhorbitently->exorbitantly
+exhortin->exhorting
 exhostive->exhaustive
 exhustiveness->exhaustiveness
 exibit->exhibit
@@ -23811,6 +24382,7 @@ exitance->existence
 exitation->excitation
 exitations->excitations
 exite->exit, excite, exits,
+exitin->exiting
 exitsing->existing, exiting,
 exitss->exists, exits,
 exitsted->existed
@@ -23910,6 +24482,7 @@ expalnations->explanations
 expanation->explanation, expansion,
 expanations->explanations, expansions,
 expanble->expandable
+expandin->expanding
 expaned->expand, expanded, explained,
 expaneded->expanded
 expaneding->expanding
@@ -23963,6 +24536,7 @@ expectatons->expectations
 expectd->expected
 expecte->expected
 expectes->expects
+expectin->expecting
 expection->exception, expectation,
 expections->exceptions, expectations,
 expediated->expedited
@@ -24118,6 +24692,7 @@ experiementations->experimentations
 experiemented->experimented
 experiementing->experimenting
 experiements->experiments
+experiencin->experiencing
 experienshial->experiential
 experiensial->experiential
 experies->expires
@@ -24235,6 +24810,7 @@ experimentatlly->experimentally
 experimentatly->experimentally
 experimentel->experimental
 experimentelly->experimentally
+experimentin->experimenting
 experimentt->experiment
 experimentted->experimented
 experimentter->experimenter
@@ -24550,6 +25126,7 @@ expirimentations->experimentations
 expirimented->experimented
 expirimenting->experimenting
 expiriments->experiments
+expirin->expiring
 expiriy->expiry
 expite->expire, expedite,
 expited->expired, expedited,
@@ -24558,6 +25135,7 @@ explainations->explanations
 explainatory->explanatory
 explaind->explained
 explaing->explaining
+explainin->explaining
 explanaiton->explanation
 explanaitons->explanations
 explanantion->explanation
@@ -24623,9 +25201,11 @@ explizit->explicit
 explizitly->explicitly
 explnation->explanation
 explnations->explanations
+exploitin->exploiting
 exploition->explosion, exploitation, exploit,
 exploitions->explosions, exploitations, exploits,
 exploititive->exploitative
+explorin->exploring
 explot->exploit, explore,
 explotation->exploitation, exploration,
 exploting->exploiting, exploring,
@@ -24665,6 +25245,8 @@ exporession->expression
 exporing->exploring, expiring, exporting, exposing,
 expors->exports
 exportet->exported, exporter,
+exportin->exporting
+exposin->exposing
 expport->export
 exppressed->expressed
 exprect->expect
@@ -24682,6 +25264,7 @@ expresions->expressions
 expresison->expression
 expresisons->expressions
 expressable->expressible
+expressin->expressing
 expressino->expression
 expressio->expression
 expressiong->expression, expressing,
@@ -24709,6 +25292,7 @@ expropiated->expropriated
 expropiates->expropriates
 expropiating->expropriating
 expropiation->expropriation
+expropriatin->expropriating
 exprot->export
 exproted->exported
 exproting->exporting
@@ -24796,6 +25380,7 @@ exten->extend, extent,
 extenal->external
 extendded->extended
 extendet->extended
+extendin->extending
 extendsion->extension
 extendsions->extensions
 extened->extended
@@ -24873,6 +25458,7 @@ extited->excited, exited,
 extiting->exciting, exiting,
 extits->exits, excites,
 extnesion->extension
+extortin->extorting
 extrac->extract
 extraced->extracted
 extracing->extracting
@@ -24892,6 +25478,7 @@ extradiction->extradition
 extraenous->extraneous
 extranous->extraneous
 extraordinarly->extraordinarily
+extrapolatin->extrapolating
 extrapole->extrapolate
 extrapoled->extrapolated
 extrapoles->extrapolates
@@ -24946,6 +25533,7 @@ extrmities->extremities
 extrodinary->extraordinary
 extrordinarily->extraordinarily
 extrordinary->extraordinary
+extrudin->extruding
 extry->entry
 exturd->extrude
 exturde->extrude
@@ -24963,6 +25551,7 @@ exucution->execution
 exucutions->executions
 exucutor->executor
 exucutors->executors
+exudin->exuding
 exurpt->excerpt
 exurpts->excerpts
 eyar->year, eyas,
@@ -24976,13 +25565,16 @@ fabircated->fabricated
 fabircates->fabricates
 fabircatings->fabricating
 fabircation->fabrication
+fabricatin->fabricating
 facce->face
+facedrawin->facedrawing
 facedrwaing->facedrawing, face drawing,
 faceis->faces, face is,
 faciliate->facilitate
 faciliated->facilitated
 faciliates->facilitates
 faciliating->facilitating
+facilitatin->facilitating
 facilites->facilities
 facilitiate->facilitate
 facilitiates->facilitates
@@ -25004,10 +25596,12 @@ facourite->favourite
 facourites->favourites
 facours->favours
 factization->factorization
+factorin->factoring
 factorizaiton->factorization
 factorys->factories
 facttories->factories
 facttory->factory
+fadin->fading
 fadind->fading
 faeture->feature
 faetures->features
@@ -25024,6 +25618,7 @@ failicies->facilities
 failicy->facility
 failied->failed
 failiing->failing
+failin->failing
 failiure->failure
 failiures->failures
 failiver->failover
@@ -25081,6 +25676,7 @@ fallbck->fallback
 fallbcks->fallbacks
 falled->failed, fell, fallen, felled,
 fallhrough->fallthrough
+fallin->falling
 fallthough->fallthrough
 fallthruogh->fallthrough
 falltrough->fallthrough
@@ -25093,6 +25689,7 @@ falsks->flasks
 falsly->falsely
 falso->false
 falt->fault, flat,
+falterin->faltering
 falure->failure
 falures->failures
 familar->familiar
@@ -25141,6 +25738,7 @@ fasened->fastened
 fasening->fastening
 fasens->fastens, fasels,
 fases->fazes, phases,
+fashionin->fashioning
 fashism->fascism
 fashist->fascist
 fashists->fascists
@@ -25156,6 +25754,7 @@ fasodd->facade
 fasodds->facades
 fassade->facade
 fassinate->fascinate
+fastenin->fastening
 fasterner->fastener
 fasterners->fasteners
 fastner->fastener
@@ -25181,10 +25780,12 @@ fauture->feature
 fautured->featured
 fautures->features
 fauturing->featuring
+favorin->favoring
 favoutrable->favourable
 favritt->favorite
 favuourites->favourites
 faymus->famous
+fazin->fazing
 fcound->found
 feasabile->feasible
 feasability->feasibility
@@ -25203,6 +25804,7 @@ featchure->feature
 featchured->featured
 featchures->features
 featchuring->featuring
+featherin->feathering
 featre->feature
 featred->featured
 featres->features
@@ -25220,6 +25822,7 @@ featues->features
 featuing->featuring
 featur->feature
 featurd->featured
+featurin->featuring
 featurng->featuring
 featurs->features
 feautre->feature
@@ -25268,6 +25871,7 @@ fertil->fertile
 fertily->fertility
 fetaure->feature
 fetaures->features
+fetchin->fetching
 fetchs->fetches
 feture->feature, future,
 fetured->featured
@@ -25333,8 +25937,10 @@ figgure->figure
 figgured->figured
 figgures->figures
 figguring->figuring
+fightin->fighting
 fightings->fighting
 figurestyle->figurestyles
+figurin->figuring
 fiield->field
 fiields->fields
 filal->final
@@ -25399,6 +26005,7 @@ fille->file, fill, filled,
 fillement->filament
 fillements->filaments
 filles->files, fills, filled,
+fillin->filling
 filll->fill
 fillled->filled
 filller->filler
@@ -25439,6 +26046,8 @@ fimware->firmware
 finacial->financial
 finailse->finalise
 finailze->finalize
+finalisin->finalising
+finalizin->finalizing
 finall->finally, final,
 finalle->finale, finally,
 finallly->finally
@@ -25500,6 +26109,7 @@ finised->finished
 finishd->finished
 finishe->finished, finish,
 finishied->finished
+finishin->finishing
 finishs->finishes
 finising->finishing
 finitel->finite
@@ -25531,6 +26141,7 @@ firendly->friendly
 firends->friends, fiends,
 firest->fires, first,
 firey->fiery
+firin->firing
 firmare->firmware
 firmaware->firmware
 firmawre->firmware
@@ -25578,6 +26189,7 @@ fixeing->fixing
 fixel->pixel
 fixels->pixels
 fixeme->fixme
+fixin->fixing
 fixwd->fixed
 fizeek->physique
 flacor->flavor
@@ -25605,12 +26217,17 @@ flaoting->floating
 flase->false, flake, flame, flare, flash, flask,
 flashflame->flashframe
 flashig->flashing
+flashin->flashing
 flasing->flashing
 flass->class, glass, flask, flash,
 flate->flat
 flatened->flattened
 flattend->flattened
+flattenin->flattening
 flattenning->flattening
+flatterin->flattering
+flavorin->flavoring
+flavourin->flavouring
 flawess->flawless
 flawessly->flawlessly
 flawlessy->flawlessly
@@ -25634,6 +26251,7 @@ fliped->flipped
 fliper->flipper
 flipers->flippers
 fliping->flipping
+flippin->flipping
 fliter->filter
 flitered->filtered
 flitering->filtering
@@ -25642,6 +26260,8 @@ floading->floating, flooding,
 floading-add->floating-add
 floaing->floating, flowing,
 floatation->flotation
+floatin->floating
+floodin->flooding
 flor->floor, flow,
 floresent->fluorescent, florescent,
 floride->fluoride
@@ -25649,7 +26269,9 @@ floting->floating
 flourescent->fluorescent, florescent,
 flouride->fluoride
 flourine->fluorine
+flourishin->flourishing
 flourishment->flourishing
+flowin->flowing
 flter->filter, falter, flutter, flatter, floater,
 fltered->filtered, faltered, fluttered, flattered,
 fltering->filtering, faltering, fluttering, flattering,
@@ -25659,8 +26281,10 @@ flud->flood
 fluorish->flourish
 fluoroscent->fluorescent
 fluroescent->fluorescent
+flushin->flushing
 flushs->flushes
 flusing->flushing
+flutterin->fluttering
 flyes->flies, flyers,
 fnction->function
 fnctions->functions
@@ -25678,6 +26302,7 @@ focued->focused
 focument->document
 focuse->focus
 focusf->focus
+focusin->focusing
 focuss->focus
 foded->folded, coded, faded, forded, boded,
 foder->folder, coder,
@@ -25691,6 +26316,7 @@ fogotten->forgotten
 fointers->pointers
 folde->folder, fold,
 foldes->folders, folder, folds,
+foldin->folding
 foler->folder
 folers->folders
 folfer->folder
@@ -25934,6 +26560,7 @@ fontains->fountains, contains,
 fontend->frontend, contend,
 fontends->frontends, contends,
 fontier->frontier
+fontifyin->fontifying
 fontisizing->fontifying
 fontonfig->fontconfig
 fontrier->frontier
@@ -25959,6 +26586,7 @@ forbad->forbade
 forbatum->verbatim
 forbbiden->forbidden
 forbidded->forbidden, forbade,
+forbiddin->forbidding
 forbiden->forbidden
 forbit->forbid
 forbiten->forbidden
@@ -25971,11 +26599,14 @@ forcasters->forecasters
 forcasting->forecasting
 forcasts->forecasts
 forceably->forcibly
+forcin->forcing
 forcot->forgot
 forcus->focus, forces,
 forcused->focused
 forcuses->focuses
 forcusing->focusing
+fordin->fording
+forecastin->forecasting
 forece->force
 foreced->forced
 foreces->forces
@@ -25987,16 +26618,21 @@ foregronds->foregrounds
 foreing->foreign
 forementionned->aforementioned
 forermly->formerly
+foreseein->foreseeing
+foretellin->foretelling
 foreward->forward, foreword, forewarn,
 forewarded->forwarded, forewarned,
 forewarding->forwarding, forewarning,
 forewards->forwards, forewords, forewarns,
+forewarnin->forewarning
+forfeitin->forfeiting
 forfiet->forfeit
 forfit->forfeit
 forfited->forfeited
 forfiting->forfeiting
 forfits->forfeits
 forgeround->foreground
+forgettin->forgetting
 forgoten->forgotten
 forgotton->forgotten
 forground->foreground
@@ -26009,6 +26645,7 @@ forld->fold
 forlder->folder
 forlders->folders
 Formalhaut->Fomalhaut
+formalizin->formalizing
 formallize->formalize
 formallized->formalized
 formaly->formally, formerly,
@@ -26024,6 +26661,7 @@ formating->formatting
 formatteded->formatted
 formattgin->formatting
 formattied->formatted
+formattin->formatting
 formattind->formatting
 formattings->formatting
 formattring->formatting
@@ -26063,6 +26701,7 @@ formualations->formulations
 formuale->formulae
 formuals->formulas
 formulaical->formulaic
+formulatin->formulating
 formulayic->formulaic
 formware->firmware
 fornat->format
@@ -26086,6 +26725,7 @@ fortan->fortran
 fortat->format
 forteen->fourteen
 fortelling->foretelling
+forthcomin->forthcoming
 forthcominng->forthcoming
 forthcomming->forthcoming
 forthe->for the, forth, forte,
@@ -26111,6 +26751,7 @@ forwaded->forwarded
 forwading->forwarding
 forwads->forwards
 forwardig->forwarding
+forwardin->forwarding
 forwared->forwarded, forward,
 forwareded->forwarded
 forwareding->forwarding
@@ -26145,6 +26786,7 @@ foult->fault
 foults->faults
 foundaries->foundries
 foundary->foundry
+foundin->founding
 Foundland->Newfoundland
 fourh->fourth
 fourties->forties
@@ -26174,6 +26816,7 @@ fragmenetd->fragmented
 fragmeneted->fragmented
 fragmeneting->fragmenting
 fragmenets->fragments
+fragmentin->fragmenting
 fragmentization->fragmentation
 fragmnet->fragment
 fram->frame, gram, dram, cram,
@@ -26188,6 +26831,7 @@ framewoek->framework
 framewoeks->frameworks
 frameword->framework
 frameworkk->framework
+framin->framing
 framlayout->framelayout
 framming->framing
 frams->frames, grams, drams, crams,
@@ -26232,7 +26876,9 @@ freeezers->freezers
 freeezes->freezes
 freeezing->freezing
 freez->frees, freeze,
+freezin->freezing
 freezs->freezes
+freightin->freighting
 freind->friend
 freindly->friendly
 freinds->friends
@@ -26376,6 +27022,7 @@ fugures->figures
 fule->file
 fulfiled->fulfilled
 fulfiling->fulfilling
+fulfillin->fulfilling
 fullfil->fulfil, fulfill,
 fullfiled->fulfilled
 fullfiling->fulfilling
@@ -26499,6 +27146,7 @@ functionaltiies->functionalities
 functionaltiy->functionality
 functionalty->functionality
 functionaly->functionally, functionality,
+functionin->functioning
 functionionalities->functionalities
 functionionality->functionality
 functionlities->functionalities
@@ -26713,6 +27361,8 @@ gastly->ghastly, vastly,
 gatable->gateable
 gateing->gating
 gatherig->gathering
+gatherin->gathering
+gatin->gating
 gatway->gateway
 gauage->gauge
 gauarana->guaraná
@@ -26831,6 +27481,8 @@ generaging->generating
 generaing->generating
 generaion->generation
 generaions->generations
+generalisin->generalising
+generalizin->generalizing
 generall->generally, general,
 generallly->generally
 generaly->generally
@@ -27012,6 +27664,7 @@ geomtrically->geometrically
 geomtries->geometries
 geomtry->geometry
 geomtrys->geometries
+georeferencin->georeferencing
 georeferncing->georeferencing
 geraff->giraffe
 geraphics->graphics
@@ -27078,6 +27731,7 @@ getoject->getobject
 gettetx->gettext
 gettig->getting
 gettign->getting
+gettin->getting
 gettings->getting, settings,
 gettitem->getitem, get item,
 gettitems->getitems, get items,
@@ -27114,11 +27768,13 @@ gitub->GitHub
 gived->given, gave,
 giveing->giving
 givem->given, give them, give 'em,
+givin->giving
 givne->given
 givveing->giving
 givven->given
 givving->giving
 glamourous->glamorous
+glancin->glancing
 glight->flight
 gloab->globe
 gloabal->global
@@ -27148,8 +27804,10 @@ glyh->glyph
 glyhs->glyphs
 glyped->glyphed
 glyphes->glyphs
+glyphin->glyphing
 glyping->glyphing
 glyserin->glycerin
+gnarlin->gnarling
 gnawwed->gnawed
 gneral->general
 gnerally->generally
@@ -27228,10 +27886,12 @@ govorment->government
 govormental->governmental
 govornment->government
 grabage->garbage
+grabbin->grabbing
 grabed->grabbed
 grabing->grabbing
 gracefull->graceful
 gracefuly->gracefully
+gracin->gracing
 gradiant->gradient, radiant,
 gradiants->gradients
 gradualy->gradually
@@ -27281,6 +27941,7 @@ graphci->graphic
 graphcial->graphical
 graphcis->graphics
 graphial->graphical
+graphin->graphing
 graphis->graphics
 grapic->graphic
 grapical->graphical
@@ -27330,9 +27991,11 @@ groubpy->groupby
 groupd->grouped
 groupe->grouped, group,
 groupes->groups, grouped,
+groupin->grouping
 groupped->grouped
 groupping->grouping
 groupt->grouped
+growin->growing
 growtesk->grotesque
 growteskly->grotesquely
 grpah->graph
@@ -27357,11 +28020,13 @@ Guadulupe->Guadalupe, Guadeloupe,
 guage->gauge
 guarante->guarantee
 guaranted->guaranteed
+guaranteein->guaranteeing
 guaranteey->guaranty
 guaranteing->guaranteeing
 guarantes->guarantees
 guarantie->guarantee
 guarbage->garbage
+guardin->guarding
 guared->guard, guarded,
 guareded->guarded
 guareente->guarantee
@@ -27558,6 +28223,7 @@ hadnling->handling
 hadnt->hadn't
 haeder->header
 haemorrage->haemorrhage
+haemorrhagin->haemorrhaging
 haev->have, heave,
 hagas->haggis
 hagases->haggises
@@ -27593,6 +28259,7 @@ handkerchifs->handkerchiefs
 handleer->handler
 handleing->handling
 handlig->handling
+handlin->handling
 handlling->handling
 handlong->handling
 handsake->handshake
@@ -27603,6 +28270,7 @@ handshage->handshake
 handshages->handshakes
 handshaging->handshaking
 handshak->handshake
+handshakin->handshaking
 handshakng->handshaking
 handshakre->handshake
 handshakres->handshakes
@@ -27622,8 +28290,10 @@ handshkng->handshaking
 handshks->handshakes
 handskake->handshake
 handwirting->handwriting
+handwritin->handwriting
 hanel->handle
 hangig->hanging
+hangin->hanging
 hankerchif->handkerchief
 hankerchifs->handkerchiefs
 hanlde->handle
@@ -27667,6 +28337,7 @@ happending->happening
 happends->happens
 happenend->happened
 happenes->happens, happened, happiness,
+happenin->happening
 happenned->happened
 happenning->happening
 happennings->happenings
@@ -27680,17 +28351,20 @@ happpened->happened
 happpening->happening
 happpenings->happenings
 happpens->happens
+haranguin->haranguing
 harased->harassed
 harases->harasses
 harasment->harassment
 harasments->harassments
 harassement->harassment
+harassin->harassing
 harcode->hardcode, charcode,
 harcoded->hardcoded
 harcodes->hardcodes, charcodes,
 harcoding->hardcoding
 hard-wirted->hard-wired
 hardare->hardware
+hardcodin->hardcoding
 hardocde->hardcode
 hardward->hardware
 hardwdare->hardware
@@ -27721,6 +28395,7 @@ harwdare->hardware
 has'nt->hasn't
 hases->hashes
 hashi->hash
+hashin->hashing
 hashreference->hash reference
 hashs->hashes
 hashses->hashes
@@ -27732,6 +28407,7 @@ hass->hash
 hastable->hashtable
 hastables->hashtables
 Hatian->Haitian
+hatin->hating
 hauty->haughty
 hav->have, half,
 hava->have, have a,
@@ -27744,6 +28420,7 @@ havent't->haven't
 havent->haven't
 havew->have
 haviest->heaviest
+havin->having
 havind->having
 havn't->haven't
 havne't->haven't
@@ -27760,6 +28437,7 @@ heade->header, head,
 headerr->header
 headerrs->headers
 heades->headers, heads,
+headin->heading
 headle->handle
 headong->heading
 headquarer->headquarter
@@ -27777,6 +28455,7 @@ hearbeat->heartbeat, heart beat, hear beat,
 hearbeating->heartbeating, heart beating, hear beating,
 hearbeats->heartbeats, heart beats, hear beats,
 heared->heard, header,
+heartbeatin->heartbeating
 heatbeat->heartbeat
 heatbeats->heartbeats
 heathy->healthy
@@ -27815,6 +28494,7 @@ helpe->helper, help, helped,
 helpes->helps, helpers,
 helpfull->helpful
 helpfuly->helpfully
+helpin->helping
 helpped->helped
 helpying->helping
 hemipshere->hemisphere
@@ -27834,6 +28514,7 @@ hemoraged->haemorrhaged, hemorrhaged,
 hemorages->haemorrhages, hemorrhages,
 hemoragic->haemorrhagic, hemorrhagic,
 hemoraging->haemorrhaging, hemorrhaging,
+hemorrhagin->hemorrhaging
 henc->hence
 henderence->hindrance
 hendler->handler
@@ -27865,6 +28546,7 @@ hesistates->hesitates
 hesistating->hesitating
 hesistation->hesitation
 hesistations->hesitations
+hesitatin->hesitating
 hestiate->hesitate
 hetrogeneous->heterogeneous
 hetrogenous->heterogenous, heterogeneous,
@@ -27895,6 +28577,7 @@ hiddin->hidden, hiding,
 hidding->hiding, hidden,
 hideen->hidden
 hiden->hidden
+hidin->hiding
 hiearchical->hierarchical
 hiearchically->hierarchically
 hiearchies->hierarchies
@@ -27999,10 +28682,12 @@ higlights->highlights
 higly->highly
 higth->height
 higway->highway
+hijackin->hijacking
 hijkack->hijack
 hijkacked->hijacked
 hijkacking->hijacking
 hijkacks->hijacks
+hikin->hiking
 hilight->highlight
 hilighted->highlighted
 hilighter->highlighter
@@ -28014,6 +28699,7 @@ himselv->himself
 hinderance->hindrance
 hinderence->hindrance
 hindrence->hindrance
+hintin->hinting
 hipopotamus->hippopotamus
 hipoteses->hypotheses
 hipotesis->hypothesis
@@ -28043,6 +28729,7 @@ hirearcical->hierarchical
 hirearcically->hierarchically
 hirearcies->hierarchies
 hirearcy->hierarchy
+hirin->hiring
 hismelf->himself
 hisory->history
 histerical->historical, hysterical,
@@ -28074,6 +28761,7 @@ hitories->histories
 hitory->history
 hitsingles->hit singles
 hitted->hit
+hittin->hitting
 hiygeine->hygiene
 hmdi->hdmi
 hmtl->html
@@ -28099,6 +28787,7 @@ homogenoues->homogeneous
 homogenous->homogeneous
 homogenously->homogeneously
 homogenuous->homogeneous
+honorin->honoring
 honory->honorary
 hoook->hook
 hoooks->hooks
@@ -28113,6 +28802,7 @@ hopeing->hoping
 hopful->hopeful
 hopfull->hopeful, hopefully,
 hopfully->hopefully
+hopin->hoping
 hopmepage->homepage
 hopmepages->homepages
 hoppefully->hopefully
@@ -28141,6 +28831,7 @@ horphan->orphan
 horrable->horrible
 horray->hooray
 horrifing->horrifying
+horrifyin->horrifying
 horyzontally->horizontally
 horziontal->horizontal
 horziontally->horizontally
@@ -28160,6 +28851,7 @@ hould->hold, should,
 hounour->honour
 houres->hours
 housand->thousand
+housekeepin->housekeeping
 houskeeping->housekeeping
 housr->hours, house,
 hovever->however
@@ -28229,6 +28921,7 @@ hundreths->hundredths
 hundrets->hundreds
 hungs->hangs, hung,
 hunrgy->hungry
+huntin->hunting
 huricane->hurricane
 huristic->heuristic
 huristics->heuristics
@@ -28277,6 +28970,7 @@ hypens->hyphens
 hyperboly->hyperbole
 Hyperldger->Hyperledger
 hypervior->hypervisor
+hyphenatin->hyphenating
 hypocracy->hypocrisy
 hypocrasy->hypocrisy
 hypocricy->hypocrisy
@@ -28292,6 +28986,7 @@ hypotetical->hypothetical
 hypotetically->hypothetically
 hypothenuse->hypotenuse
 hypothenuses->hypotenuses
+hypothesizin->hypothesizing
 hypter->hyper
 hyptotheses->hypotheses
 hyptothesis->hypothesis
@@ -28467,6 +29162,7 @@ identifyed->identified
 identifyer->identifier
 identifyers->identifiers
 identifyes->identifies
+identifyin->identifying
 identiication->identification
 identiications->identifications
 identiied->identified
@@ -28554,6 +29250,7 @@ ignorgg->ignoring
 ignorgig->ignoring
 ignorging->ignoring
 ignorgs->ignores
+ignorin->ignoring
 ignormable->ignorable
 ignormd->ignored
 ignorme->ignore
@@ -28690,6 +29387,7 @@ imigrated->immigrated, emigrated,
 imigration->immigration, emigration,
 imilar->similar
 iminent->imminent, immanent, eminent,
+imitatin->imitating
 imlement->implement
 imlementation->implementation
 imlementations->implementations
@@ -28767,6 +29465,7 @@ imortes->imports
 imorting->importing
 imorts->imports
 imovable->immovable
+impactin->impacting
 impcat->impact
 impcated->impacted
 impcating->impacting
@@ -28803,6 +29502,7 @@ impementing->implementing
 impementling->implementing
 impementor->implementer
 impements->implements
+impendin->impending
 imperiaal->imperial
 imperical->empirical, imperial,
 imperically->empirically
@@ -28917,6 +29617,7 @@ implementeed->implemented
 implementeing->implementing
 implementes->implements
 implementet->implemented
+implementin->implementing
 implemention->implementation
 implementions->implementations
 implementtaion->implementation
@@ -29011,6 +29712,7 @@ implmented->implemented
 implmenting->implementing
 implments->implements
 imploys->employs
+implyin->implying
 imporance->importance
 imporant->important
 imporantly->importantly
@@ -29040,6 +29742,7 @@ importence->importance, impotence,
 importend->important, imported,
 importent->important, impotent,
 importently->importantly, impotently,
+importin->importing
 importnce->importance
 importnt->important
 importntly->importantly
@@ -29079,6 +29782,7 @@ imprements->implements, improvements,
 impres->impress
 impresive->impressive
 impressario->impresario
+impressin->impressing
 impreve->improve
 impreved->improved
 imprevement->improvement
@@ -29134,11 +29838,13 @@ improvemnt->improvement
 improvemnts->improvements
 improvent->improvement, improvident,
 improvents->improvements
+improvin->improving
 improvision->improvisation
 improvmenet->improvement
 improvmenets->improvements
 improvment->improvement
 improvments->improvements
+impugnin->impugning
 impune->impugn
 impuned->impugned
 impuner->impugner
@@ -29146,6 +29852,7 @@ impunes->impugns
 impuning->impugning
 impuns->impugns
 imput->input
+imputin->imputing
 imputs->inputs, imputes,
 imputted->inputted, imputed,
 imputting->inputting, imputing,
@@ -29217,6 +29924,7 @@ inbrio->embryo
 inbrios->embryos
 inbulit->inbuilt, built-in,
 incalid->invalid
+incapacitatin->incapacitating
 incarcirated->incarcerated
 incase->in case
 incatation->incantation
@@ -29231,6 +29939,7 @@ incemental->incremental
 incementally->incrementally
 incemented->incremented
 incements->increments
+incensin->incensing
 incerase->increase
 incerased->increased
 incerasing->increasing
@@ -29266,6 +29975,7 @@ includeing->including
 includied->included
 includig->including
 includign->including
+includin->including
 includng->including
 includs->includes
 inclue->include
@@ -29301,6 +30011,7 @@ incombatible->incompatible
 incombatibly->incompatibly
 incomfort->discomfort, uncomfortable, in comfort,
 incomfortable->uncomfortable
+incomin->incoming
 incomming->incoming
 incommplete->incomplete
 incompaitible->incompatible
@@ -29468,6 +30179,7 @@ incorperated->incorporated
 incorperates->incorporates
 incorperating->incorporating
 incorperation->incorporation
+incorporatin->incorporating
 incorportae->incorporate
 incorportaed->incorporated
 incorportaes->incorporates
@@ -29527,6 +30239,7 @@ increamenting->incrementing
 increaments->increments
 increas->increase
 increasd->increased
+increasin->increasing
 increate->increase, in create,
 increated->increased, in created,
 increates->increases
@@ -29543,6 +30256,7 @@ incremenetd->incremented
 incremeneted->incremented
 incrementall->incremental, incrementally,
 incrementaly->incrementally
+incrementin->incrementing
 incremet->increment
 incremetal->incremental
 incremeted->incremented
@@ -29724,6 +30438,7 @@ indeveres->endeavours, endeavors,
 indevering->endeavouring, endeavoring,
 indevers->endeavours, endeavors,
 indexig->indexing
+indexin->indexing
 indexs->indexes, indices,
 indext->index, indent,
 indiactor->indicator
@@ -29737,6 +30452,7 @@ indicateds->indicated, indicates,
 indicatee->indicates, indicated,
 indicater->indicator, indicated, indicates, indicate,
 indicaters->indicators, indicates,
+indicatin->indicating
 indicationg->indicating, indication,
 indicatior->indicator
 indicatiors->indicators
@@ -29818,6 +30534,7 @@ indroduces->introduces
 indroducing->introducing
 indroduction->introduction
 indroductions->introductions
+inducin->inducing
 indulgue->indulge
 indure->endure
 indutrial->industrial
@@ -29897,6 +30614,7 @@ inferfacing->interfacing
 infering->inferring
 inferrable->inferable
 inferrence->inference
+inferrin->inferring
 infex->index
 infilitrate->infiltrate
 infilitrated->infiltrated
@@ -29915,6 +30633,7 @@ infintesimal->infinitesimal
 infinty->infinity
 infite->infinite
 inflamation->inflammation
+inflatin->inflating
 inflatoin->inflation
 inflexable->inflexible
 influece->influence
@@ -29966,6 +30685,7 @@ informaton->information
 informatonal->informational
 informfation->information
 informfational->informational
+informin->informing
 informtion->information
 informtional->informational
 inforrmation->information
@@ -30002,6 +30722,7 @@ infrustructure->infrastructure
 infrustructures->infrastructures
 ingegral->integral
 ingenius->ingenious
+ingestin->ingesting
 ingnorar->ignore, ignorant,
 ingnore->ignore
 ingnored->ignored
@@ -30033,6 +30754,7 @@ inherith->inherit
 inherithed->inherited
 inherithing->inheriting
 inheriths->inherits
+inheritin->inheriting
 inheritted->inherited
 inheritting->inheriting
 inherrit->inherit
@@ -30380,6 +31102,7 @@ initialiseing->initialising
 initialisiation->initialisation
 initialisiations->initialisations
 initialisiert->initialised, initialized,
+initialisin->initialising
 initialisong->initialising
 initialiss->initialise, initialises,
 initialistion->initialisation
@@ -30411,6 +31134,7 @@ initializedd->initialized
 initializeing->initializing
 initializiation->initialization
 initializiations->initializations
+initializin->initializing
 initializong->initializing
 initializs->initialize, initializes,
 initializtion->initialization
@@ -30471,6 +31195,7 @@ initiatiats->initiates
 initiatie->initiate
 initiatied->initiated
 initiaties->initiates
+initiatin->initiating
 initiatve->initiative, initiate,
 initiatves->initiatives, initiates,
 initiial->initial
@@ -30650,6 +31375,7 @@ inizializes->initializes
 inizializing->initializing
 inizially->initially
 inizials->initials
+injectin->injecting
 inlalid->invalid
 inlclude->include
 inlcluded->included
@@ -30803,6 +31529,7 @@ inpu->input
 inpust->input, inputs,
 inputed->inputted
 inputsream->inputstream
+inputtin->inputting
 inpuut->input
 inrement->increment
 inrements->increments
@@ -30911,6 +31638,7 @@ insitution->institution
 insitutional->institutional
 insitutions->institutions
 insonsistency->inconsistency
+inspectin->inspecting
 inspite->in spite, inspire,
 instaance->instance
 instabce->instance
@@ -30948,6 +31676,7 @@ installator->installer
 installators->installers
 installe->installer, installed, install,
 installes->installs
+installin->installing
 installion->installation, installing,
 installl->install
 installlation->installation
@@ -30982,6 +31711,7 @@ instantating->instantiating
 instantation->instantiation
 instantations->instantiations
 instantiaties->instantiates
+instantiatin->instantiating
 instanze->instance
 instatance->instance
 instatiate->instantiate
@@ -31027,6 +31757,7 @@ insterters->inserters
 insterting->inserting
 instertion->insertion
 insterts->inserts
+instillin->instilling
 institue->institute
 institues->institutes
 instituion->institution
@@ -31108,12 +31839,14 @@ instrucitonal->instructional
 instrucitons->instructions
 instructer->instructor, instructed, instruct,
 instructers->instructors, instructs,
+instructin->instructing
 instrumenet->instrument
 instrumenetation->instrumentation
 instrumenetd->instrumented
 instrumeneted->instrumented
 instrumentaion->instrumentation
 instrumentaiton->instrumentation
+instrumentin->instrumenting
 instrumnet->instrument
 instrumnets->instruments
 instrut->instruct
@@ -31240,6 +31973,7 @@ integrading->integrating
 integradion->integration
 integradions->integrations
 integrat->integrate, integral,
+integratin->integrating
 integrats->integrates, integrals,
 integreate->integrate
 integreated->integrated
@@ -31278,6 +32012,7 @@ intendation->indentation, intention,
 intendations->indentations, intentions,
 intendend->intended
 intendet->intended
+intendin->intending
 inteneded->intended
 intenet->internet, intent,
 intenisty->intensity
@@ -31330,6 +32065,7 @@ interacsion->interaction
 interacsions->interactions
 interacteve->interactive
 interactevely->interactively
+interactin->interacting
 interactionn->interaction
 interactionns->interactions
 interactiv->interactive
@@ -31446,10 +32182,12 @@ interesseted->interested
 interesst->interest
 interessted->interested
 interessting->interesting
+interestin->interesting
 intereview->interview
 interfac->interface
 interfacce->interface
 interfacces->interfaces
+interfacin->interfacing
 interfacs->interfaces
 interfact->interact, interface,
 interfacts->interacts, interfaces,
@@ -31471,6 +32209,7 @@ interfer->interfere
 interferance->interference
 interferd->interfered
 interfereing->interfering
+interferin->interfering
 interfernce->interference
 interferred->interfered
 interferring->interfering
@@ -31501,6 +32240,8 @@ interitance->inheritance
 interited->inherited
 interiting->inheriting
 interits->inherits
+interlacin->interlacing
+interleavin->interleaving
 interliveing->interleaving
 interlly->internally
 interm->interim, intern,
@@ -31523,6 +32264,7 @@ internatioanlist->internationalist
 internatioanlists->internationalists
 internatioanlly->internationally
 internation->international
+internationalizin->internationalizing
 internel->internal
 internels->internals
 internface->interface
@@ -31556,6 +32298,7 @@ interpolaed->interpolated
 interpolaion->interpolation
 interpolaiton->interpolation
 interpolar->interpolator
+interpolatin->interpolating
 interpolayed->interpolated
 interpoloate->interpolate
 interpoloated->interpolated
@@ -31579,6 +32322,7 @@ interpretatons->interpretations
 interprete->interpret
 interpretes->interprets
 interpretet->interpreted
+interpretin->interpreting
 interpretion->interpretation
 interpretions->interpretations
 interpretor->interpreter
@@ -31614,6 +32358,7 @@ interruped->interrupted
 interruping->interrupting
 interrups->interrupts
 interruptable->interruptible
+interruptin->interrupting
 interruptors->interrupters
 interruptted->interrupted
 interrut->interrupt
@@ -31625,6 +32370,7 @@ interseccting->intersecting
 intersecction->intersection
 interseccts->intersects
 intersecrion->intersection
+intersectin->intersecting
 intersecton->intersection
 intersectons->intersections
 intersepts->intercepts, intersteps,
@@ -31633,6 +32379,7 @@ intersperese->intersperse
 intersperesed->interspersed
 interspereses->intersperses
 intersperesing->interspersing
+interspersin->interspersing
 interst->interest
 intersted->interested
 intersting->interesting
@@ -31654,6 +32401,7 @@ interuupt->interrupt
 intervall->interval
 intervalls->intervals
 interveening->intervening
+intervenin->intervening
 intervines->intervenes
 intesection->intersection
 intesity->intensity
@@ -31801,6 +32549,7 @@ intilizer->initializer
 intilizers->initializers
 intilizes->initializes
 intilizing->initializing
+intimidatin->intimidating
 intimitading->intimidating
 intimite->intimate
 intinite->infinite
@@ -31906,12 +32655,14 @@ intrfacing->interfacing
 intriduce->introduce
 intriduced->introduced
 intriduction->introduction
+intriguin->intriguing
 intrisic->intrinsic
 intrisically->intrinsically
 intrisics->intrinsics
 intrisinc->intrinsic
 intrisincally->intrinsically
 intrisincs->intrinsics
+introducin->introducing
 introducted->introduced
 introducting->introducing
 introductionary->introductory
@@ -32003,6 +32754,7 @@ invaldates->invalidates
 invalde->invalid
 invalidaiton->invalidation
 invalidaitons->invalidations
+invalidatin->invalidating
 invalidatiopn->invalidation
 invalide->invalid
 invalidiate->invalidate
@@ -32027,6 +32779,7 @@ inverions->inversions
 invers->inverse, invert,
 invertedd->inverted
 invertibrates->invertebrates
+invertin->inverting
 invertion->inversion
 invertions->inversions
 inverval->interval
@@ -32042,6 +32795,7 @@ investiage->investigate
 investiaged->investigated
 investiages->investigates
 investiaging->investigating
+investigatin->investigating
 investingate->investigate
 investingated->investigated
 investingates->investigates
@@ -32075,6 +32829,7 @@ invokable->invocable
 invokation->invocation
 invokations->invocations
 invokee->invoked, invoke,
+invokin->invoking
 invokve->invoke
 invokved->invoked
 invokves->invokes
@@ -32087,6 +32842,7 @@ involing->involving
 involtue->involute
 involtued->involuted
 involtues->involutes
+involvin->involving
 involvment->involvement
 invove->involve, invoke,
 invoved->involved, invoked,
@@ -32137,6 +32893,7 @@ irradated->irradiated
 irradates->irradiates
 irradating->irradiating
 irradation->irradiation
+irradiatin->irradiating
 irraditate->irradiate
 irraditated->irradiated
 irraditates->irradiates
@@ -32156,6 +32913,7 @@ irresistable->irresistible
 irresistably->irresistibly
 irrevelant->irrelevant, irreverent,
 irreversable->irreversible
+irritatin->irritating
 is'nt->isn't
 isalha->isalpha
 isconnection->isconnected
@@ -32183,6 +32941,7 @@ isntalls->installs
 isntance->instance
 isntances->instances
 isntead->instead, isn't read,
+isolatin->isolating
 isotrophically->isotropically
 ispatches->dispatches
 isplay->display
@@ -32193,6 +32952,7 @@ isssue->issue
 isssued->issued
 isssues->issues
 issueing->issuing
+issuin->issuing
 issus->issues
 issuse->issue, issues,
 issused->issued
@@ -32228,6 +32988,7 @@ ists->its, lists,
 istself->itself
 isue->issue
 isues->issues
+italicizin->italicizing
 itearte->iterate
 itearted->iterated
 iteartes->iterates
@@ -32284,6 +33045,7 @@ iterater->iterator, iterated, iterates, iterate,
 iteraterate->iterate
 iteratered->iterated
 iteraters->iterators, iterates,
+iteratin->iterating
 iteratior->iterator
 iteratiors->iterators
 iteratoin->iteration
@@ -32457,13 +33219,16 @@ jewl->Jew, jewel,
 jewllery->jewellery
 jhondoe->johndoe
 jist->gist
+jitterin->jittering
 jitterr->jitter
 jitterring->jittering
 jkd->jdk
 jodpers->jodhpurs
 Johanine->Johannine
 joineable->joinable
+joinin->joining
 joinning->joining
+jointin->jointing
 jont->joint
 jonts->joints
 jornal->journal
@@ -32486,6 +33251,8 @@ jounaling->journaling
 jounals->journals
 jouney->journey
 jouneys->journeys
+journalin->journaling
+journeyin->journeying
 journied->journeyed
 journies->journeys
 journing->journeying
@@ -32511,6 +33278,7 @@ juli->July
 jumo->jump
 jumoed->jumped
 jumpimng->jumping
+jumpin->jumping
 jumpt->jumped, jump,
 juni->June
 jupyther->Jupyter
@@ -32553,6 +33321,7 @@ justifcations->justifications
 justifed->justified
 justifes->justifies, justices,
 justifing->justifying
+justifyin->justifying
 justs->just
 juxt->just
 juxtification->justification
@@ -32570,10 +33339,12 @@ kalidescopes->kaleidoscopes
 karisma->charisma
 karismatic->charismatic
 karismatically->charismatically
+kayakin->kayaking
 kazakstan->Kazakhstan
 keboard->keyboard
 keboards->keyboards
 keep-alives->keep-alive
+keepin->keeping
 keept->kept
 keesh->quiche
 kenel->kernel, kennel,
@@ -32634,6 +33405,7 @@ keyworks->keywords, key works,
 keywors->keywords
 keywprd->keyword
 keywprds->keywords
+kiboshin->kiboshing
 kibutz->kibbutz
 kibutzes->kibbutzim
 kibutzim->kibbutzim
@@ -32645,6 +33417,7 @@ kidknapper->kidnapper
 kidknappers->kidnappers
 kidknapping->kidnapping
 kidknaps->kidnaps
+kidnappin->kidnapping
 kighbosh->kibosh
 kighboshed->kiboshed
 kighboshes->kiboshes
@@ -32679,6 +33452,7 @@ knarled->gnarled
 knarling->gnarling
 knarls->gnarls
 knarly->gnarly
+kneadin->kneading
 knive->knife
 kno->know
 knockous->noxious
@@ -32686,6 +33460,7 @@ knockously->noxiously
 knoing->knowing
 knoledge->knowledge
 knoledgeable->knowledgeable
+knowin->knowing
 knowladge->knowledge
 knowladgeable->knowledgeable
 knowlage->knowledge
@@ -32769,6 +33544,8 @@ labbeled->labeled, labelled,
 labbels->labels
 labed->labeled, labelled,
 labeld->labelled
+labelin->labeling
+labellin->labelling
 labirinth->labyrinth
 lable->label, ladle, labile, able,
 labled->labeled, labelled,
@@ -32776,6 +33553,7 @@ lablel->label
 lablels->labels
 lables->labels
 labling->labeling, labelling,
+laborin->laboring
 labouriously->laboriously
 labratory->laboratory
 labrynth->labyrinth
@@ -32788,6 +33566,7 @@ lackers->lacquers
 lackrimose->lachrymose
 lackrimosity->lachrymosity
 lackrimosly->lachrymosely
+lacquerin->lacquering
 laer->later, layer,
 laest->least, latest,
 laf->laugh, leaf, loaf, lad, lag, lac, kaf, kaph,
@@ -32811,6 +33590,7 @@ lanauage->language
 lanauages->languages
 lanauge->language
 lanauges->languages
+lancin->lancing
 langage->language
 langages->languages
 langague->language
@@ -32920,6 +33700,7 @@ larvas->larvae
 larvay->larvae
 larvays->larvae
 larvy->larvae
+laserin->lasering
 laso->also, lasso,
 lasonya->lasagna
 lastes->latest
@@ -32942,10 +33723,12 @@ laucher->launcher
 lauchers->launchers
 lauches->launches
 lauching->launching
+laughin->laughing
 laugnage->language
 laugnages->languages
 lauguage->language
 lauguages->languages
+launchin->launching
 launchs->launch, launches,
 launck->launch
 laungage->language
@@ -32966,6 +33749,7 @@ lavelled->leveled, labelled,
 lavelling->levelling, labelling,
 lavels->levels, labels,
 layed->laid
+layerin->layering
 layou->layout
 layringes->larynges
 layrinks->larynx
@@ -33013,11 +33797,14 @@ leaglity->legality
 leaglize->legalize
 leaneant->lenient
 leaneantly->leniently
+leanin->leaning
 leanr->lean, learn, leaner,
 leapyear->leap year
 leapyears->leap years
+learnin->learning
 leary->leery
 leaset->least
+leasin->leasing
 leasure->leisure
 leasurely->leisurely
 leasures->leisures
@@ -33026,6 +33813,7 @@ leat->lead, leak, least, leaf,
 leathal->lethal
 leats->least
 leaveing->leaving
+leavin->leaving
 leavong->leaving
 leeg->league
 leegs->leagues
@@ -33038,6 +33826,7 @@ lefted->left
 legac->legacy
 legact->legacy
 legalimate->legitimate
+legalizin->legalizing
 legasy->legacy
 legecies->legacies
 legecy->legacy
@@ -33080,6 +33869,7 @@ lenghty->lengthy
 lengt->length
 lengten->lengthen
 lengtext->longtext
+lengthenin->lengthening
 lengthes->lengths
 lengthh->length
 lengthly->lengthy, lengthwise, lengthily,
@@ -33114,11 +33904,14 @@ leutenant->lieutenant
 levae->leave, levee,
 levaridge->leverage
 leve->level, levee,
+levelin->leveling
+levellin->levelling
 leves->levels, levees,
 levetate->levitate
 levetated->levitated
 levetates->levitates
 levetating->levitating
+levitatin->levitating
 levl->level
 levle->level
 lew->lieu, hew, sew, dew,
@@ -33137,6 +33930,7 @@ leyering->layering
 leyers->layers
 leyout->layout
 leyouts->layouts
+liaisin->liaising
 liares->liars
 liase->liaise
 liased->liaised
@@ -33211,8 +34005,10 @@ lications->locations
 licemse->license
 licemses->licenses
 licenceing->licencing
+licencin->licencing
 licencse->license, licenses,
 licens->license
+licensin->licensing
 licese->license
 licesed->licensed
 liceses->licenses
@@ -33262,6 +34058,8 @@ lighing->lighting
 lighning->lightning
 lightbulp->lightbulb
 lightbulps->lightbulbs
+lightin->lighting
+lightnin->lightning
 lightweigh->lightweight
 lightwieght->lightweight
 lightwight->lightweight
@@ -33309,6 +34107,7 @@ limitier->limiter
 limitiers->limiters
 limitiing->limiting
 limitimg->limiting
+limitin->limiting
 limition->limitation
 limitions->limitations
 limitis->limits
@@ -33378,6 +34177,7 @@ linkes->links, linked, likes, lines,
 linkfy->linkify
 linnaena->linnaean
 lintain->lintian
+lintin->linting
 linz->lines
 lippizaner->lipizzaner
 liquify->liquefy
@@ -33413,6 +34213,7 @@ listeing->listening
 listeneing->listening
 listeneres->listeners
 listenes->listens
+listenin->listening
 listenn->listen
 listenned->listened
 listenner->listener
@@ -33430,6 +34231,7 @@ listenters->listeners
 listenting->listening
 listents->listens
 listernes->listeners
+listin->listing
 listned->listened
 listner->listener
 listners->listeners
@@ -33465,6 +34267,7 @@ livel->level
 livels->levels
 livetime->lifetime
 livetimes->lifetimes
+livin->living
 livley->lively
 lizens->license
 lizense->license
@@ -33548,6 +34351,7 @@ locaizer->localizer
 locaizes->localizes
 localation->location
 localed->located
+localizin->localizing
 localtion->location
 localtions->locations
 localy->locally
@@ -33556,6 +34360,7 @@ locatin->location, locating,
 locatins->locations
 loccked->locked
 locgical->logical
+lockin->locking
 lockingf->locking
 locla->local
 loclae->locale
@@ -33579,6 +34384,7 @@ lodable->loadable
 loded->loaded
 loder->loader
 loders->loaders
+lodgin->lodging
 loding->loading
 loev->love
 logarithimic->logarithmic
@@ -33623,6 +34429,7 @@ lonber->longer, loner,
 lond->long
 lonelyness->loneliness
 long-runnign->long-running
+long-runnin->long-running
 longe->longer, lounge,
 longers->longer
 longitudonal->longitudinal
@@ -33654,6 +34461,7 @@ losd->lost, loss, lose, load,
 losely->loosely
 losen->loosen
 losened->loosened
+losin->losing
 losted->listed, lost, lasted,
 lotation->rotation, flotation,
 lotharingen->Lothringen
@@ -33661,6 +34469,7 @@ lowd->load, low, loud,
 lowerace->lowercase
 loweraced->lowercased
 loweracing->lowercasing
+lowercasin->lowercasing
 lozonya->lasagna
 lpatform->platform
 lsat->last, slat, sat,
@@ -33681,6 +34490,7 @@ lushisly->lusciously
 lveo->love
 lvoe->love
 Lybia->Libya
+lyin->lying
 maake->make
 maange->manage
 maanged->managed
@@ -33754,6 +34564,7 @@ maibox->mailbox
 mailformed->malformed
 mailicious->malicious
 mailiciously->maliciously
+mailin->mailing
 mailling->mailing
 maillinglist->mailing list
 maillinglists->mailing lists
@@ -33785,6 +34596,7 @@ maintaince->maintenance
 maintainces->maintenances
 maintainence->maintenance
 maintaing->maintaining
+maintainin->maintaining
 maintaint->maintain
 maintainted->maintained
 maintainter->maintainer
@@ -33838,6 +34650,7 @@ makeing->making
 makfile->makefile
 makfiles->makefiles
 makign->making
+makin->making
 makretplace->marketplace
 makro->macro
 makros->macros
@@ -33854,6 +34667,7 @@ maliciusly->maliciously
 malicous->malicious
 malicousally->maliciously
 malicously->maliciously
+malignin->maligning
 maline->malign
 malined->maligned
 malining->maligning
@@ -33889,6 +34703,7 @@ managenment->management
 managerment->management
 managet->manager
 managets->managers
+managin->managing
 managmenet->management
 managment->management
 manaise->mayonnaise
@@ -33920,6 +34735,7 @@ manetainer->maintainer
 manetainers->maintainers
 manetaining->maintaining
 manetains->maintains
+maneuverin->maneuvering
 manfest->manifest
 manfested->manifested
 manfesting->manifesting
@@ -33956,6 +34772,7 @@ manifacturer->manufacturer
 manifacturers->manufacturers
 manifactures->manufactures
 manifect->manifest
+manifestin->manifesting
 manifiest->manifest
 manifiested->manifested
 manifiesting->manifesting
@@ -33993,6 +34810,7 @@ mannually->manually
 mannualy->manually
 manoeuverability->maneuverability
 manoeuvering->maneuvering
+manoeuvrin->manoeuvring
 manouevring->manoeuvring
 manouver->maneuver, manoeuvre,
 manouverability->maneuverability, manoeuvrability,
@@ -34036,6 +34854,7 @@ manufactuer->manufacture, manufacturer,
 manufactuerd->manufactured
 manufactuers->manufactures, manufacturers,
 manufacturedd->manufactured
+manufacturin->manufacturing
 manufature->manufacture
 manufatured->manufactured
 manufaturer->manufacturer
@@ -34072,9 +34891,11 @@ mapp->map
 mappble->mappable
 mappeds->mapped
 mappeed->mapped
+mappin->mapping
 mappped->mapped
 mappping->mapping
 mapppings->mappings
+marchin->marching
 marger->merger, marker,
 margers->mergers, markers,
 marging->margin, merging,
@@ -34089,6 +34910,7 @@ marixsts->marxists
 marjority->majority
 markaup->markup
 markes->marks, marked, markers,
+marketin->marketing
 marketting->marketing
 markey->marquee
 markeys->marquees
@@ -34097,6 +34919,7 @@ marrage->marriage
 marraige->marriage
 marrtyred->martyred
 marryied->married
+marshalin->marshaling
 marshmellow->marshmallow
 marshmellows->marshmallows
 marter->martyr
@@ -34119,11 +34942,13 @@ maskerading->masquerading
 maskeraid->masquerade
 masos->macos
 masquarade->masquerade
+masqueradin->masquerading
 masqurade->masquerade
 Massachusettes->Massachusetts
 Massachussets->Massachusetts
 Massachussetts->Massachusetts
 massagebox->messagebox
+massagin->massaging
 massectomy->mastectomy
 massewer->masseur
 massmedia->mass media
@@ -34140,6 +34965,7 @@ masterbation->masturbation
 mastquerade->masquerade
 mastter->master
 mastters->masters
+masturbatin->masturbating
 mata->meta, mater,
 mata-data->meta-data
 matadata->metadata
@@ -34235,6 +35061,7 @@ maximimum->maximum
 maximimums->maximums
 maximium->maximum
 maximiums->maximums
+maximizin->maximizing
 maximnum->maximum
 maximnums->maximums
 maximuim->maximum
@@ -34342,6 +35169,7 @@ measureable->measurable
 measureably->measurably
 measuremenet->measurement
 measuremenets->measurements
+measurin->measuring
 measurmenet->measurement
 measurmenets->measurements
 measurment->measurement
@@ -34446,6 +35274,7 @@ meethod->method
 meethodology->methodology
 meethods->methods
 meetign->meeting
+meetin->meeting
 meganism->mechanism
 mege->merge
 meged->merged
@@ -34517,6 +35346,7 @@ memner->member
 memoery->memory
 memomry->memory
 memor->memory
+memorizin->memorizing
 memoty->memory
 memove->memmove
 mempry->memory
@@ -34525,6 +35355,7 @@ memwar->memoir
 memwars->memoirs
 memwoir->memoir
 memwoirs->memoirs
+menacin->menacing
 menaing->meaning, menacing, mending,
 menaings->meanings
 menally->mentally
@@ -34534,6 +35365,7 @@ menber->member
 menbers->members
 menbership->membership
 menberships->memberships
+mendin->mending
 menetion->mention
 menetioned->mentioned
 menetioning->mentioning
@@ -34555,9 +35387,11 @@ menthod->method, menthol,
 menthods->methods
 mentiond->mentioned
 mentione->mentioned
+mentionin->mentioning
 mentionned->mentioned
 mentionning->mentioning
 mentionnned->mentioned
+mentorin->mentoring
 menual->manual
 menue->menu
 menues->menus
@@ -34578,6 +35412,8 @@ merget->merged, merger, merge,
 mergge->merge
 mergged->merged
 mergging->merging
+mergin->merging
+meritin->meriting
 merly->merely, formerly,
 mermory->memory
 merory->memory
@@ -34593,6 +35429,8 @@ meshe->mesh, meshed, meshes,
 meskeeto->mosquito
 meskeetoes->mosquitoes
 meskeetos->mosquitos
+mesmerisin->mesmerising
+mesmerizin->mesmerizing
 mesoneen->mezzanine
 mesoneens->mezzanines
 messae->message, messy,
@@ -34630,6 +35468,7 @@ messge->message
 messged->messaged, messed,
 messges->messages, messes,
 messging->messaging, messing,
+messin->messing
 messsage->message
 messsaged->messaged
 messsages->messages
@@ -34652,6 +35491,7 @@ mesurment->measurement
 meta-attrubute->meta-attribute
 meta-attrubutes->meta-attributes
 meta-progamming->meta-programming
+meta-programmin->meta-programming
 metacharater->metacharacter
 metacharaters->metacharacters
 metadat->metadata
@@ -34666,6 +35506,7 @@ metapackges->metapackages
 metaphore->metaphor
 metaphoricial->metaphorical
 metaprogamming->metaprogramming
+metaprogrammin->metaprogramming
 metatada->metadata
 metatadata->metadata
 metatdata->metadata
@@ -34791,6 +35632,7 @@ mige->midge
 miges->midges
 migh->might
 migrateable->migratable
+migratin->migrating
 migt->might, midget,
 migth->might
 miht->might
@@ -34878,6 +35720,7 @@ mimatching->mismatching
 mimiced->mimicked
 mimicing->mimicking
 mimick->mimic
+mimickin->mimicking
 mimicks->mimics
 mimima->minima
 mimimal->minimal
@@ -34921,7 +35764,9 @@ MingGW->MinGW
 minimam->minimum
 minimial->minimal
 minimim->minimum
+minimisin->minimising
 minimium->minimum
+minimizin->minimizing
 minimsation->minimisation
 minimse->minimise
 minimsed->minimised
@@ -35015,6 +35860,7 @@ mirorrs->mirrors
 mirors->mirrors, minors,
 mirro->mirror
 mirroed->mirrored
+mirrorin->mirroring
 mirrorn->mirror
 mirrorr->mirror
 mirrorred->mirrored
@@ -35048,6 +35894,7 @@ mischieveous->mischievous
 mischieveously->mischievously
 mischievious->mischievous
 misconfiged->misconfigured
+misconfigurin->misconfiguring
 Miscrosoft->Microsoft
 misdameanor->misdemeanor
 misdameanors->misdemeanors
@@ -35067,6 +35914,7 @@ misinterpert->misinterpret
 misinterperted->misinterpreted
 misinterperting->misinterpreting
 misinterperts->misinterprets
+misinterpretin->misinterpreting
 misinterprett->misinterpret
 misinterpretted->misinterpreted
 misinterpretting->misinterpreting
@@ -35076,12 +35924,14 @@ misions->missions, minions, visions,
 misisng->missing
 misison->mission
 misisons->missions
+misleadin->misleading
 mismach->mismatch
 mismached->mismatched
 mismaches->mismatches
 mismaching->mismatching
 mismactch->mismatch
 mismatchd->mismatched
+mismatchin->mismatching
 mismatchs->mismatches
 mismatich->mismatch
 Misouri->Missouri
@@ -35091,6 +35941,7 @@ mispelling->misspelling
 mispellings->misspellings
 mispells->misspells
 mispelt->misspelt
+misplacin->misplacing
 mispronounciation->mispronunciation
 misquito->mosquito
 misquitoes->mosquitoes
@@ -35132,6 +35983,7 @@ misspel->misspell
 misspeled->misspelled
 misspeling->misspelling
 misspelings->misspellings
+misspellin->misspelling
 misspels->misspells
 missplace->misplace
 missplaced->misplaced
@@ -35183,6 +36035,8 @@ mistrows->maestros
 misue->misuse
 misued->misused
 misuing->misusing
+misunderstandin->misunderstanding
+misusin->misusing
 mitake->mistake
 mitaken->mistaken
 mitakes->mistakes
@@ -35192,6 +36046,7 @@ miticateing->mitigating
 miticates->mitigates
 miticating->mitigating
 miticator->mitigator
+mitigatin->mitigating
 mittigate->mitigate
 miximum->maximum
 mixted->mixed
@@ -35240,8 +36095,10 @@ modefiers->modifiers
 modefies->modifies
 modefy->modify
 modefying->modifying
+modelin->modeling
 modelinng->modeling
 modell->model
+modellin->modelling
 modellinng->modelling
 modellled->modelled
 modellling->modelling
@@ -35251,6 +36108,8 @@ modernination->modernization
 moderninations->modernizations
 moderninationz->modernizations
 modernizationz->modernizations
+modernizin->modernizing
+modesettin->modesetting
 modesettting->modesetting
 modeul->module
 modeuls->modules
@@ -35352,6 +36211,7 @@ modifyed->modified
 modifyer->modifier
 modifyers->modifiers
 modifyes->modifies
+modifyin->modifying
 modiification->modification
 modiifications->modifications
 modiified->modified
@@ -35369,6 +36229,7 @@ modlue->module
 modlues->modules
 modprobbing->modprobing
 modprobeing->modprobing
+modprobin->modprobing
 modtified->modified
 modue->module
 moduel->module
@@ -35457,6 +36318,7 @@ monitered->monitored
 monitering->monitoring
 moniters->monitors
 monitoing->monitoring
+monitorin->monitoring
 monitring->monitoring
 monkies->monkeys
 monlayer->monolayer
@@ -35548,6 +36410,7 @@ motivaiton->motivation
 motiviated->motivated
 motiviation->motivation
 motononic->monotonic
+motorin->motoring
 motoroloa->motorola
 moudle->module
 moudles->modules
@@ -35556,6 +36419,7 @@ moudules->modules
 mounth->month, mouth,
 mounths->months, mouths,
 mountian->mountain
+mountin->mounting
 mountpiont->mountpoint
 mountpionts->mountpoints
 mouspointer->mousepointer
@@ -35757,11 +36621,13 @@ multipllication->multiplication
 multiplyed->multiplied
 multiplyer->multiplier, multiplayer,
 multiplyers->multipliers
+multiplyin->multiplying
 multipresistion->multiprecision
 multipul->multiple
 multipy->multiply
 multipying->multiplying
 multipyling->multiplying
+multithreadin->multithreading
 multithred->multithread
 multithreded->multithreaded
 multithreding->multithreading
@@ -35818,6 +36684,7 @@ muncipality->municipality
 municiple->municipal
 munnicipality->municipality
 munute->minute
+murderin->murdering
 murr->myrrh
 muscel->muscle, mussel,
 muscels->mussels, muscles,
@@ -35972,6 +36839,7 @@ naiborhoods->neighborhoods, neighbourhoods,
 naiborly->neighborly, neighbourly,
 naibors->neighbors, neighbours,
 naieve->naive
+nailin->nailing
 naivity->naivety
 nam->name
 namaed->named
@@ -35991,6 +36859,7 @@ namesd->named, names,
 namess->names
 namesspace->namespace
 namesspaces->namespaces
+namin->naming
 namme->name
 nammed->named
 nammes->names
@@ -36012,6 +36881,7 @@ nanosencond->nanosecond
 nanosenconds->nanoseconds
 nanoseond->nanosecond
 nanoseonds->nanoseconds
+napalmin->napalming
 Naploeon->Napoleon
 Napolean->Napoleon
 Napoleonian->Napoleonic
@@ -36024,6 +36894,7 @@ napommes->napalms
 napomming->napalming
 napomms->napalms
 napoms->napalms
+narkin->narking
 narl->gnarl, snarl, earl, farl, marl, nail, nark, nary,
 narled->gnarled, snarled, nailed, narked,
 narling->gnarling, snarling, nailing, narking,
@@ -36066,6 +36937,7 @@ natioanlist->nationalist
 natioanlists->nationalists
 natioanlly->nationally
 natioanls->nationals
+nationalizin->nationalizing
 nativelyx->natively
 natrual->natural
 natrually->naturally
@@ -36099,6 +36971,7 @@ naviagtor->navigator
 naviagtors->navigators
 navigater->navigator, navigated, navigates, navigate,
 navigaters->navigators, navigates,
+navigatin->navigating
 navigaton->navigation, navigator,
 navitvely->natively
 navtive->native
@@ -36237,6 +37110,7 @@ neede->needed, need, needle,
 needeed->needed
 needeing->needing
 needes->needs, needed, needles,
+needin->needing
 neeed->need, needed,
 neeeded->needed
 neeeding->needing
@@ -36398,6 +37272,7 @@ negothiator->negotiator
 negothiators->negotiators
 negotiater->negotiator, negotiated, negotiates, negotiate,
 negotiaters->negotiators, negotiates,
+negotiatin->negotiating
 negotible->negotiable
 negoticable->negotiable
 negoticate->negotiate
@@ -36612,6 +37487,7 @@ neighborhoor->neighbor
 neighborhoors->neighbors
 neighborhoud->neighborhood
 neighborhouds->neighborhoods
+neighborin->neighboring
 neighbos->neighbors
 neighbot->neighbor
 neighbothood->neighborhood
@@ -36638,6 +37514,7 @@ neighbourhoor->neighbour
 neighbourhoors->neighbours
 neighbourhoud->neighbourhood
 neighbourhouds->neighbourhoods
+neighbourin->neighbouring
 neighbous->neighbours
 neighbout->neighbour
 neighbouthood->neighbourhood
@@ -36802,6 +37679,7 @@ nexted->nested, texted,
 nexting->nesting, texting,
 ngix->nginx
 ngnix->nginx
+nichin->niching
 niear->near
 niearest->nearest
 niether->neither
@@ -36871,6 +37749,7 @@ nnovisheate->novitiate
 nnovisheates->novitiates
 nnumber->number
 no-overide->no-override
+noddin->nodding
 nodel->model, nodal,
 nodels->models
 nodess->nodes
@@ -36929,6 +37808,7 @@ nomrals->normals
 non-alphanumunder->non-alphanumeric
 non-asii->non-ascii
 non-assiged->non-assigned
+non-blockin->non-blocking
 non-bloking->non-blocking
 non-compleeted->non-completed
 non-complient->non-compliant
@@ -36988,6 +37868,7 @@ non-negotitated->non-negotiated
 non-negotited->non-negotiated
 non-negoziable->non-negotiable
 non-negoziated->non-negotiated
+non-neighborin->non-neighboring
 non-persistant->non-persistent
 non-priviliged->non-privileged
 non-referenced-counted->non-reference-counted
@@ -37058,6 +37939,8 @@ normaizes->normalizes
 normaizing->normalizing
 normale->normal
 normales->normals
+normalisin->normalising
+normalizin->normalizing
 normall->normal, normally,
 normallisation->normalisation
 normallise->normalise
@@ -37115,6 +37998,7 @@ notbooks->notebooks, not books,
 notce->notice, notch, note, nonce,
 notced->noticed, notched, noted,
 notces->notices, notches, notes, nonces,
+notchin->notching
 notcing->noticing, nothing, notching, noting,
 noteable->notable
 noteably->notably
@@ -37147,6 +38031,7 @@ noticications->notifications
 noticied->noticed, notified,
 noticies->notices, notifies,
 noticiing->noticing
+noticin->noticing
 noticy->notify, notice,
 noticying->notifying
 notidication->notification
@@ -37198,8 +38083,10 @@ notifycation->notification
 notifycations->notifications
 notifyed->notified
 notifyes->notifies
+notifyin->notifying
 notigication->notification
 notigications->notifications
+notin->noting
 notitication->notification
 notitications->notifications
 notitied->notified
@@ -37226,6 +38113,8 @@ notticed->noticed
 nottices->notices
 notticing->noticing
 notwhithstanding->notwithstanding
+notwithstandin->notwithstanding
+nourishin->nourishing
 noveau->nouveau
 novemeber->November
 Novemer->November
@@ -37258,6 +38147,7 @@ ntegration->integration
 ntegrations->integrations
 ntegrity->integrity
 ntification->notification
+nuancin->nuancing
 nuber->number
 nubered->numbered
 nubering->numbering
@@ -37295,6 +38185,7 @@ numberators->numerators
 numberic->numeric
 numberical->numerical
 numberically->numerically
+numberin->numbering
 numberous->numerous
 numberr->number
 numberred->numbered
@@ -37355,6 +38246,7 @@ nurisher->nourisher
 nurishes->nourishes
 nurishing->nourishing
 nurishment->nourishment
+nurturin->nurturing
 nusance->nuisance
 nutral->neutral
 nutrally->neutrally
@@ -37426,6 +38318,7 @@ obeserves->observes
 obeserving->observing
 obession->obsession
 obessions->obsessions
+obeyin->obeying
 obgect->object
 obgects->objects
 obhect->object
@@ -37451,6 +38344,8 @@ objctives->objectives
 objcts->objects
 objec->object
 objecs->objects
+objectifyin->objectifying
+objectin->objecting
 objectss->objects
 objejct->object
 objekt->object
@@ -37482,6 +38377,7 @@ obseravtion->observation
 obseravtions->observations
 observ->observe
 observered->observed
+observin->observing
 obsevrer->observer
 obsevrers->observers
 obslete->obsolete
@@ -37502,6 +38398,7 @@ obssessed->obsessed
 obstacal->obstacle
 obstancles->obstacles
 obstruced->obstructed
+obstructin->obstructing
 obsure->obscure
 obtaien->obtain, obtained,
 obtaiend->obtained
@@ -37509,6 +38406,7 @@ obtaiens->obtains
 obtaine->obtain, obtained, obtains,
 obtaines->obtains
 obtainig->obtaining
+obtainin->obtaining
 obtaion->obtain
 obtaioned->obtained
 obtaions->obtains
@@ -37612,6 +38510,7 @@ occuppiers->occupiers
 occuppies->occupies
 occuppy->occupy
 occuppying->occupying
+occupyin->occupying
 occuracy->accuracy
 occurance->occurrence
 occurances->occurrences
@@ -37629,6 +38528,7 @@ occurrance->occurrence
 occurrances->occurrences
 occurrencies->occurrences
 occurrencs->occurrences
+occurrin->occurring
 occurrred->occurred
 occurrrence->occurrence
 occurrrences->occurrences
@@ -37702,6 +38602,7 @@ ofcource->of course
 off-laod->off-load
 off-laoded->off-loaded
 off-laoding->off-loading
+off-loadin->off-loading
 offcers->officers
 offcial->official
 offcially->officially
@@ -37712,6 +38613,7 @@ offenest->oftenest
 offens->offend, offense, offends, offers,
 offerd->offered
 offereings->offerings
+offerin->offering
 offest->offset
 offests->offsets
 offet->offset, offer,
@@ -37754,6 +38656,7 @@ offisionados->aficionados
 offlaod->offload
 offlaoded->offloaded
 offlaoding->offloading
+offloadin->offloading
 offloded->offloaded
 offred->offered
 offsence->offence
@@ -37766,6 +38669,7 @@ offseted->offsetted
 offseting->offsetting
 offsetp->offset
 offsett->offset
+offsettin->offsetting
 offstets->offsets
 offten->often
 oficial->official
@@ -37794,6 +38698,7 @@ oger->ogre
 ogerish->ogreish
 ogers->ogres
 oging->going, ogling,
+oglin->ogling
 oher->other, her,
 oherwise->otherwise
 ohter->other
@@ -37850,6 +38755,7 @@ omision->omission
 omited->omitted
 omiting->omitting
 omitt->omit
+omittin->omitting
 omlet->omelet
 omlets->omelets
 omlette->omelette
@@ -37890,6 +38796,7 @@ onedimenionsal->one-dimensional
 oneliners->one-liners
 oneyway->oneway
 ongly->only
+ongoin->ongoing
 onl->only
 onlie->online, only,
 onliene->online
@@ -38265,6 +39172,7 @@ opportunites->opportunities
 opportunties->opportunities
 opportunty->opportunity
 opportuny->opportunity
+opposin->opposing
 opposit->opposite
 oppositition->opposition
 opposits->opposites
@@ -38280,6 +39188,7 @@ opproximation->approximation
 opproximations->approximations
 opps->oops
 oppsofite->opposite
+oppugnin->oppugning
 oppurtunities->opportunities
 oppurtunity->opportunity
 oprand->operand
@@ -38350,6 +39259,7 @@ optimiced->optimized, optimised,
 optimier->optimizer, optimiser,
 optimimum->optimum
 optimisim->optimism
+optimisin->optimising
 optimisitc->optimistic
 optimisitic->optimistic
 optimissm->optimism
@@ -38365,6 +39275,7 @@ optimizier->optimizer
 optimiziers->optimizers
 optimizies->optimizes
 optimiziing->optimizing
+optimizin->optimizing
 optimiztion->optimization
 optimiztions->optimizations
 optimsitic->optimistic
@@ -38463,8 +39374,10 @@ orcestrated->orchestrated
 orcestrates->orchestrates
 orcestrating->orchestrating
 orcestrator->orchestrator
+orchestratin->orchestrating
 orded->ordered
 orderd->ordered
+orderin->ordering
 ordert->ordered
 orderves->hors d'oeuvre
 ording->ordering
@@ -38479,10 +39392,12 @@ orgamise->organise
 organim->organism
 organisaion->organisation
 organisaions->organisations
+organisin->organising
 organistion->organisation
 organistions->organisations
 organizaion->organization
 organizaions->organizations
+organizin->organizing
 organiztion->organization
 organiztions->organizations
 organsiation->organisation
@@ -38575,6 +39490,7 @@ origiginally->originally
 origiginals->originals
 originall->original, originally,
 originaly->originally
+originatin->originating
 originial->original
 originially->originally
 originiated->originated
@@ -38629,6 +39545,7 @@ oscilating->oscillating
 oscilator->oscillator
 oscillater->oscillator, oscillated, oscillates, oscillate,
 oscillaters->oscillators, oscillates,
+oscillatin->oscillating
 oscilliscope->oscilloscope
 oscilliscopes->oscilloscopes
 osffset->offset
@@ -38795,10 +39712,14 @@ oustanding->outstanding
 oustide->outside
 outbut->output
 outbuts->outputs
+outdoin->outdoing
 outgoign->outgoing
+outgoin->outgoing
 outher->other, outer,
 outherwise->otherwise
+outin->outing
 outisde->outside
+outlinin->outlining
 outllook->outlook
 outloud->out loud
 outoign->outgoing
@@ -38812,6 +39733,7 @@ outperfomeing->outperforming
 outperfoming->outperforming
 outperfomr->outperform
 outperfomring->outperforming
+outperformin->outperforming
 outpout->output
 outpouts->outputs
 outpu->output
@@ -38821,9 +39743,11 @@ outpust->output, outputs,
 outpusts->outputs
 outputed->outputted
 outputing->outputting
+outputtin->outputting
 outrside->outside, other side,
 outselves->ourselves
 outsid->outside
+outstandin->outstanding
 outter->outer
 outtermost->outermost
 outupt->output
@@ -38850,6 +39774,7 @@ oveloading->overloading
 oveloads->overloads
 over-engeneer->over-engineer
 over-engeneering->over-engineering
+over-engineerin->over-engineering
 overaall->overall
 overal->overall
 overcompansate->overcompensate
@@ -38858,9 +39783,12 @@ overcompansates->overcompensates
 overcompansating->overcompensating
 overcompansation->overcompensation
 overcompansations->overcompensations
+overcompensatin->overcompensating
 overengeneer->overengineer
 overengeneering->overengineering
+overengineerin->overengineering
 overfl->overflow
+overflowin->overflowing
 overflw->overflow
 overfow->overflow
 overfowed->overflowed
@@ -38877,6 +39805,7 @@ overiding->overriding
 overlaped->overlapped
 overlaping->overlapping
 overlapp->overlap
+overlappin->overlapping
 overlayed->overlaid
 overlflow->overflow
 overlflowed->overflowed
@@ -38888,6 +39817,7 @@ overlfowing->overflowing
 overlfows->overflows
 overloade->overload
 overloades->overloads, overloaded,
+overloadin->overloading
 overlodaded->overloaded
 overloded->overloaded
 overlodes->overloads
@@ -38910,6 +39840,7 @@ overrided->overrode, overridden,
 overriden->overridden
 overrident->overridden
 overridiing->overriding
+overridin->overriding
 overrids->overrides
 overrie->override, ovary,
 overries->overrides, ovaries,
@@ -38930,6 +39861,7 @@ oversubscibe->oversubscribe
 oversubscibed->oversubscribed
 oversubscirbe->oversubscribe
 oversubscirbed->oversubscribed
+oversubscribin->oversubscribing
 overthere->over there
 overun->overrun
 overvise->otherwise
@@ -38941,6 +39873,7 @@ overvrites->overwrites
 overwelm->overwhelm
 overwelming->overwhelming
 overwheliming->overwhelming
+overwhelmin->overwhelming
 overwiew->overview
 overwirte->overwrite
 overwirting->overwriting
@@ -38958,6 +39891,7 @@ overwriding->overwriting, overriding,
 overwriteable->overwritable
 overwrited->overwritten, overwrote,
 overwriten->overwritten
+overwritin->overwriting
 overwritren->overwritten
 overwritte->overwrite
 overwrittes->overwrites
@@ -39022,6 +39956,7 @@ ownder->owner
 ownerhsip->ownership
 ownersip->ownership
 ownes->owns, ones,
+ownin->owning
 ownload->download, own load,
 ownloaded->downloaded, own loaded,
 ownloader->downloader, own loader,
@@ -39074,6 +40009,8 @@ pachooly->patchouli
 pacht->patch
 pachtches->patches
 pachtes->patches
+pacifyin->pacifying
+pacin->pacing
 pacjage->package
 pacjaged->packaged
 pacjages->packages
@@ -39098,6 +40035,7 @@ packaegs->packages
 packaes->packages
 packag->package
 packagd->packaged
+packagin->packaging
 packags->packages
 packaing->packaging
 packats->packets
@@ -39120,6 +40058,7 @@ packging->packaging, packing,
 packgs->packages
 packhage->package
 packhages->packages
+packin->packing
 packkage->package
 packkaged->packaged
 packkages->packages
@@ -39138,6 +40077,7 @@ paculier->peculiar
 paculierly->peculiarly
 padam->param
 padd->pad, padded,
+paddin->padding
 padds->pads
 pading->padding
 paermission->permission
@@ -39226,6 +40166,7 @@ pamflet->pamphlet
 pamplet->pamphlet
 paniced->panicked
 panicing->panicking
+panickin->panicking
 pannel->panel
 pannels->panels
 pantomine->pantomime
@@ -39298,6 +40239,8 @@ paralleize->parallelize
 paralleized->parallelized
 paralleizes->parallelizes
 paralleizing->parallelizing
+parallelisin->parallelising
+parallelizin->parallelizing
 parallell->parallel
 parallellisation->parallelisation
 parallellise->parallelise
@@ -39379,6 +40322,8 @@ parameteres->parameters
 parameteric->parametric
 parameterical->parametrical
 parameterically->parametrically
+parameterisin->parameterising
+parameterizin->parameterizing
 parameterts->parameters
 parametes->parameters
 parametesr->parameters
@@ -39514,6 +40459,7 @@ paricle->particle
 paricles->particles
 paricular->particular
 paricularly->particularly
+parin->paring
 parisitic->parasitic
 parital->partial, parietal,
 paritally->partially
@@ -39678,6 +40624,7 @@ particaular->particular
 particaularly->particularly
 particaulr->particular
 particaulrly->particularly
+participatin->participating
 particlar->particular
 particlarly->particularly
 particlars->particulars
@@ -39725,6 +40672,7 @@ partiticular->particular
 partitinioning->partitioning
 partitioing->partitioning
 partitiones->partitions
+partitionin->partitioning
 partitionned->partitioned
 partitionning->partitioning
 partitionns->partitions
@@ -39741,6 +40689,7 @@ partiula->particular
 partiular->particular
 partiularly->particularly
 partiulars->particulars
+partnerin->partnering
 parttion->partition
 parttioned->partitioned
 parttioning->partitioning
@@ -39817,6 +40766,9 @@ passwrods->passwords
 pasteing->pasting
 pasteries->pastries
 pastery->pastry
+pasteurisin->pasteurising
+pasteurizin->pasteurizing
+pastin->pasting
 pasttime->pastime
 pastural->pastoral
 pasturisation->pasteurisation
@@ -39833,6 +40785,7 @@ pasword->password
 paswords->passwords
 patameter->parameter
 patameters->parameters
+patchin->patching
 patchs->patches, paths,
 patcket->packet
 patckets->packets
@@ -39853,6 +40806,7 @@ pathces->patches
 pathcing->patching
 pathes->paths, patches,
 pathign->pathing
+pathin->pathing
 pathnme->pathname
 patholgoical->pathological
 pathwya->pathway
@@ -39891,6 +40845,7 @@ patttern->pattern
 pattterns->patterns
 pavillion->pavilion
 pavillions->pavilions
+pavin->paving
 payement->payment, pavement,
 payements->payments, pavements,
 paínt->paint
@@ -39986,11 +40941,13 @@ peirods->periods
 Peloponnes->Peloponnese, Peloponnesus,
 penalities->penalties
 penality->penalty
+penalizin->penalizing
 penatenturies->penitentiaries
 penatentury->penitentiary
 penatly->penalty
 pendantic->pedantic
 pendig->pending
+pendin->pending
 pendning->pending
 penerator->penetrator
 pengwen->penguin
@@ -40187,6 +41144,7 @@ performence->performance
 performences->performances
 performent->performant
 performes->performed, performs,
+performin->performing
 performnace->performance
 performnaces->performances
 perfors->performs
@@ -40294,6 +41252,8 @@ permuation->permutation
 permuations->permutations
 permutaion->permutation
 permutaions->permutations
+permutatin->permutating
+permutin->permuting
 permution->permutation
 permutions->permutations
 peroendicular->perpendicular
@@ -40379,6 +41339,7 @@ perservering->persevering
 perserves->preserves
 perserving->preserving
 perseverence->perseverance
+perseverin->persevering
 persew->pursue
 persewed->pursued
 persewer->pursuer
@@ -40401,6 +41362,7 @@ persistant->persistent
 persistantly->persistently
 persisten->persistent
 persistented->persisted
+persistin->persisting
 persited->persisted
 persitence->persistence
 persitent->persistent
@@ -40427,6 +41389,7 @@ perssious->precious
 perssiously->preciously
 perssiuos->precious
 perssiuosly->preciously
+persuadin->persuading
 persuded->persuaded
 persue->pursue
 persued->pursued
@@ -40434,6 +41397,7 @@ persuing->pursuing
 persuit->pursuit
 persuits->pursuits
 persumably->presumably
+pertainin->pertaining
 perticipate->participate
 perticipated->participated
 perticipates->participates
@@ -40461,18 +41425,21 @@ pertubing->perturbing
 perturbate->perturb
 perturbates->perturbs
 perturbe->perturb, perturbed,
+perturbin->perturbing
 pervent->prevent, percent, pervert, fervent,
 pervented->prevented, perverted,
 perventing->preventing, perverting,
 pervention->prevention
 perventions->preventions
 pervents->prevents, perverts,
+pervertin->perverting
 perview->preview, purview,
 perviews->previews, purviews,
 pervious->previous
 perviously->previously
 pessiary->pessary
 petetion->petition
+petitionin->petitioning
 pevent->prevent
 pevented->prevented
 peventing->preventing
@@ -40503,6 +41470,7 @@ pharmasuticaly->pharmaceutical
 pharoah->pharaoh
 pharoh->pharaoh
 phasepsace->phasespace
+phasin->phasing
 phasis->phases
 phenomenom->phenomenon
 phenomenonal->phenomenal
@@ -40587,6 +41555,7 @@ pich->pitch, pick, pinch,
 piched->pitched, picked, pinched,
 piches->pitches, pinches,
 piching->pitching, picking, pinching,
+pickin->picking
 picknic->picnic
 pickniced->picnicked
 picknicer->picnicker
@@ -40602,6 +41571,7 @@ picniced->picnicked
 picnicer->picnicker
 picnicing->picnicking
 picnick->picnic
+picnickin->picnicking
 picnicks->picnics
 picoseond->picosecond
 picoseonds->picoseconds
@@ -40615,6 +41585,7 @@ pidgeon->pigeon, pidgin,
 pidgeons->pigeons, pidgins,
 pieceweise->piecewise, piece wise,
 piecewiese->piecewise, piece wise,
+piecin->piecing
 piecwise->piecewise, piece wise,
 pigen->pigeon, pigpen,
 pigens->pigeons, pigpens,
@@ -40640,6 +41611,7 @@ pimxap->pixmap
 pimxaps->pixmaps
 pinapple->pineapple
 pincher->pinscher
+pinchin->pinching
 pinnaple->pineapple
 pinockle->pinochle
 pinoneered->pioneered
@@ -40655,6 +41627,7 @@ pipeines->pipelines
 pipelien->pipeline
 pipeliens->pipelines
 pipelin->pipeline
+pipelinin->pipelining
 pipelinining->pipelining
 pipelins->pipelines
 pipepline->pipeline
@@ -40668,11 +41641,13 @@ piplelines->pipelines
 pipline->pipeline
 piplines->pipelines
 pirric->Pyrrhic
+pitchin->pitching
 pithon->python, piton,
 pitmap->pixmap, bitmap,
 pitty->pity
 pivacy->privacy, piracy,
 pivate->private, pirate,
+pivotin->pivoting
 pivott->pivot
 pivotting->pivoting
 pixelx->pixels, pixel,
@@ -40696,6 +41671,7 @@ placemet->placement, placemat, place mat,
 placemets->placements, placemats, place mats,
 placholder->placeholder
 placholders->placeholders
+placin->placing
 placmenet->placement
 placmenets->placements
 placment->placement
@@ -40708,6 +41684,7 @@ plaftorm->platform
 plaftorms->platforms
 plagarism->plagiarism
 plagerism->plagiarism
+plagiarizin->plagiarizing
 plalform->platform
 plalforms->platforms
 planation->plantation
@@ -40766,6 +41743,7 @@ playgroud->playground
 playgrouds->playgrounds
 playgroun->playground
 playgrouns->playgrounds, playground,
+playin->playing
 playist->playlist
 playists->playlists
 playright->playwright
@@ -40788,6 +41766,7 @@ pleaes->please
 pleasd->pleased
 pleasent->pleasant
 pleasently->pleasantly
+pleasin->pleasing
 pleass->pleases, bless,
 plebicite->plebiscite
 plecing->placing
@@ -40802,6 +41781,7 @@ pliars->pliers
 pllatforms->platforms
 ploted->plotted
 ploting->plotting
+plottin->plotting
 ploygon->polygon
 ploygonal->polygonal
 ploygons->polygons
@@ -40860,6 +41840,7 @@ pointes->points
 pointetr->pointer
 pointetrs->pointers
 pointeur->pointer
+pointin->pointing
 pointseta->poinsettia
 pointss->points
 pointzer->pointer
@@ -40870,6 +41851,7 @@ poisitioned->positioned
 poisitioning->positioning
 poisitionning->positioning
 poisitions->positions
+poisonin->poisoning
 poistion->position
 poistioned->positioned
 poistioning->positioning
@@ -40920,6 +41902,7 @@ poket->pocket
 polarisaiton->polarisation
 polariy->polarity
 polarizaiton->polarization
+polarizin->polarizing
 polcies->policies
 polciy->policy
 polcy->policy
@@ -40941,8 +41924,10 @@ polinomials->polynomials
 politican->politician
 politicans->politicians
 politicing->politicking
+politickin->politicking
 pollenate->pollinate
 polltry->poultry
+pollutin->polluting
 polocies->policies
 polocy->policy
 polocys->policies
@@ -41026,6 +42011,7 @@ pooint->point
 poointed->pointed
 poointer->pointer
 pooints->points
+poopin->pooping
 poossibilities->possibilities
 poossibility->possibility
 poossible->possible
@@ -41052,6 +42038,7 @@ poposing->proposing, opposing,
 popoulation->population
 popoulations->populations
 popoup->popup
+poppin->popping
 poppup->popup
 popularaty->popularity
 populare->popular
@@ -41131,9 +42118,11 @@ portaits->portraits
 portayed->portrayed
 portected->protected
 portguese->Portuguese
+portionin->portioning
 portioon->portion
 portrail->portrayal, portrait,
 portraing->portraying
+portrayin->portraying
 portugese->Portuguese
 portuguease->Portuguese
 portugues->Portuguese
@@ -41172,6 +42161,7 @@ posifions->positions
 posiitive->positive
 posiitives->positives
 posiitivity->positivity
+posin->posing
 posion->poison, Psion, position,
 posioned->positioned, poisoned,
 posioning->poisoning, positioning,
@@ -41185,6 +42175,7 @@ posistioned->positioned
 posistioning->positioning
 posistions->positions
 positiong->positioning, position,
+positionin->positioning
 positionn->position
 positionned->positioned
 positionnes->positions
@@ -41229,6 +42220,7 @@ possesing->possessing
 possesion->possession
 possesive->possessive
 possessess->possesses
+possessin->possessing
 possiabilities->possibilities
 possiability->possibility
 possiable->possible
@@ -41294,6 +42286,7 @@ posssibly->possibly
 post-morten->post-mortem
 post-proces->post-process
 post-procesing->post-processing
+post-processin->post-processing
 postcondtion->postcondition
 postcondtions->postconditions
 Postdam->Potsdam
@@ -41334,8 +42327,10 @@ postives->positives
 postmage->postimage
 postphoned->postponed
 postpocessing->postprocessing
+postponin->postponing
 postponinig->postponing
 postprocesing->postprocessing
+postprocessin->postprocessing
 postscritp->postscript
 postulat->postulate
 postuminus->posthumous
@@ -41458,6 +42453,7 @@ pre-pend->prepend
 pre-pended->prepended
 pre-pending->prepending
 pre-pends->prepends
+pre-populatin->pre-populating
 pre-poulate->pre-populate
 pre-poulated->pre-populated
 pre-poulates->pre-populates
@@ -41465,8 +42461,10 @@ pre-poulating->pre-populating
 pre-pre-realease->pre-pre-release
 pre-proces->pre-process
 pre-procesing->pre-processing
+pre-processin->pre-processing
 pre-realease->pre-release
 pre-registeres->pre-registers
+preallocatin->preallocating
 preallocationg->preallocating, preallocation,
 prealocate->preallocate
 prealocated->preallocated
@@ -41507,6 +42505,7 @@ precding->preceding
 preced->precede
 precedencs->precedence
 precedessor->predecessor
+precedin->preceding
 preceds->precedes
 precedural->procedural
 precedurally->procedurally
@@ -41589,6 +42588,7 @@ precussion->percussion
 precussions->percussions
 predecesor->predecessor
 predecesors->predecessors
+predeclarin->predeclaring
 predeclarnig->predeclaring
 prededence->precedence
 predefiend->predefined
@@ -41620,11 +42620,14 @@ predicitve->predictive
 predictibility->predictability
 predictible->predictable
 predictibly->predictably
+predictin->predicting
 predifined->predefined
 predomiantly->predominately
 preeceding->preceding
 preemptable->preemptible
 preesnt->present
+preexistin->preexisting
+prefacin->prefacing
 prefectches->prefetches
 prefecth->prefetch
 prefectly->perfectly
@@ -41659,6 +42662,7 @@ preferrable->preferable
 preferrably->preferably
 preferrence->preference
 preferrences->preferences
+preferrin->preferring
 preferrred->preferred
 prefetchs->prefetches
 prefex->prefix
@@ -41685,10 +42689,12 @@ preficient->proficient
 preficiently->proficiently
 preficientsy->proficiency
 preficing->prefixing, prefacing,
+prefilterin->prefiltering
 prefitler->prefilter
 prefitlered->prefiltered
 prefitlering->prefiltering
 prefitlers->prefilters
+prefixin->prefixing
 preformance->performance
 preformances->performances
 preformant->performant
@@ -41719,6 +42725,7 @@ prejudgudice->prejudice
 prejudgudiced->prejudiced
 prejudgudices->prejudices
 prejudgudicing->prejudicing
+prejudicin->prejudicing
 preliferation->proliferation
 prelimitary->preliminary
 premeire->premiere
@@ -41747,6 +42754,7 @@ prepairs->prepares
 prepand->prepend
 preparetion->preparation
 preparetions->preparations
+preparin->preparing
 prepartion->preparation
 prepartions->preparations
 prepate->prepare
@@ -41754,6 +42762,7 @@ prepated->prepared
 prepates->prepares
 prepatory->preparatory
 prependet->prepended
+prependin->prepending
 prepented->prepended
 preperation->preparation
 preperations->preparations
@@ -41778,11 +42787,13 @@ preprended->prepended
 prepresent->represent
 prepresented->represented
 prepresents->represents
+preprintin->preprinting
 preproces->preprocess
 preprocesing->preprocessing
 preprocesor->preprocessor
 preprocesser->preprocessor
 preprocessers->preprocessors
+preprocessin->preprocessing
 preprocesssing->preprocessing
 prequisite->prerequisite
 prequisites->prerequisites
@@ -41790,6 +42801,7 @@ prerelase->prerelease
 prerelased->prereleased
 prerelases->prereleases
 prerelasing->prereleasing
+prereleasin->prereleasing
 prerequesite->prerequisite
 prerequesites->prerequisites
 prerequisit->prerequisite
@@ -41833,9 +42845,11 @@ presentaion->presentation
 presentaional->presentational
 presentaions->presentations
 presentated->presented
+presentin->presenting
 presernt->present
 preserrved->preserved
 preserv->preserve
+preservin->preserving
 presetation->presentation
 preseve->preserve
 preseved->preserved
@@ -41852,6 +42866,7 @@ presicely->precisely
 presicion->precision
 presidenital->presidential
 presidental->presidential
+presidin->presiding
 presing->pressing
 presist->persist
 presistable->persistable
@@ -41895,6 +42910,7 @@ pressenter->press enter, presenter,
 pressenters->presenters
 pressenting->presenting
 pressents->presents
+pressin->pressing
 pressious->precious
 pressiously->preciously
 pressiuos->precious
@@ -41916,6 +42932,7 @@ pressume->presume, pressure,
 pressumed->presumed, pressured,
 pressumes->presumes, pressures,
 pressuming->presuming, pressuring,
+pressurin->pressuring
 prestigeous->prestigious
 prestigous->prestigious
 presuambly->presumably
@@ -41925,6 +42942,7 @@ presumeably->presumably
 presumebly->presumably
 presumely->presumably
 presumibly->presumably
+presumin->presuming
 presure->pressure, presume,
 presured->pressured, presumed,
 presures->pressures, presumes,
@@ -41949,6 +42967,7 @@ prevelant->prevalent
 preven->prevent
 prevend->prevent
 prevente->prevented, prevent,
+preventin->preventing
 preverse->preserve, perverse,
 preversed->preserved
 preverses->preserves
@@ -42071,6 +43090,7 @@ priniciple->principle
 priniciples->principles
 prining->printing
 printes->printers
+printin->printing
 printting->printing
 priod->period, prior, prod, pried,
 priodic->periodic
@@ -42087,9 +43107,11 @@ priorised->prioritised
 priorises->prioritises
 priorising->prioritising
 priorites->priorities
+prioritisin->prioritising
 prioritities->priorities
 prioritity->priority
 prioritiy->priority
+prioritizin->prioritizing
 prioritsation->prioritisation
 prioritsations->prioritisations
 prioritse->prioritise
@@ -42305,6 +43327,7 @@ procedings->proceedings
 procedre->procedure
 procedres->procedures
 proceedes->proceeds
+proceedin->proceeding
 proceedure->procedure
 proceedures->procedures
 proceeed->proceed
@@ -42342,6 +43365,7 @@ processess->processes
 processessing->processing
 processibg->processing
 processig->processing
+processin->processing
 processinf->processing
 processore->processor
 processores->processors
@@ -42358,6 +43382,7 @@ procide->provide
 procided->provided
 procides->provides
 proclaimation->proclamation
+proclaimin->proclaiming
 proclamed->proclaimed
 proclaming->proclaiming
 proclomation->proclamation
@@ -42366,6 +43391,7 @@ procoessed->processed
 procoessing->processing
 procotol->protocol
 procotols->protocols
+procrastinatin->procrastinating
 procrastrinate->procrastinate
 procrastrinated->procrastinated
 procrastrinates->procrastinates
@@ -42390,6 +43416,7 @@ procudes->produces, procures,
 procuding->producing, procuring,
 procudure->procedure
 procudures->procedures
+procurin->procuring
 prodce->produce
 prodced->produced, proceed,
 prodceding->proceeding
@@ -42421,6 +43448,7 @@ prodiving->providing
 producable->producible
 producables->producible
 produceds->produces, produced,
+producin->producing
 produciton->production
 producitons->productions
 producted->produced
@@ -42504,6 +43532,7 @@ profied->profiled
 profier->profiler
 profies->profiles
 profilic->prolific
+profilin->profiling
 profirle->profile
 profirled->profiled
 profirler->profiler
@@ -42604,6 +43633,7 @@ programmend->programmed
 programmetically->programmatically
 programmical->programmatical
 programmign->programming
+programmin->programming
 programmming->programming
 programms->programs
 progreess->progress
@@ -42615,6 +43645,7 @@ progresion->progression
 progresions->progressions
 progresive->progressive
 progresively->progressively
+progressin->progressing
 progresss->progress
 progrewss->progress
 progrmae->program
@@ -42623,6 +43654,7 @@ progroms->pogroms, programs,
 progrss->progress
 prohabition->prohibition
 prohibative->prohibitive
+prohibitin->prohibiting
 prohibitted->prohibited
 prohibitting->prohibiting
 prohibt->prohibit
@@ -42644,6 +43676,7 @@ projecs->projects
 projectd->projected
 projecter->projector, projected, project,
 projecters->projectors, projects,
+projectin->projecting
 projectio->projection
 projecttion->projection
 projet->project
@@ -42668,6 +43701,7 @@ prolem->problem
 prolematic->problematic
 prolems->problems
 prolicks->prolix
+proliferatin->proliferating
 prologomena->prolegomena
 promatory->promontory
 promethues->Prometheus
@@ -42677,6 +43711,7 @@ prominantly->prominently
 prominately->prominently, predominately,
 promis->promise
 promiscous->promiscuous
+promisin->promising
 promiss->promise
 promisse->promise, promises, promised,
 promissed->promised
@@ -42685,9 +43720,11 @@ promissing->promising
 promixity->proximity
 prommpt->prompt
 prommpts->prompts
+promotin->promoting
 promotted->promoted
 promprted->prompted
 promps->prompts
+promptin->prompting
 promt->prompt
 promted->prompted, promoted,
 promter->prompter, promoter,
@@ -42752,6 +43789,7 @@ propable->probable
 propably->probably
 propagater->propagator, propagated, propagates, propagate,
 propagaters->propagators, propagates,
+propagatin->propagating
 propage->propagate, propane,
 propaged->propagated
 propages->propagates
@@ -42859,7 +43897,9 @@ proporpotional->proportional
 proportianal->proportional
 proporties->properties
 proportinal->proportional
+proportionin->proportioning
 proporty->property
+proposin->proposing
 propostion->proposition
 propotion->proportion, promotion,
 propotional->proportional, promotional,
@@ -42904,12 +43944,14 @@ propvider->provider
 prority->priority
 prorotype->prototype
 proseletyzing->proselytizing
+proselytizin->proselytizing
 prosess->process, profess, prowess, possess,
 prosessed->processed, professed, possessed,
 prosesses->processes, professes, possesses,
 prosessing->processing, professing, possessing,
 prosessor->processor, professor,
 prosessors->processors, professors,
+prospectin->prospecting
 prosseses->processes, possesses,
 protability->portability, probability,
 protable->portable
@@ -42922,6 +43964,7 @@ protcools->protocols
 protcted->protected
 protecion->protection
 protecte->protected, protect,
+protectin->protecting
 protectiv->protective
 protectoin->protection
 protedcted->protected
@@ -42952,6 +43995,7 @@ prototye->prototype
 prototyed->prototyped
 prototyes->prototypes
 prototying->prototyping
+prototypin->prototyping
 protoype->prototype
 protoyped->prototyped
 protoypes->prototypes
@@ -42993,6 +44037,7 @@ provid->provide, prove, proved, proves,
 provideres->providers
 providewd->provided
 providfers->providers
+providin->providing
 providor->provider, providore,
 providors->providers, providores,
 provids->provides, proves,
@@ -43011,10 +44056,12 @@ provies->provides, proves,
 provilege->privilege
 provileged->privileged
 provileges->privileges
+provin->proving
 provinicial->provincial
 provisioing->provisioning
 provisiong->provisioning
 provisionging->provisioning
+provisionin->provisioning
 provisiosn->provision
 provison->provision
 provisonal->provisional
@@ -43145,6 +44192,7 @@ publicher->publisher
 publichers->publishers
 publiches->publishes
 publiching->publishing
+publicizin->publicizing
 publick->public
 publihsed->published
 publihser->publisher
@@ -43161,6 +44209,7 @@ publishd->published
 publisheed->published
 publisherr->publisher
 publishher->publisher
+publishin->publishing
 publishor->publisher
 publishr->publisher
 publishre->publisher
@@ -43247,10 +44296,12 @@ purcahse->purchase
 purcahsed->purchased
 purcahses->purchases
 purcahsing->purchasing
+purchasin->purchasing
 purgable->purgeable
 purgest->purges
 puritannical->puritanical
 purposedly->purposely
+purposin->purposing
 purpotedly->purportedly
 purpse->purpose, purse, purple,
 purpses->purposes, purses,
@@ -43259,6 +44310,7 @@ purpuses->purposes
 pursuade->persuade
 pursuaded->persuaded
 pursuades->persuades
+pursuin->pursuing
 purtain->pertain
 purtained->pertained
 purtaining->pertaining
@@ -43269,6 +44321,7 @@ puting->putting
 putpose->purpose
 putposed->purposed
 putposes->purposes
+puttin->putting
 pwoer->power
 pxoxied->proxied
 pxoxies->proxies
@@ -43368,6 +44421,7 @@ quadroople->quadruple
 quadroopled->quadrupled
 quadrooples->quadruples
 quadroopling->quadrupling
+quadruplin->quadrupling
 quafeur->coiffure
 quafeured->coiffured
 quailified->qualified
@@ -43376,6 +44430,7 @@ qualfy->qualify
 qualifer->qualifier
 qualifiy->qualify
 qualifiying->qualifying
+qualifyin->qualifying
 qualit->quality
 qualites->qualities
 qualitification->qualification
@@ -43406,6 +44461,7 @@ quantaties->quantities
 quantaty->quantity
 quantifiy->quantify
 quantifiying->quantifying
+quantifyin->quantifying
 quantit->quantity, quantic,
 quantites->quantities
 quantitites->quantities
@@ -43449,6 +44505,7 @@ querstionnaires->questionnaires
 querstions->questions
 quersts->quests
 queryies->queries
+queryin->querying
 queryinterace->queryinterface
 querys->queries
 quesant->croissant
@@ -43493,6 +44550,7 @@ questionaire->questionnaire
 questionaires->questionnaires
 questionare->questionnaire
 questionares->questionnaires
+questionin->questioning
 questionnair->questionnaire
 questionnairs->questionnaires
 questios->questions
@@ -43510,10 +44568,12 @@ questonnaire->questionnaire
 questonnaires->questionnaires
 questons->questions
 queu->queue
+queuein->queueing
 queueu->queue
 queueud->queued
 queueuing->queuing, queueing,
 queueus->queues
+queuin->queuing
 queus->queues
 quew->queue
 quickier->quicker
@@ -43541,6 +44601,7 @@ quith->quit, with,
 quiting->quitting
 quitt->quit
 quitted->quit
+quittin->quitting
 quizes->quizzes
 quizs->quizzes
 quizzs->quizzes
@@ -43550,6 +44611,7 @@ quotaion->quotation
 quotaions->quotations
 quoteed->quoted
 quotent->quotient
+quotin->quoting
 quottes->quotes
 quried->queried
 quries->queries
@@ -43649,6 +44711,8 @@ randomally->randomly
 randome->random
 randomely->randomly
 randomeness->randomness
+randomisin->randomising
+randomizin->randomizing
 rangeo->range
 raoming->roaming
 raotat->rotate
@@ -43670,6 +44734,7 @@ raplacements->replacements
 raplaces->replaces
 raplacing->replacing
 rapore->rapport
+rappellin->rappelling
 rapresent->represent
 rapresentation->representation
 rapresented->represented
@@ -43692,26 +44757,33 @@ rasing->raising
 rasons->reasons
 raspbery->raspberry
 raspoberry->raspberry
+rasterizin->rasterizing
 ratatooee->ratatouille
 ratatoolee->ratatouille
 ratatui->ratatouille
 rathar->rather
 rathern->rather
+rationalizin->rationalizing
 rationnal->rational, rationale,
 rationnals->rationals, rationales,
+rattlin->rattling
 rcall->recall
 rceate->create
 rceating->creating
 rduce->reduce
+re-addin->re-adding
 re-attachement->re-attachment
 re-declare->redeclare
 re-declared->redeclared
 re-declares->redeclares
 re-declaring->redeclaring
 re-defiend->re-defined
+re-enablin->re-enabling
 re-engeneer->re-engineer
 re-engeneering->re-engineering
+re-engineerin->re-engineering
 re-evaulated->re-evaluated
+re-implementin->re-implementing
 re-impliment->re-implement
 re-implimenting->re-implementing
 re-negatiotiable->re-negotiable
@@ -43837,6 +44909,7 @@ re-negothiation->re-negotiation
 re-negothiations->re-negotiations
 re-negothiator->re-negotiator
 re-negothiators->re-negotiators
+re-negotiatin->re-negotiating
 re-negotible->re-negotiable
 re-negoticable->re-negotiable
 re-negoticate->re-negotiate
@@ -43921,7 +44994,9 @@ re-negoziator->re-negotiator
 re-negoziators->re-negotiators
 re-realease->re-release
 re-spawining->re-spawning, respawning,
+re-spawnin->re-spawning
 re-synching->re-syncing
+re-syncin->re-syncing
 re-uplad->re-upload
 re-upladad->re-upload, re-uploaded,
 re-upladed->re-uploaded
@@ -43936,6 +45011,7 @@ re-uplaoder->re-uploader
 re-uplaoders->re-uploaders
 re-uplaoding->re-uploading
 re-uplaods->re-uploads
+re-uploadin->re-uploading
 re-uplod->re-upload
 re-uplodad->re-upload, re-uploaded,
 re-uploded->re-uploaded
@@ -43959,6 +45035,7 @@ reacently->recently
 reacheable->reachable
 reacher->richer, reader,
 reachers->readers
+reachin->reaching
 reachs->reaches
 reacing->reaching
 reacll->recall
@@ -43966,6 +45043,8 @@ reacord->record
 reacorded->recorded
 reacording->recording
 reacords->records
+reacquirin->reacquiring
+reactin->reacting
 reactquire->reacquire
 readabilty->readability
 readanle->readable
@@ -43973,6 +45052,7 @@ readapted->re-adapted
 readbility->readability
 readble->readable
 readby->read, read by,
+readdressin->readdressing
 readdrss->readdress
 readdrssed->readdressed
 readdrsses->readdresses
@@ -43985,6 +45065,7 @@ readibility->readability
 readible->readable
 readig->reading
 readigs->readings
+readin->reading
 readius->radius
 readl-only->read-only
 readly->readily, ready,
@@ -44021,9 +45102,11 @@ realeasing->releasing
 realiability->reliability
 realiable->reliable
 realiably->reliably
+realisin->realising
 realitime->realtime
 realitvely->relatively
 realiy->really
+realizin->realizing
 realiztion->realization
 realiztions->realizations
 reall->real, really, recall,
@@ -44045,6 +45128,7 @@ reallocaition->reallocation
 reallocaitions->reallocations
 reallocaiton->reallocation
 reallocaitons->reallocations
+reallocatin->reallocating
 realsitic->realistic
 realte->relate
 realted->related
@@ -44084,6 +45168,7 @@ reapeater->repeater
 reapeating->repeating
 reapeats->repeats
 reappeares->reappears
+reappearin->reappearing
 reapper->reappear
 reappered->reappeared
 reappering->reappearing
@@ -44118,6 +45203,7 @@ rearrangd->rearranged
 rearrangde->rearranged
 rearrangent->rearrangement
 rearrangents->rearrangements
+rearrangin->rearranging
 rearrangmeent->rearrangement
 rearrangmeents->rearrangements
 rearrangmenet->rearrangement
@@ -44151,8 +45237,10 @@ reasoable->reasonable
 reasonabily->reasonably
 reasonble->reasonable
 reasonbly->reasonably
+reasonin->reasoning
 reasonnable->reasonable
 reasonnably->reasonably
+reassignin->reassigning
 reassinging->reassigning
 reassocation->reassociation
 reassocations->reassociations
@@ -44179,6 +45267,7 @@ rebuiding->rebuilding
 rebuids->rebuilds
 rebuil->rebuild, rebuilt,
 rebuilded->rebuilt
+rebuildin->rebuilding
 rebuiling->rebuilding
 rebuilld->rebuild
 rebuillding->rebuilding
@@ -44210,6 +45299,7 @@ recalcuates->recalculates
 recalcuations->recalculations
 recalculaion->recalculation
 recalculatble->re-calculable
+recalculatin->recalculating
 recalcution->recalculation
 recalulate->recalculate
 recalulation->recalculation
@@ -44279,6 +45369,7 @@ reccursion->recursion
 reccursions->recursions
 reccursive->recursive
 reccursively->recursively
+recedin->receding
 receeded->receded
 receeding->receding
 receet->receipt
@@ -44300,6 +45391,7 @@ receivd->received
 receivedfrom->received from
 receiveing->receiving
 receiviing->receiving
+receivin->receiving
 receivs->receives
 recend->rescind
 recendable->rescindable
@@ -44321,6 +45413,7 @@ recepit->recipe, receipt,
 receptical->receptacle
 recepticals->receptacles
 recepy->recipe, recopy,
+recessin->recessing
 receve->receive
 receved->received
 recever->receiver, recover,
@@ -44335,6 +45428,7 @@ receviing->receiving
 receving->receiving
 rechable->reachable
 rechargable->rechargeable
+rechargin->recharging
 recheability->reachability
 reched->reached
 rechek->recheck
@@ -44376,6 +45470,7 @@ recject->reject
 recjected->rejected
 recjecting->rejecting
 recjects->rejects
+reckonin->reckoning
 reclaimation->reclamation
 recnt->recent, recant, rent,
 recntly->recently
@@ -44426,7 +45521,9 @@ recogniced->recognized, recognised,
 recognices->recognizes, recognises,
 recognicing->recognizing, recognising,
 recogninse->recognise
+recognisin->recognising
 recognizeable->recognizable
+recognizin->recognizing
 recognzied->recognized
 recomend->recommend
 recomendation->recommendation
@@ -44459,6 +45556,7 @@ recommeding->recommending
 recommeds->recommends
 recommenation->recommendation
 recommenations->recommendations
+recommendin->recommending
 recommened->recommended, recommend,
 recommeneded->recommended
 recommentation->recommendation
@@ -44494,6 +45592,7 @@ recompence->recompense
 recomplie->recompile, recomply,
 recomput->recompute
 recomputaion->recomputation
+recomputin->recomputing
 recompuute->recompute
 recompuuted->recomputed
 recompuutes->recomputes
@@ -44501,6 +45600,7 @@ recompuuting->recomputing
 reconaissance->reconnaissance
 reconasence->reconnaissance
 reconcilation->reconciliation
+reconcilin->reconciling
 recondifure->reconfigure
 reconecct->reconnect
 reconeccted->reconnected
@@ -44577,6 +45677,7 @@ reconncting->reconnecting
 reconnction->reconnection
 reconnctions->reconnections
 reconncts->reconnects
+reconnectin->reconnecting
 reconnet->reconnect
 reconneted->reconnected
 reconneting->reconnecting
@@ -44594,6 +45695,7 @@ reconstrcution->reconstruction
 reconstrcutions->reconstructions
 reconstructer->reconstructor, reconstruct,
 reconstructers->reconstructors, reconstructs,
+reconstructin->reconstructing
 reconstuct->reconstruct
 reconstucted->reconstructed
 reconstucting->reconstructing
@@ -44618,6 +45720,7 @@ recontructions->reconstructions
 recontructor->reconstructor
 recontructors->reconstructors
 recontructs->reconstructs
+recordin->recording
 recordproducer->record producer
 recordss->records
 recored->recorded
@@ -44636,6 +45739,7 @@ recquires->requires, reacquires,
 recquiring->requiring, reacquiring,
 recrational->recreational
 recreateation->recreation
+recreatin->recreating
 recrete->recreate
 recreted->recreated
 recretes->recreates
@@ -44650,6 +45754,7 @@ recrooter->recruiter
 recrooters->recruiters
 recrooting->recruiting
 recroots->recruits
+recruitin->recruiting
 recrusevly->recursively
 recrusion->recursion
 recrusions->recursions
@@ -44685,7 +45790,9 @@ recurrance->recurrence
 recurrances->recurrences
 recurrant->recurrent
 recurrantly->recurrently
+recurrin->recurring
 recursily->recursively
+recursin->recursing
 recursivelly->recursively
 recursivion->recursion
 recursivley->recursively
@@ -44698,6 +45805,7 @@ recurssion->recursion
 recurssions->recursions
 recurssive->recursive
 recurssively->recursively
+recusin->recusing
 recusion->recursion, reclusion,
 recusions->recursions, reclusions,
 recusive->recursive, reclusive,
@@ -44707,6 +45815,7 @@ recusrively->recursively
 recusrsive->recursive
 recustion->recursion
 recustions->recursions
+recyclin->recycling
 recyclying->recycling
 recylcing->recycling
 recyle->recycle
@@ -44719,8 +45828,11 @@ redandant->redundant
 redction->reduction, redaction,
 redeable->readable
 redeclaation->redeclaration
+redeclarin->redeclaring
+redeemin->redeeming
 redefiend->redefined
 redefiende->redefined
+redefinin->redefining
 redefiniton->redefinition
 redefinitons->redefinitions
 redefintion->redefinition
@@ -44729,6 +45841,7 @@ redemtion->redemption
 redemtions->redemptions
 redenderer->renderer
 redered->rendered
+redesignin->redesigning
 redesing->redesign
 redesinged->redesigned
 redesinging->redesigning
@@ -44758,6 +45871,7 @@ redistirbutes->redistributes
 redistirbuting->redistributing
 redistirbution->redistribution
 redistributeable->redistributable
+redistributin->redistributing
 redistrubute->redistribute
 redistrubuted->redistributed
 redistrubution->redistribution
@@ -44772,6 +45886,7 @@ rednering->rendering
 redners->renders, redness,
 redonly->readonly
 reduceable->reducible
+reducin->reducing
 redudancy->redundancy
 redudant->redundant
 redunancy->redundancy
@@ -44824,8 +45939,10 @@ reeturn->return
 reeturned->returned
 reeturning->returning
 reeturns->returns
+reevaluatin->reevaluating
 reevalute->reevaluate
 reevaulating->reevaluating
+refactorin->refactoring
 refactrion->refraction
 refactrive->refractive
 refartor->refactor, refractor,
@@ -44885,6 +46002,7 @@ referecned->referenced
 referecnes->references
 referecning->referencing
 refered->referred
+refereein->refereeing
 referefences->references
 referemce->reference
 referemces->references
@@ -44894,6 +46012,7 @@ referencable->referenceable
 referencd->referenced, reference,
 referencial->referential
 referencially->referentially
+referencin->referencing
 referencs->references
 referenct->referenced
 referene->reference
@@ -44951,6 +46070,7 @@ referrences->references
 referrencing->referencing
 referreres->referrers
 referres->refers
+referrin->referring
 referrred->referred
 referrrer->referrer
 referrrers->referrers
@@ -44986,19 +46106,25 @@ refferrers->referrers
 refferring->referring
 reffers->refers, reefers,
 refinemenet->refinement
+refinin->refining
 refinmenet->refinement
 refinment->refinement
+reflectin->reflecting
 reflet->reflect
 refleted->reflected
 refleting->reflecting
 refletion->reflection
 refletions->reflections
 reflets->reflects
+refocusin->refocusing
 refocuss->refocus
 reformated->reformatted
 reformating->reformatting
 reformattd->reformatted
+reformattin->reformatting
+reformin->reforming
 refractice->refractive
+refractorin->refractoring
 refreh->refresh
 refrence->reference
 refrenced->referenced
@@ -45010,6 +46136,7 @@ refrerenceing->referencing
 refrerences->references
 refrerencial->referential
 refrers->refers
+refreshin->refreshing
 refreshs->refreshes
 refreshses->refreshes
 refridgeration->refrigeration
@@ -45027,11 +46154,13 @@ refroms->reforms
 refrormatting->reformatting
 refure->refuse
 refures->refuses
+refusin->refusing
 refusla->refusal
 regalar->regular
 regalars->regulars
 regardeless->regardless
 regardes->regards
+regardin->regarding
 regardles->regardless
 regardlesss->regardless
 regarg->regard
@@ -45064,6 +46193,7 @@ regeister->register
 regeistered->registered
 regeistration->registration
 regenarated->regenerated
+regeneratin->regenerating
 regenrated->regenerated
 regenratet->regenerated
 regenrating->regenerating
@@ -45114,6 +46244,7 @@ registerered->registered
 registeres->registers
 registeresd->registered
 registeries->registries
+registerin->registering
 registerred->registered
 registerring->registering
 registert->registered
@@ -45166,6 +46297,7 @@ regons->regions
 regorded->recorded
 regresion->regression
 regresison->regression
+regressin->regressing
 regresssion->regression
 regrigerator->refrigerator
 regsion->region
@@ -45219,6 +46351,8 @@ regulaotrs->regulators
 regulaotry->regulatory
 regularily->regularly
 regulariry->regularly
+regularisin->regularising
+regularizin->regularizing
 regularlisation->regularisation
 regularlise->regularise
 regularlised->regularised
@@ -45245,11 +46379,13 @@ regurlar->regular
 regurlarly->regularly
 regurlars->regulars
 reguster->register
+rehearsin->rehearsing
 rehersal->rehearsal
 rehersing->rehearsing
 reicarnation->reincarnation
 reight->right, eight, freight,
 reigining->reigning
+reignin->reigning
 reigon->reign, region,
 reigonal->regional
 reigons->reigns, regions,
@@ -45261,9 +46397,11 @@ reigstration->registration
 reigstrations->registrations
 reigstries->registries
 reigstry->registry
+reimplantin->reimplanting
 reimplemenet->reimplement
 reimplementaion->reimplementation
 reimplementaions->reimplementations
+reimplementin->reimplementing
 reimplemention->reimplementation
 reimplementions->reimplementations
 reimplent->reimplement, reimplant,
@@ -45295,6 +46433,7 @@ reinfocement->reinforcement
 reinfocements->reinforcements
 reinfoces->reinforces
 reinfocing->reinforcing
+reinforcin->reinforcing
 reinitailise->reinitialise
 reinitailised->reinitialised
 reinitailize->reinitialize
@@ -45306,7 +46445,9 @@ reinstalation->reinstallation
 reinstalations->reinstallations
 reinstaled->reinstalled
 reinstaling->reinstalling
+reinstallin->reinstalling
 reinstals->reinstalls
+reinstantiatin->reinstantiating
 reinstatiate->reinstantiate
 reinstatiated->reinstantiated
 reinstatiates->reinstantiates
@@ -45322,6 +46463,7 @@ reitterate->reiterate
 reitterated->reiterated
 reitterates->reiterates
 reivison->revision
+rejectin->rejecting
 rejplace->replace
 reknown->renown
 reknowned->renowned
@@ -45348,6 +46490,7 @@ relaod->reload
 relaoded->reloaded
 relaoding->reloading
 relaods->reloads
+relapsin->relapsing
 relase->release
 relased->released
 relaser->releaser
@@ -45363,6 +46506,7 @@ relatib->relative, relatable,
 relatibe->relative
 relatibely->relatively
 relatievly->relatively
+relatin->relating
 relatiopnship->relationship
 relativ->relative
 relativated->relative, relatively,
@@ -45388,6 +46532,7 @@ releant->relevant, relent,
 releas->release
 releasead->released
 releaseing->releasing
+releasin->releasing
 releasse->release
 releate->relate
 releated->related
@@ -45458,6 +46603,7 @@ reliefed->relieved
 reliefes->relieves
 reliefing->relieving
 relient->reliant
+relievin->relieving
 religeon->religion
 religeons->religions
 religeous->religious
@@ -45465,6 +46611,7 @@ religous->religious
 religously->religiously
 relinguish->relinquish
 relinguishing->relinquishing
+relinquishin->relinquishing
 relinqushment->relinquishment
 relintquish->relinquish
 relisation->realisation
@@ -45486,6 +46633,7 @@ relm->realm, elm, helm, ream, rem,
 relms->realms, elms, helms, reams,
 reloade->reload
 reloades->reloads, reloaded,
+reloadin->reloading
 relocae->relocate
 relocaes->relocates
 relocaiing->relocating
@@ -45500,6 +46648,7 @@ relocaitions->relocations
 relocaiton->relocation
 relocaitons->relocations
 relocateable->relocatable
+relocatin->relocating
 reloccate->relocate
 reloccated->relocated
 reloccates->relocates
@@ -45525,7 +46674,9 @@ remaines->remains, remained,
 remaing->remaining
 remainging->remaining
 remainig->remaining
+remainin->remaining
 remainst->remains
+remakin->remaking
 remander->remainder
 remane->remain, rename, remake,
 remaned->remained, renamed,
@@ -45538,6 +46689,7 @@ remanining->remaining
 remanins->remains
 remaped->remapped
 remaping->remapping
+remappin->remapping
 rembember->remember
 rembembered->remembered
 rembembering->remembering
@@ -45553,6 +46705,7 @@ remebers->remembers
 rememberable->memorable
 rememberance->remembrance
 rememberd->remembered
+rememberin->remembering
 remembrence->remembrance
 rememeber->remember
 rememebered->remembered
@@ -45589,11 +46742,13 @@ remiander->remainder, reminder,
 remianed->remained
 remianing->remaining
 remians->remains
+remindin->reminding
 reminent->remnant
 reminescent->reminiscent
 remining->remaining
 reminis->reminisce
 reminiscense->reminiscence
+reminiscin->reminiscing
 reminise->reminisce
 reminised->reminisced
 reminisent->reminiscent
@@ -45627,6 +46782,7 @@ remoote->remote
 remore->remote, remove,
 remorted->reported
 remot->remote
+remotin->remoting
 remotly->remotely
 remots->remotes
 removce->remove
@@ -45636,6 +46792,7 @@ removees->removes
 removefromat->removeformat
 removeing->removing
 removerd->removed
+removin->removing
 remplace->replace
 remplaced->replaced
 remplacement->replacement
@@ -45658,6 +46815,7 @@ renable->re-enable
 renabled->re-enabled
 renables->re-enables
 renabling->re-enabling
+renamin->renaming
 rendayvoo->rendezvous
 rendayvooed->rendezvoused
 rendayvou->rendezvous
@@ -45676,6 +46834,7 @@ renderered->rendered
 rendererers->renderers, renderer's,
 renderering->rendering
 renderes->renders, renderers, renderer's,
+renderin->rendering
 renderning->rendering
 renderr->render
 renderred->rendered
@@ -45700,6 +46859,7 @@ renegatiotiation->renegotiation
 renegatiotiations->renegotiations
 renegatiotiator->renegotiator
 renegatiotiators->renegotiators
+renegin->reneging
 renegoable->renegotiable
 renegoate->renegotiate
 renegoated->renegotiated
@@ -45814,6 +46974,7 @@ renegothiation->renegotiation
 renegothiations->renegotiations
 renegothiator->renegotiator
 renegothiators->renegotiators
+renegotiatin->renegotiating
 renegotible->renegotiable
 renegoticable->renegotiable
 renegoticate->renegotiate
@@ -45897,6 +47058,7 @@ renegoziations->renegotiations
 renegoziator->renegotiator
 renegoziators->renegotiators
 reneweal->renewal
+renewin->renewing
 renewl->renewal
 renforce->reinforce
 renforced->reinforced
@@ -45915,10 +47077,13 @@ rennovation->renovation
 renosance->renaissance, resonance,
 renoun->renown
 renouned->renowned, renounced,
+renovatin->renovating
 rentime->runtime
 rentors->renters
+renumberin->renumbering
 reoadmap->roadmap
 reoccurrence->recurrence
+reoccurrin->reoccurring
 reocmpression->recompression
 reocurring->reoccurring, recurring,
 reoder->reorder
@@ -45952,10 +47117,12 @@ reopsitories->repositories
 reopsitory->repository
 reord->record, reword,
 reorded->recorded, reordered, reorder, reworded,
+reorderin->reordering
 reording->recording, reordering, rewording,
 reords->records, rewords,
 reorer->reorder
 reorganision->reorganisation
+reorganizin->reorganizing
 reorginised->reorganised
 reorginized->reorganized
 reoslution->resolution
@@ -45994,6 +47161,8 @@ repalces->replaces
 repalcing->replacing
 repant->repaint, repent,
 repants->repaints, repents,
+reparameterisin->reparameterising
+reparameterizin->reparameterizing
 reparamterisation->reparameterisation
 reparamterise->reparameterise
 reparamterised->reparameterised
@@ -46014,6 +47183,7 @@ repblics->republics
 repeadet->repeated
 repeadetly->repeatedly
 repeates->repeats
+repeatin->repeating
 repeatly->repeatedly
 repect->respect
 repectable->respectable
@@ -46029,9 +47199,11 @@ repeled->repelled
 repeler->repeller
 repeling->repelling
 repell->repel
+repellin->repelling
 repells->repels
 repentence->repentance
 repentent->repentant
+repentin->repenting
 reperesent->represent
 reperesentation->representation
 reperesentational->representational
@@ -46073,6 +47245,7 @@ repetively->repetitively, receptively,
 repetoire->repertoire
 repetoires->repertoires
 repets->repeats, repents, repels, resets,
+rephasin->rephasing
 repid->rapid
 repition->repetition
 repitions->repetitions
@@ -46108,6 +47281,7 @@ replacemet->replacement
 replacemets->replacements
 replacent->replacement
 replacents->replacements
+replacin->replacing
 replacmenet->replacement
 replacment->replacement
 replacments->replacements
@@ -46126,6 +47300,7 @@ replasing->replacing, relapsing, rephasing,
 replcace->replace
 replcaced->replaced
 replcaof->replicaof
+replenishin->replenishing
 replentish->replenish
 replentished->replenished
 replentishes->replenishes
@@ -46143,7 +47318,9 @@ replicaition->replication
 replicaitions->replications
 replicaiton->replication
 replicaitons->replications
+replicatin->replicating
 repling->replying
+replyin->replying
 replys->replies
 repoduce->reproduce
 repoduced->reproduced
@@ -46180,6 +47357,7 @@ reporsitories->repositories
 reporsitory->repository
 reportadly->reportedly
 reportign->reporting
+reportin->reporting
 reportresouces->reportresources
 reposiotories->repositories
 reposiotory->repository
@@ -46188,6 +47366,7 @@ reposiry->repository
 repositaries->repositories
 repositary->repository
 reposities->repositories
+repositionin->repositioning
 repositiories->repositories
 repositiory->repository
 repositiroes->repositories
@@ -46209,6 +47388,7 @@ reposonding->responding
 reposonse->response
 reposonses->responses
 repostes->reposts, ripostes,
+repostin->reposting
 repostiories->repositories
 repostiory->repository
 repostories->repositories
@@ -46280,6 +47460,7 @@ representd->represented
 represente->represents, represented,
 representes->represents, represented,
 representiative->representative
+representin->representing
 represention->representation
 representions->representations
 representive->representative
@@ -46311,6 +47492,7 @@ reprocuce->reproduce, reprocure,
 reprocuced->reproduced, reprocured,
 reprocuces->reproduces, reprocures,
 reprocucing->reproducing, reprocuring,
+reprocurin->reprocuring
 reprodice->reproduce
 reprodiced->reproduced
 reprodicibility->reproducibility
@@ -46328,6 +47510,7 @@ reproducble->reproducible
 reproduciability->reproduceability
 reproduciable->reproduceable
 reproduciblity->reproducibility
+reproducin->reproducing
 reprot->report
 reproted->reported
 reproting->reporting
@@ -46378,6 +47561,8 @@ repulic->republic
 repulican->republican
 repulicans->republicans
 repulics->republics
+repurposin->repurposing
+reputin->reputing
 reputpose->repurpose
 reputposed->repurposed
 reputposes->repurposes
@@ -46434,6 +47619,7 @@ requestesd->requested
 requestested->requested
 requestests->requests, requested,
 requestied->requested
+requestin->requesting
 requestor->requester
 requestors->requesters
 requestying->requesting
@@ -46471,12 +47657,14 @@ requiremenet->requirement
 requiremenets->requirements
 requiremnt->requirement
 requiremnts->requirements
+requirin->requiring
 requirment->requirement
 requirmentes->requirements
 requirments->requirements
 requirs->requires
 requisit->requisite
 requisits->requisites
+requitin->requiting
 requre->require
 requred->required
 requrement->requirement
@@ -46518,6 +47706,7 @@ rererence->reference, reverence,
 rererences->references, reverences,
 rerference->reference
 rerferences->references
+reroutin->rerouting
 rerpesentation->representation
 rertieve->retrieve
 rertieved->retrieved
@@ -46527,6 +47716,7 @@ rertieves->retrieves
 reruirement->requirement
 reruirements->requirements
 reruning->rerunning
+rerunnin->rerunning
 rerurn->return, rerun,
 rerwite->rewrite
 resarch->research
@@ -46537,6 +47727,7 @@ resarts->restarts
 resaurant->restaurant
 resaurants->restaurants
 rescaned->rescanned
+rescindin->rescinding
 rescource->resource
 rescourced->resourced
 rescources->resources
@@ -46544,8 +47735,10 @@ rescourcing->resourcing
 rescrition->restriction
 rescritions->restrictions
 rescueing->rescuing
+rescuin->rescuing
 reseach->research
 reseached->researched
+researchin->researching
 researvation->reservation
 researvations->reservations
 researve->reserve
@@ -46556,6 +47749,7 @@ reselction->reselection
 resembelance->resemblance
 resembes->resembles
 resemblence->resemblance
+resemblin->resembling
 resently->recently
 resepect->respect
 resepected->respected
@@ -46580,12 +47774,14 @@ reserching->researching
 reserv->reserve
 reserverd->reserved
 reservered->reserved
+reservin->reserving
 resest->reset, recessed,
 resestatus->resetstatus
 resetable->resettable
 reseted->reset
 reseting->resetting
 resetted->reset
+resettin->resetting
 resevation->reservation
 resevations->reservations
 reseve->reserve
@@ -46606,6 +47802,7 @@ resgistries->registries
 resgistry->registry
 residencial->residential
 residental->residential
+residin->residing
 resierfs->reiserfs
 resignement->resignment
 resilence->resilience, residence,
@@ -46631,6 +47828,7 @@ resitor->resistor
 resitors->resistors
 resivwar->reservoir
 resizeble->resizeable, resizable,
+resizin->resizing
 reslection->reselection
 resloution->resolution
 resloutions->resolutions
@@ -46667,6 +47865,7 @@ resolutino->resolution
 resolutinos->resolutions
 resolutins->resolutions
 resoluton->resolution
+resolvin->resolving
 resolvinf->resolving
 reson->reason
 resonable->reasonable
@@ -46717,6 +47916,7 @@ resourcd->resourced, resource,
 resourcde->resourced, resource,
 resourcees->resources
 resourceype->resourcetype
+resourcin->resourcing
 resourcs->resources, resource,
 resourcse->resources, resource,
 resourcsed->resourced, resource,
@@ -46743,12 +47943,14 @@ resovlers->resolvers
 resovles->resolves
 resovling->resolving
 respawining->respawning
+respawnin->respawning
 respberries->raspberries
 respberry->raspberry
 respecitve->respective
 respecitvely->respectively
 respecive->respective
 respecively->respectively
+respectin->respecting
 respectivelly->respectively
 respectivley->respectively
 respectivly->respectively
@@ -46781,6 +47983,7 @@ responcible->responsible
 responcive->responsive
 responciveness->responsiveness
 responde->respond, response, responds, responded, responder,
+respondin->responding
 respone->response, respond,
 responed->respond, responded,
 responeded->responded
@@ -46917,6 +48120,8 @@ restaraunt->restaurant
 restaraunteur->restaurateur
 restaraunteurs->restaurateurs
 restaraunts->restaurants
+restartin->restarting
+restatin->restating
 restatting->restarting, restating,
 restauranteurs->restaurateurs
 restauration->restoration
@@ -46946,6 +48151,7 @@ restorated->restored
 restoreable->restorable
 restoreble->restorable
 restoreing->restoring
+restorin->restoring
 restors->restores
 restouration->restoration
 restraunt->restraint, restaurant,
@@ -46953,12 +48159,14 @@ restraunts->restraints, restaurants,
 restrcted->restricted
 restrcuture->restructure
 restriced->restricted
+restrictin->restricting
 restroing->restoring
 restructed->restricted, restructured,
 reStructedText->reStructuredText
 restructing->restricting, restructuring,
 reStructuredTetx->reStructuredText
 reStructuredTxet->reStructuredText
+restructurin->restructuring
 restrucure->restructure
 restrucured->restructured
 reStrucuredText->reStructuredText
@@ -46985,6 +48193,7 @@ resturn->return, returns,
 resturns->returns
 resuable->reusable
 resuables->reusables
+resubmittin->resubmitting
 resubstituion->resubstitution
 resuce->reduce, rescue,
 resuced->reduced, rescued,
@@ -47012,6 +48221,7 @@ resulotions->resolutions
 resuls->results
 resulsets->resultsets
 resulst->results
+resultin->resulting
 resultion->resolution
 resultions->resolutions
 resultung->resulting
@@ -47024,6 +48234,7 @@ resulvers->resolvers
 resulves->resolves
 resulving->resolving
 resumbmitting->resubmitting
+resumin->resuming
 resumitted->resubmitted
 resumt->resume
 resuorce->resource
@@ -47040,6 +48251,7 @@ resurecting->resurrecting
 resurection->resurrection
 resurections->resurrections
 resurects->resurrects
+resurrectin->resurrecting
 resurse->recurse, resource,
 resursed->recursed, resourced,
 resurses->recurses, resources,
@@ -47079,6 +48291,7 @@ retcieved->retrieved, received,
 retciever->retriever, receiver,
 retcievers->retrievers, receivers,
 retcieves->retrieves, receives,
+retestin->retesting
 retet->reset, retest,
 retetting->resetting, retesting,
 rether->rather
@@ -47108,11 +48321,13 @@ retquireseek->requireseek
 retquiresgpos->requiresgpos
 retquiresgsub->requiresgsub
 retquiressl->requiressl
+retractin->retracting
 retranser->retransfer
 retransferd->retransferred
 retransfered->retransferred
 retransfering->retransferring
 retransferrd->retransferred
+retransferrin->retransferring
 retransfert->retransfer, retransferred,
 retransmited->retransmitted
 retransmition->retransmission
@@ -47149,6 +48364,7 @@ retrieces->retrieves
 retriev->retrieve
 retrieveds->retrieved
 retrieveing->retrieving
+retrievin->retrieving
 retrivable->retrievable
 retrival->retrieval, retrial,
 retrive->retrieve
@@ -47169,9 +48385,11 @@ retrvieved->retrieved
 retrviever->retriever
 retrvievers->retrievers
 retrvieves->retrieves
+retryin->retrying
 retsart->restart
 retsarts->restarts
 retun->return
+retunin->retuning
 retunr->return, retune,
 retunred->returned, retuned,
 retunring->returning, retuning,
@@ -47195,6 +48413,7 @@ returnd->returned
 returne->returned, return,
 returnes->returns
 returnig->returning
+returnin->returning
 returnn->return
 returnned->returned
 returnning->returning
@@ -47242,6 +48461,7 @@ reuplaoding->reuploading
 reuplaods->reuploads
 reuploade->reupload
 reuploades->reuploads, reuploaded,
+reuploadin->reuploading
 reuplod->reupload
 reuplodad->reupload, reuploaded,
 reuploded->reuploaded
@@ -47262,6 +48482,7 @@ reuqiring->requiring
 reurn->return
 reursively->recursively
 reuseable->reusable
+reusin->reusing
 reuslt->result
 reuslted->resulted
 reuslting->resulting
@@ -47274,7 +48495,9 @@ reutnrs->returns
 reutrn->return
 reutrns->returns
 revaildating->revalidating
+revalidatin->revalidating
 revaluated->reevaluated
+revampin->revamping
 reveive->receive, revive,
 reveived->received, reviewed, revived,
 reveiver->receiver, reviewer, reviver,
@@ -47292,6 +48515,7 @@ revelance->relevance
 revelant->relevant
 revelence->relevance
 revelent->relevant
+revelin->reveling
 revelution->revolution
 revelutionary->revolutionary
 revelutions->revolutions
@@ -47310,6 +48534,7 @@ reversable->reversible
 reverse-engeneer->reverse-engineer
 reverse-engeneering->reverse-engineering
 reverse-engieer->reverse-engineer
+reverse-engineerin->reverse-engineering
 reverseed->reversed
 reversees->reverses
 reverve->reserve
@@ -47321,15 +48546,18 @@ revewers->reviewers
 revewing->reviewing, renewing, reveling,
 revewrse->reverse
 revews->reviews, renews, revels,
+reviewin->reviewing
 reviewl->review
 reviewsectio->reviewsection
 revisisions->revisions
+revisitin->revisiting
 revison->revision
 revisons->revisions
 revist->revisit
 revisted->revisited
 revisting->revisiting
 revists->revisits
+revivin->reviving
 reviw->review
 reviwed->reviewed
 reviwer->reviewer
@@ -47360,6 +48588,7 @@ revolutoinary->revolutionary
 revolutoins->revolutions
 revoluttionary->revolutionary
 revoluutionary->revolutionary
+revolvin->revolving
 revrese->reverse
 revrieve->retrieve
 revrieved->retrieved
@@ -47373,20 +48602,24 @@ rewieved->reviewed
 rewiever->reviewer
 rewieving->reviewing
 rewievs->reviews
+rewirin->rewiring
 rewirtable->rewritable
 rewirte->rewrite
 rewirtten->rewritten
 rewitable->rewritable
 rewite->rewrite
 rewitten->rewritten
+rewordin->rewording
 reworkd->reworked
 rewriable->rewritable, reliable,
 rewriet->rewrite
 rewriite->rewrite
 rewrited->rewrote, rewritten,
 rewriten->rewritten
+rewritin->rewriting
 rewritting->rewriting
 rewuired->required
+rezonin->rezoning
 rference->reference
 rferences->references
 rfeturned->returned
@@ -47406,6 +48639,8 @@ rickoshay->ricochet
 rickoshayed->ricocheted
 rickoshaying->ricocheting
 rickoshays->ricochets
+ricochetin->ricocheting
+riddlin->riddling
 ridiculus->ridiculous
 riendeer->reindeer
 riendeers->reindeers
@@ -47437,6 +48672,8 @@ riminicer->reminiscer
 riminices->reminisces
 riminicing->reminiscing
 rimitives->primitives
+rin->ring
+ringin->ringing
 rininging->ringing
 rinosarus->rhinoceros
 rinosaruses->rhinoceroses
@@ -47472,6 +48709,8 @@ rmove->remove
 rmoved->removed
 rmoving->removing
 rnage->rage, range,
+roamin->roaming
+roastin->roasting
 roataion->rotation
 roatation->rotation
 roate->rotate
@@ -47513,6 +48752,7 @@ roiginally->originally
 roiginals->originals
 roiginating->originating
 roigins->origins
+rollin->rolling
 romote->remote
 romoted->remoted
 romoteing->remoting
@@ -47553,6 +48793,7 @@ rotataion->rotation
 rotataions->rotations
 rotatd->rotated, rotate,
 rotateable->rotatable
+rotatin->rotating
 rotatio->rotation, ratio,
 rotatios->rotations, ratios,
 rotats->rotates, rotate,
@@ -47562,10 +48803,13 @@ rougly->roughly
 rouine->routine
 rouines->routines
 round-robbin->round-robin
+round-trippin->round-tripping
 roundign->rounding
+roundin->rounding
 roundtriped->roundtripped, round-tripped, round tripped,
 roundtriping->roundtripping, round-tripping, round tripping,
 roundtripp->roundtrip, round-trip, round trip,
+roundtrippin->roundtripping
 roung->round
 rountine->routine
 rountines->routines
@@ -47624,8 +48868,10 @@ rudimentally->rudimentary
 rudimentatry->rudimentary
 rudimentory->rudimentary
 rudimentry->rudimentary
+ruinin->ruining
 rulle->rule
 rumatic->rheumatic
+rummagin->rummaging
 rumtime->runtime
 rumtimes->runtimes
 runing->running, ruining,
@@ -47679,6 +48925,7 @@ sabatoshed->sabotaged
 sabatoshes->sabotages
 sabatoshing->sabotaging
 sabatour->saboteur
+sabotagin->sabotaging
 sacalar->scalar
 sacalars->scalars
 sacale->scale
@@ -47686,6 +48933,7 @@ sacaled->scaled
 sacales->scales
 sacaling->scaling
 sacarin->saccharin
+sackin->sacking
 saclar->scalar, sacral,
 saclars->scalars
 sacle->scale, sale, sable,
@@ -47696,6 +48944,7 @@ sacrafice->sacrifice
 sacreligious->sacrilegious
 Sacremento->Sacramento
 sacrifical->sacrificial
+sacrificin->sacrificing
 sacrifying->sacrificing
 sacrilegeous->sacrilegious
 sacrin->saccharin
@@ -47704,6 +48953,7 @@ sade->sad
 saem->same
 safe-pooint->safe-point
 safe-pooints->safe-points
+safeguardin->safeguarding
 safeguared->safeguard, safeguarded,
 safeing->saving
 safepooint->safepoint
@@ -47717,6 +48967,7 @@ safty->safety
 saggital->sagittal
 sagital->sagittal
 Sagitarius->Sagittarius
+sailin->sailing
 sais->says
 saleries->salaries
 salery->salary
@@ -47734,6 +48985,7 @@ samori->samurai
 sampel->sample
 sampeld->sampled
 sampels->samples
+samplin->sampling
 samue->same, Samuel,
 samwich->sandwich
 samwiched->sandwiched
@@ -47747,12 +48999,14 @@ sanatizers->sanitizers
 sanatizes->sanitizes
 sanatizing->sanitizing
 sanaty->sanity
+sanctionin->sanctioning
 sanctionning->sanctioning
 sandobx->sandbox
 sandwhich->sandwich, sand which,
 sandwhiched->sandwiched
 sandwhiches->sandwiches
 sandwhiching->sandwiching
+sandwichin->sandwiching
 sandwitch->sandwich, sand witch,
 sandwitched->sandwiched
 sandwitches->sandwiches, sand witches,
@@ -47770,6 +49024,8 @@ sanetizers->sanitizers
 sanetizes->sanitizes
 sanetizing->sanitizing
 Sanhedrim->Sanhedrin
+sanitisin->sanitising
+sanitizin->sanitizing
 sanitizisation->sanitization
 sanizer->sanitizer
 sanpshot->snapshot
@@ -47804,6 +49060,7 @@ sapeenaing->subpoenaing
 sapeenas->subpoenas
 saphire->sapphire
 saphires->sapphires
+saplin->sapling
 sargant->sergeant
 sargeant->sergeant
 sarimonial->ceremonial
@@ -47864,6 +49121,7 @@ satisfiy->satisfy
 satisfiying->satisfying
 satisfyied->satisfied
 satisfyies->satisfies
+satisfyin->satisfying
 satisied->satisfied
 satisies->satisfies
 satisifaction->satisfaction
@@ -47911,6 +49169,7 @@ sautayed->sautéd
 sautayes->sautés
 sautaying->sautéing
 sautays->sautés
+sautéin->sautéing
 sav->save
 savees->saves
 saveguard->safeguard
@@ -47923,6 +49182,7 @@ savely->safely
 savere->severe
 savety->safety
 savgroup->savegroup
+savin->saving
 savve->save, savvy, salve,
 savves->saves, salves,
 savy->savvy
@@ -47938,6 +49198,7 @@ sawteing->sautéing
 sawtes->sautés
 saxaphone->saxophone
 sbsampling->subsampling
+scaffoldin->scaffolding
 scafold->scaffold
 scafolded->scaffolded
 scafolder->scaffolder
@@ -47949,10 +49210,12 @@ scalarr->scalar
 scaleability->scalability
 scaleable->scalable
 scaleing->scaling
+scalin->scaling
 scalled->scaled
 scandanavia->Scandinavia
 scaned->scanned
 scaning->scanning
+scannin->scanning
 scannning->scanning
 scarch->search, scorch, scratch, starch, scarce,
 scarched->searched, scorched, scratched,
@@ -48044,6 +49307,7 @@ schedul->schedule
 scheduld->scheduled
 schedulier->scheduler
 scheduliers->schedulers
+schedulin->scheduling
 schedulling->scheduling
 scheduls->schedules
 scheduluing->scheduling
@@ -48051,6 +49315,7 @@ schem->scheme
 schematrio->schematron
 schematrion->schematron
 schemd->schemed
+schemin->scheming
 schems->schemes
 schma->schema, schwa,
 schmas->schemas, schwas,
@@ -48065,6 +49330,7 @@ scholarhips->scholarships
 scholarstic->scholastic, scholarly,
 scholdn't->shouldn't
 schoole->schools, schooled,
+schoolin->schooling
 schould->should
 schow->show, chow,
 schowing->showing, chowing,
@@ -48097,6 +49363,7 @@ sciript->script
 sciripts->scripts
 scirpt->script
 scirpts->scripts
+scissorin->scissoring
 scketch->sketch
 scketched->sketched
 scketches->sketches
@@ -48118,17 +49385,22 @@ scondary->secondary
 scondly->secondly
 sconds->seconds
 scopeing->scoping
+scopin->scoping
+scorchin->scorching
 scorebord->scoreboard
+scorin->scoring
 scource->source, scouse,
 scourced->sourced, scoured,
 scourcer->scourer, sorcerer, scouser,
 scources->sources
+scourgin->scourging
 scrach->scratch
 scrached->scratched
 scraches->scratches
 scraching->scratching
 scrachs->scratches
 scrao->scrap
+scratchin->scratching
 screeb->screen
 screebs->screens
 screebshot->screenshot
@@ -48160,6 +49432,7 @@ scripoting->scripting
 scripots->scripts
 scripst->scripts
 scripte->script, scripted,
+scriptin->scripting
 scriptype->scripttype
 scrit->script, scrip,
 scritp->script
@@ -48240,6 +49513,7 @@ scuccesses->successes
 scuccessully->successfully
 sculpter->sculptor, sculpture,
 sculpters->sculptors, sculptures,
+sculptin->sculpting
 scupt->sculpt
 scupted->sculpted
 scupting->sculpting
@@ -48283,6 +49557,7 @@ searhers->searchers
 searhes->searches
 searhing->searching
 seatch->search
+seatin->seating
 secceed->succeed
 secceeded->succeeded, seceded,
 secceeding->succeeding, seceding,
@@ -48294,6 +49569,7 @@ seccessfully->successfully
 seccond->second
 secconds->seconds
 secction->section
+secedin->seceding
 seceed->succeed, secede,
 seceeded->succeeded, seceded,
 secenario->scenario
@@ -48364,6 +49640,7 @@ secrity->security
 secruity->security
 sectin->section
 sectins->sections
+sectionin->sectioning
 sectionis->sections, section is,
 sectionning->sectioning
 sectiont->sectioned, section,
@@ -48411,6 +49688,7 @@ seege->siege
 seeged->sieged
 seeges->sieges
 seeging->sieging
+seein->seeing
 seelect->select
 seelected->selected
 seemes->seems
@@ -48418,6 +49696,7 @@ seemless->seamless
 seemlessly->seamlessly
 seesion->session
 seesions->sessions
+seethin->seething
 seeting->seating, setting, seething,
 seetings->settings
 seeverities->severities
@@ -48465,6 +49744,7 @@ segmenst->segments
 segmentaion->segmentation
 segmente->segment
 segmentes->segments
+segmentin->segmenting
 segmetn->segment
 segmetned->segmented
 segmetns->segments
@@ -48474,6 +49754,7 @@ segmnetations->segmentations
 segmneted->segmented
 segmneting->segmenting
 segmnets->segments
+seguein->segueing
 segument->segment
 seguoys->segues
 segway->segue
@@ -48489,6 +49770,7 @@ seive->sieve
 seived->sieved
 seives->sieves
 seiving->sieving
+seizin->seizing
 sekect->select
 sekected->selected
 sekects->selects
@@ -48595,6 +49877,7 @@ self-contianed->self-contained
 self-opinyonated->self-opinionated
 self-referencial->self-referential
 self-refering->self-referring
+self-referrin->self-referring
 selfs->self
 sellect->select
 sellected->selected
@@ -48654,6 +49937,7 @@ sencond->second
 sencondary->secondary
 senconds->seconds
 sendign->sending
+sendin->sending
 sendinging->sending
 sendinng->sending
 senegraph->scenegraph, scene graph,
@@ -48731,6 +50015,7 @@ separatedly->separately
 separatelly->separately
 separater->separator, separated, separates, separate,
 separaters->separators, separates,
+separatin->separating
 separatley->separately
 separatly->separately
 separato->separator
@@ -48959,6 +50244,7 @@ sequenc->sequence
 sequencial->sequential
 sequencially->sequentially
 sequencies->sequences
+sequencin->sequencing
 sequencs->sequences, sequence,
 sequene->sequence
 sequenes->sequences
@@ -49048,6 +50334,8 @@ serialiaze->serialize
 serialiazed->serialized
 serialiazes->serializes
 serialiazing->serializing
+serialisin->serialising
+serializin->serializing
 serialsiation->serialisation
 serialsie->serialise
 serialsied->serialised
@@ -49128,8 +50416,10 @@ serverles->serverless
 serverlesss->serverless
 serverlsss->serverless
 servicies->services
+servicin->servicing
 servie->service
 servies->services
+servin->serving
 servise->service
 servised->serviced
 servises->services
@@ -49205,6 +50495,7 @@ settin->setting
 settinga->settings
 settingss->settings
 settins->settings
+settlin->settling
 settlment->settlement
 settng->setting
 settngs->settings
@@ -49251,8 +50542,10 @@ shadasloo->shadaloo
 shaddow->shadow
 shadhow->shadow
 shadoloo->shadaloo
+shadowin->shadowing
 shal->shall
 shamen->shaman, shamans,
+shamin->shaming
 shandeleer->chandelier
 shandeleers->chandeliers
 shandow->shadow
@@ -49263,6 +50556,8 @@ shanger->changer
 shanges->changes
 shanghi->Shanghai
 shanging->changing, shanking,
+shankin->shanking
+shapin->shaping
 shapshot->snapshot
 shapshots->snapshots
 shapsnot->snapshot
@@ -49270,6 +50565,7 @@ shapsnots->snapshots
 shapt->shaped, shape,
 shareed->shared
 shareing->sharing
+sharin->sharing
 sharloton->charlatan
 sharraid->charade
 sharraids->charades
@@ -49325,6 +50621,7 @@ shepered->shepherd
 sheperedly->shepherdly
 shepereds->shepherds
 shepes->shapes
+shepherdin->shepherding
 sheping->shaping
 shepperd->shepherd
 shepperded->shepherded
@@ -49344,14 +50641,18 @@ shfting->shifting
 shfts->shifts
 shgould->should
 shicane->chicane
+shieldin->shielding
 shif->shift
 shif-tab->shift-tab
 shifed->shifted
 shifing->shifting
 shifs->shifts
+shiftin->shifting
 shineing->shining
+shinin->shining
 shiped->shipped
 shiping->shipping
+shippin->shipping
 shoft->shift, short,
 shoftware->software
 shoild->should
@@ -49363,6 +50664,7 @@ sholuld->should
 sholuldn't->shouldn't
 shoould->should
 shopkeeepers->shopkeepers
+shoppin->shopping
 shopuld->should
 shorctut->shortcut
 shorctuts->shortcuts
@@ -49374,6 +50676,7 @@ short-cicruits->short-circuits
 shortand->shorthand
 shortcat->shortcut
 shortcats->shortcuts
+shortcomin->shortcoming
 shortcomming->shortcoming
 shortcommings->shortcomings
 shortcutt->shortcut
@@ -49420,6 +50723,7 @@ shouuldn't->shouldn't
 shouw->show
 shouws->shows
 showfer->chauffeur, shower,
+showin->showing
 showvinism->chauvinism
 shpae->shape
 shpaes->shapes
@@ -49432,6 +50736,7 @@ shreak->shriek
 shreshold->threshold
 shriks->shrinks
 shrinked->shrunk, shrank,
+shrinkin->shrinking
 shrtcut->shortcut
 shrtcuts->shortcuts
 shs->ssh, NHS,
@@ -49445,6 +50750,7 @@ shtoppes->stops, shops,
 shtopping->stopping, shopping,
 shtops->stops, shops,
 shttp->https
+shuckin->shucking
 shudown->shutdown
 shufle->shuffle
 shuld->should
@@ -49455,6 +50761,8 @@ shurely->surely
 shutdownm->shutdown
 shuting->shutting
 shutodwn->shutdown
+shuttin->shutting
+shuttlin->shuttling
 shwo->show
 shwon->shown
 shystem->system
@@ -49464,6 +50772,7 @@ shystems->systems
 shystemwindow->systemwindow, system window,
 sibiling->sibling
 sibilings->siblings
+siblin->sibling
 sibtitle->subtitle
 sibtitles->subtitles
 sicinct->succinct
@@ -49475,8 +50784,10 @@ sidde->side
 sideral->sidereal
 siduction->seduction
 sie->size, sigh, side,
+siegin->sieging
 sience->science, silence,
 sies->size, sighs, sides,
+sievin->sieving
 siez->size, seize,
 sieze->seize, size,
 siezed->seized, sized,
@@ -49523,7 +50834,9 @@ sigles->singles, sigils,
 sigleton->singleton
 signabl->signable, signal,
 signales->signals
+signalin->signaling
 signall->signal
+signallin->signalling
 signatue->signature
 signatur->signature
 signes->signs
@@ -49561,6 +50874,7 @@ signifigant->significant
 signifigantly->significantly
 signifiy->signify
 signifiying->signifying
+signifyin->signifying
 signitories->signatories
 signitory->signatory
 signiture->signature
@@ -49588,6 +50902,7 @@ sigurets->cigarettes
 sigurette->cigarette
 silabus->syllabus
 silabuses->syllabuses
+silencin->silencing
 silentely->silently
 silenty->silently
 silhouete->silhouette
@@ -49595,6 +50910,7 @@ silhoueted->silhouetted
 silhouetes->silhouettes
 silhoueting->silhouetting
 silhouetist->silhouettist
+silhouettin->silhouetting
 silhouwet->silhouette
 silhouweted->silhouetted
 silhouwetes->silhouettes
@@ -49741,6 +51057,7 @@ simplificaitons->simplifications
 simplifing->simplifying
 simplifiy->simplify
 simplifiying->simplifying
+simplifyin->simplifying
 simplifys->simplifies
 simpliifcation->simplification
 simpliifcations->simplifications
@@ -49805,6 +51122,7 @@ simulatenous->simultaneous
 simulatenously->simultaneously
 simulater->simulators, simulated, simulates, simulate,
 simulaters->simulators, simulates,
+simulatin->simulating
 simultaenous->simultaneous
 simultaenously->simultaneously
 simultanaeous->simultaneous
@@ -49852,6 +51170,7 @@ singl->single
 singlar->singular
 single-threded->single-threaded
 singlely->singly
+singlin->singling
 singls->singles, single,
 singlton->singleton
 singltons->singletons
@@ -49998,8 +51317,10 @@ sitirs->stirs
 sitl->still
 sitll->still
 sitmuli->stimuli
+sittin->sitting
 situaion->situation
 situaions->situations
+situatin->situating
 situationals->situational, situations,
 situationly->situationally, situational,
 situationnal->situational
@@ -50035,17 +51356,20 @@ sizemologists->seismologists
 sizemologogical->seismological
 sizemologogically->seismologically
 sizemology->seismology
+sizin->sizing
 sizor->sizer, scissor,
 sizors->sizers, scissors,
 sizre->size
 Skagerak->Skagerrak
 skalar->scalar
 skateing->skating
+skatin->skating
 skecth->sketch
 skecthes->sketches
 skeep->skip
 skelton->skeleton
 skept->skipped
+sketchin->sketching
 sketchs->sketches
 sketck->sketch, skate,
 sketcked->sketched, skated,
@@ -50060,6 +51384,7 @@ skiped->skipped, skyped,
 skiping->skipping
 skipp->skip, skipped,
 skippd->skipped
+skippin->skipping
 skippped->skipped
 skippps->skips
 skipps->skips
@@ -50108,7 +51433,9 @@ sleector->selector
 sleectors->selectors
 sleects->selects
 sleeped->slept
+sleepin->sleeping
 sleepp->sleep
+sleuthin->sleuthing
 slewth->sleuth
 slewthed->sleuthed
 slewthing->sleuthing
@@ -50131,6 +51458,7 @@ sligt->slight
 sligth->slight
 sligthly->slightly
 sligtly->slightly
+slin->sling
 sliped->slipped
 sliseshow->slideshow
 slite->sleight, elite, slide, site,
@@ -50153,6 +51481,7 @@ smapling->sampling
 smealting->smelting
 smebody->somebody
 smehow->somehow
+smeltin->smelting
 smeone->someone
 smething->something
 smetime->sometime
@@ -50173,6 +51502,7 @@ smoewhere->somewhere
 smoot->smooth
 smooter->smoother
 smoothign->smoothing
+smoothin->smoothing
 smooting->smoothing
 smouth->smooth
 smouthness->smoothness
@@ -50184,13 +51514,17 @@ snaphots->snapshots
 snaphsot->snapshot
 snaphsots->snapshots
 snaping->snapping
+snappin->snapping
 snappng->snapping
 snapshoted->snapshotted
 snapshoting->snapshotting
+snapshottin->snapshotting
 snapsnot->snapshot
 snapsnots->snapshots
+snarlin->snarling
 snashot->snapshot
 snashots->snapshots
+snatchin->snatching
 sneeks->sneaks
 snese->sneeze
 snipet->snippet
@@ -50271,10 +51605,12 @@ solate->isolate
 solated->isolated
 solates->isolates
 solating->isolating
+solderin->soldering
 soldger->soldier
 soldgered->soldiered
 soldgering->soldiering
 soldgers->soldiers
+soldierin->soldiering
 soler->solver, solar, solely,
 soley->solely
 solf->solve, sold,
@@ -50305,6 +51641,7 @@ soluton->solution
 solutons->solutions
 solveable->solvable
 solveing->solving
+solvin->solving
 solwed->solved
 som->some
 sombody->somebody
@@ -50334,6 +51671,7 @@ somethign->something
 somethime->sometime
 somethimes->sometimes
 somethimg->something
+somethin->something
 somethiong->something
 sometiem->sometime, sometimes,
 sometiems->sometimes
@@ -50435,6 +51773,7 @@ sorrounds->surrounds
 sortcut->shortcut
 sortcuts->shortcuts
 sortig->sorting
+sortin->sorting
 sortings->sorting
 sortlst->sortlist
 sortner->sorter
@@ -50467,6 +51806,7 @@ souldn't->shouldn't
 soultion->solution
 soultions->solutions
 soundard->soundcard
+soundin->sounding
 sountrack->soundtrack
 sourbraten->sauerbraten
 sourc->source
@@ -50475,6 +51815,7 @@ sourcde->sourced, source,
 sourcedrectory->sourcedirectory
 sourcee->source
 sourcees->sources
+sourcin->sourcing
 sourcs->sources, source,
 sourcse->sources, source,
 sourct->source
@@ -50538,6 +51879,7 @@ spacifiers->specifiers, pacifiers,
 spacifies->specifies, pacifies,
 spacify->specify, pacify,
 spacifying->specifying, pacifying,
+spacin->spacing
 spaece->space
 spaeced->spaced
 spaeces->spaces
@@ -50548,6 +51890,7 @@ spagheti->spaghetti
 spagnum->sphagnum
 spainish->Spanish
 spaning->spanning
+spannin->spanning
 sparate->separate
 sparated->separated
 sparately->separately
@@ -50565,6 +51908,7 @@ spaw->spawn
 spawed->spawned
 spawing->spawning
 spawining->spawning
+spawnin->spawning
 spaws->spawns
 spcae->space
 spcaed->spaced
@@ -50594,6 +51938,7 @@ speading->spreading, speeding, spending, speaking,
 speads->spreads, speeds, spends, speaks, spears,
 speadsheet->spreadsheet
 speadsheets->spreadsheets
+speakin->speaking
 spearate->separate
 spearated->separated
 spearately->separately
@@ -50643,9 +51988,11 @@ speciafied->specified
 specialiced->specialised, specialized,
 specialisaiton->specialisation
 specialisaitons->specialisations
+specialisin->specialising
 specialitzed->specialised, specialized,
 specializaiton->specialization
 specializaitons->specializations
+specializin->specializing
 speciall->special, specially,
 speciallized->specialised, specialized,
 specialy->specially
@@ -50774,6 +52121,7 @@ specift->specify
 specifyed->specified
 specifyied->specified
 specifyig->specifying
+specifyin->specifying
 specifyinhg->specifying
 speciic->specific
 speciied->specified
@@ -50817,6 +52165,7 @@ spedified->specified
 spedify->specify
 speeak->speak
 speeaking->speaking
+speedin->speeding
 speeed->speed
 speeeding->speeding
 speeeds->speeds
@@ -51103,7 +52452,10 @@ speicific->specific
 speicified->specified
 speicify->specify
 speling->spelling
+spellcheckin->spellchecking
+spellin->spelling
 spellshecking->spellchecking
+spendin->spending
 spendour->splendour
 speparate->separate
 speparated->separated
@@ -51162,6 +52514,7 @@ spezify->specify
 spicific->specific
 spicified->specified
 spicify->specify
+spielin->spieling
 spile->spite, spiral,
 spilts->splits
 spiltting->splitting
@@ -51182,6 +52535,7 @@ splite->split, splits, splice,
 splited->split
 spliting->splitting
 splitted->split
+splittin->splitting
 splittng->splitting
 spllitting->splitting
 spoace->space
@@ -51209,6 +52563,7 @@ spports->supports
 spreaded->spread
 spreadhseet->spreadsheet
 spreadhseets->spreadsheets
+spreadin->spreading
 spreadsheat->spreadsheet
 spreadsheats->spreadsheets
 spreasheet->spreadsheet
@@ -51220,7 +52575,9 @@ sprecially->specially
 spred->spread
 spredsheet->spreadsheet
 spreedsheet->spreadsheet
+sprin->spring
 sprinf->sprintf
+springin->springing
 spript->script
 spripted->scripted
 spripting->scripting
@@ -51251,9 +52608,14 @@ sqaured->squared
 sqaures->squares
 sqeuence->sequence
 sqllite->SQLite
+squarin->squaring
 squashgin->squashing
+squashin->squashing
+squattin->squatting
+squawkin->squawking
 squence->sequence
 squirel->squirrel
+squirin->squiring
 squirl->squirrel
 squrared->squared
 squre->square, sure, squire,
@@ -51338,6 +52700,7 @@ stabilite->stabilize
 stabilited->stabilized
 stabilites->stabilizes
 stabiliting->stabilizing
+stabilizin->stabilizing
 stabillity->stability
 stabilty->stability
 stabilzation->stabilization
@@ -51407,6 +52770,8 @@ standalown->standalone, stand-alone,
 standar->standard
 standarad->standard
 standard-complient->standard-compliant
+standardisin->standardising
+standardizin->standardizing
 standardss->standards
 standarisation->standardisation
 standarise->standardise
@@ -51487,6 +52852,7 @@ startet->started
 startign->starting
 startin->starting
 startlisteneing->startlistening
+startlistenin->startlistening
 startnig->starting
 startparanthesis->startparentheses
 startted->started
@@ -51561,17 +52927,21 @@ stautses->statuses
 stawberries->strawberries
 stawberry->strawberry
 stawk->stalk
+stayin->staying
 stcokbrush->stockbrush
 stdanard->standard
 stdanards->standards
+steamin->steaming
 stegnographic->steganographic
 stegnography->steganography
+stemmin->stemming
 stength->strength
 steram->stream
 steramed->streamed
 steramer->streamer
 steraming->streaming
 sterams->streams
+sterilizin->sterilizing
 sterio->stereo
 steriods->steroids
 sterotype->stereotype
@@ -51582,6 +52952,7 @@ stetches->stretches, sketches, stitches, stenches,
 stetching->stretching, sketching, stitching,
 stickness->stickiness
 stickyness->stickiness
+stiffenin->stiffening
 stiffneing->stiffening
 stiky->sticky
 stil->still
@@ -51593,7 +52964,9 @@ stiring->stirring
 stirng->string
 stirngs->strings
 stirr->stir
+stirrin->stirring
 stirrs->stirs
+stitchin->stitching
 stivk->stick
 stivks->sticks
 stle->style
@@ -51623,6 +52996,7 @@ stoopidly->stupidly
 stoped->stopped
 stoping->stopping
 stopp->stop
+stoppin->stopping
 stoppped->stopped
 stoppping->stopping
 stopps->stops
@@ -51637,6 +53011,7 @@ storege->storage
 storeing->storing
 storeis->stories, stores, store is, storeys,
 storge->storage
+storin->storing
 storise->stories
 stornegst->strongest
 storys->stories, storeys,
@@ -51656,6 +53031,7 @@ stragety->strategy
 straigh->straight
 straigh-forward->straightforward
 straighforward->straightforward
+straightenin->straightening
 straightfoward->straightforward
 straigt->straight
 straigtforward->straightforward
@@ -51689,6 +53065,8 @@ strcutre->structure
 strcutural->structural
 strcuture->structure
 strcutures->structures
+streamin->streaming
+streamlinin->streamlining
 streamm->stream
 streammed->streamed
 streamming->streaming
@@ -51740,11 +53118,13 @@ strengten->strengthen
 strengtened->strengthened
 strengtening->strengthening
 strengtens->strengthens
+strengthenin->strengthening
 strengts->strengths
 strenous->strenuous
 strentgh->strength
 strenth->strength
 strerrror->strerror
+stretchin->stretching
 striaght->straight
 striaghten->straighten
 striaghtens->straightens
@@ -51768,8 +53148,10 @@ striings->strings
 strikely->strikingly
 strin->string, strine, stein,
 stringifed->stringified
+stringifyin->stringifying
 strinsg->strings
 strippen->stripped
+strippin->stripping
 stript->stripped, script,
 stripted->scripted, stripped,
 stripting->scripting, stripping,
@@ -51783,6 +53165,8 @@ stroe->store, stroke, strobe, strove, strode,
 stroed->stored, stroked, strode,
 stroes->stores, strokes, strobes,
 stroing->storing, string, strong, stroking,
+strokin->stroking
+strollin->strolling
 stronlgy->strongly
 stronly->strongly
 strorage->storage
@@ -51837,6 +53221,7 @@ structues->structures
 structuing->structuring
 structur->structure
 structurd->structured
+structurin->structuring
 structurs->structures
 strucur->structure
 strucural->structural
@@ -51862,6 +53247,7 @@ struggeled->struggled
 struggeles->struggles
 struggeling->struggling
 struggels->struggles
+strugglin->struggling
 strust->trust, strut,
 struttural->structural
 strutture->structure
@@ -51900,6 +53286,8 @@ studing->studying
 studis->studies, studios,
 studoi->studio
 studois->studios
+studyin->studying
+stuffin->stuffing
 stuggle->struggle
 stuggled->struggled
 stuggles->struggles
@@ -51940,6 +53328,7 @@ stying->staying, styling,
 styless->styles, styleless,
 stylessheet->stylesheet, stylesheets,
 stylessheets->stylesheets
+stylin->styling
 sub-lcuase->sub-clause
 subbtle->subtle
 subcatagories->subcategories
@@ -52016,6 +53405,7 @@ submited->submitted
 submiting->submitting
 submition->submission
 submitions->submissions
+submittin->submitting
 submittion->submission
 submittions->submissions
 submittted->submitted
@@ -52075,6 +53465,7 @@ suboutine->subroutine
 subpackge->subpackage
 subpackges->subpackages
 subpecies->subspecies
+subpoenain->subpoenaing
 subporgram->subprogram
 subproccese->subprocess
 subpsace->subspace
@@ -52090,6 +53481,7 @@ subresoure->subresource
 subresoures->subresources
 subroutie->subroutine
 subrouties->subroutines
+subsamplin->subsampling
 subsceptible->susceptible
 subscibe->subscribe
 subscibed->subscribed
@@ -52104,6 +53496,7 @@ subscirbing->subscribing
 subscirpt->subscript
 subscirption->subscription
 subscirptions->subscriptions
+subscribin->subscribing
 subscribtion->subscription
 subscribtions->subscriptions
 subscritpion->subscription
@@ -52197,6 +53590,7 @@ substracted->subtracted
 substracting->subtracting
 substraction->subtraction
 substracts->subtracts
+substrin->substring
 substucture->substructure
 substuctures->substructures
 substutite->substitute
@@ -52228,6 +53622,7 @@ subtitutes->substitutes
 subtituting->substituting
 subtitution->substitution
 subtitutions->substitutions
+subtractin->subtracting
 subtrafuge->subterfuge
 subtrate->substrate
 subtrates->substrates
@@ -52274,6 +53669,7 @@ succeds->succeeds
 succee->succeed
 succeedde->succeeded
 succeedes->succeeds
+succeedin->succeeding
 succeeed->succeed, succeeded,
 succeeeded->succeeded
 succeeeding->succeeding
@@ -52443,6 +53839,7 @@ sucsession->succession
 sucsessive->successive
 sucsessor->successor
 sucsessors->successors
+suctionin->suctioning
 sude->sudo, side, sure, dude, suede, sued,
 sudent->student
 sudents->students
@@ -52461,6 +53858,7 @@ suffciency->sufficiency
 suffcient->sufficient
 suffciently->sufficiently
 sufferage->suffrage
+sufferin->suffering
 sufferred->suffered
 sufferring->suffering
 sufficate->suffocate
@@ -52480,6 +53878,8 @@ suffiency->sufficiency
 suffient->sufficient
 suffiently->sufficiently
 suffisticated->sophisticated
+suffixin->suffixing
+suffocatin->suffocating
 suficate->suffocate
 suficated->suffocated
 suficates->suffocates
@@ -52542,6 +53942,7 @@ sugguests->suggests
 suh->such
 suiete->suite
 suiteable->suitable
+sullyin->sullying
 sumamry->summary
 sumaries->summaries
 sumarisation->summarisation
@@ -52565,7 +53966,9 @@ sumbodule->submodule
 sumbodules->submodules
 sumed-up->summed-up
 summar->summary, summer,
+summarisin->summarising
 summarizen->summarize
+summarizin->summarizing
 summay->summary
 summeries->summaries
 summerisation->summarisation
@@ -52642,6 +54045,7 @@ superintendant->superintendent
 superios->superior, superiors,
 superopeator->superoperator
 supersed->superseded
+supersedin->superseding
 superseed->supersede
 superseedd->superseded
 superseede->supersede
@@ -52708,6 +54112,8 @@ suppied->supplied
 suppier->supplier
 suppies->supplies
 supplamented->supplemented
+supplantin->supplanting
+supplementin->supplementing
 suppliad->supplied
 suppliementing->supplementing
 suppliment->supplement
@@ -52718,6 +54124,7 @@ supplimenting->supplementing
 suppliments->supplements
 suppling->supplying
 supplyed->supplied
+supplyin->supplying
 suppoed->supposed
 suppoert->support
 suppoerted->supported
@@ -52754,6 +54161,7 @@ supposeded->supposed
 supposedely->supposedly
 supposeds->supposed
 supposedy->supposedly
+supposin->supposing
 supposingly->supposedly
 suppossed->supposed
 suppost->support, suppose, supports,
@@ -52786,6 +54194,7 @@ suppreses->suppresses
 suppresing->suppressing
 suppresion->suppression
 suppresions->suppressions
+suppressin->suppressing
 suppressingd->suppressing
 supprot->support
 supproted->supported
@@ -52877,6 +54286,7 @@ surounded->surrounded
 surounding->surrounding
 suroundings->surroundings
 surounds->surrounds
+surpassin->surpassing
 surpise->surprise
 surpised->surprised
 surpises->surprises
@@ -52891,6 +54301,7 @@ surpresses->suppresses
 surpressing->suppressing
 surpression->suppression
 surpressions->suppressions
+surprisin->surprising
 surprisinlgy->surprisingly
 surprize->surprise
 surprized->surprised
@@ -52898,6 +54309,7 @@ surprizing->surprising
 surprizingly->surprisingly
 surregat->surrogate
 surrended->surrounded, surrendered,
+surrenderin->surrendering
 surrepetitious->surreptitious
 surrepetitiously->surreptitiously
 surreptious->surreptitious
@@ -52913,6 +54325,7 @@ surrouded->surrounded
 surrouding->surrounding
 surroudings->surroundings
 surrouds->surrounds
+surroundin->surrounding
 surrround->surround
 surrrounded->surrounded
 surrrounding->surrounding
@@ -52922,6 +54335,7 @@ surrundering->surrendering
 survay->survey
 survays->surveys
 surveilence->surveillance
+surveilin->surveiling
 surveill->surveil
 surveyer->surveyor
 survice->service, survive,
@@ -52930,6 +54344,7 @@ survices->services, survives,
 surviver->survivor
 survivers->survivors
 survivied->survived
+survivin->surviving
 susbcribe->subscribe
 susbcribed->subscribed
 susbcriber->subscriber
@@ -52976,7 +54391,9 @@ susequently->subsequently
 susinct->succinct
 susinctly->succinctly
 susinkt->succinct
+suspectin->suspecting
 suspedn->suspend
+suspendin->suspending
 suspeneded->suspended
 suspention->suspension
 suspicios->suspicious
@@ -53032,6 +54449,7 @@ swalloed->swallowed
 swaped->swapped
 swapiness->swappiness
 swaping->swapping
+swappin->swapping
 swarmin->swarming
 swcloumns->swcolumns
 swepth->swept
@@ -53046,6 +54464,9 @@ swicthed->switched
 swicthes->switches
 swicthing->switching
 swiming->swimming
+swimmin->swimming
+swishin->swishing
+switchin->switching
 switchs->switches
 switcht->switched, switch,
 switchted->switched
@@ -53168,6 +54589,7 @@ symbo->symbol
 symbolc->symbolic
 symbole->symbol
 symboles->symbols
+symbolizin->symbolizing
 symboll->symbol
 symbollic->symbolic
 symbolls->symbols
@@ -53240,12 +54662,15 @@ synchroneous->synchronous
 synchroneously->synchronously
 synchronious->synchronous
 synchroniously->synchronously
+synchronisin->synchronising
 synchronizaton->synchronization
+synchronizin->synchronizing
 synchronsouly->synchronously
 synchronuous->synchronous
 synchronuously->synchronously
 synchronus->synchronous
 synchronusly->synchronously
+syncin->syncing
 syncrhonisation->synchronisation
 syncrhonise->synchronise
 syncrhonised->synchronised
@@ -53347,6 +54772,8 @@ syntethics->synthetics
 syntetic->synthetic
 syntetize->synthesize
 syntetized->synthesized
+synthesisin->synthesising
+synthesizin->synthesizing
 synthethic->synthetic
 synthetize->synthesize
 synthetized->synthesized
@@ -53378,6 +54805,9 @@ sysmte->system
 sysmtes->systems
 systax->syntax
 syste->system
+systematisin->systematising
+systematizin->systematizing
+systemizin->systemizing
 systemn->system
 systemwindiow->systemwindow, system window,
 systen->system
@@ -53467,6 +54897,7 @@ tabualtor->tabulator
 tabualtors->tabulators
 tabulater->tabulator, tabulated, tabulates, tabulate,
 tabulaters->tabulators, tabulates,
+tabulatin->tabulating
 tage->stage, take, tag, tagged,
 taged->tagged
 tages->tags, stages,
@@ -53490,11 +54921,13 @@ taht->that
 tailred->tailored
 tained->tainted, stained,
 taked->took, taken,
+takin->taking
 taks->task, tasks, takes,
 takslet->tasklet
 talbe->table
 talbes->tables
 talekd->talked
+talkin->talking
 tallerable->tolerable
 tamplate->template
 tamplated->templated
@@ -53554,6 +54987,7 @@ targered->targeted
 targering->targeting
 targers->targets, taggers,
 targest->targets, largest,
+targetin->targeting
 targetted->targeted
 targetting->targeting
 targettting->targeting
@@ -53604,6 +55038,7 @@ te->the, be, we, to,
 teacer->teacher
 teacers->teachers
 teached->taught
+teachin->teaching
 teachnig->teaching
 teaher->teacher
 teahers->teachers
@@ -53796,6 +55231,7 @@ templaetd->templated
 templaets->templates
 templat->template
 templateas->templates
+templatin->templating
 templats->templates
 templete->template
 templeted->templated
@@ -53891,6 +55327,7 @@ temprorily->temporarily
 temprory->temporary
 temproy->temporary
 temptatation->temptation
+temptin->tempting
 tempurature->temperature
 tempuratures->temperatures
 tempurture->temperature
@@ -53988,6 +55425,7 @@ termimals->terminals
 terminatd->terminated
 terminater->terminator, terminated, terminates, terminate,
 terminaters->terminators, terminates,
+terminatin->terminating
 terminats->terminates
 termindate->terminate
 termine->determine
@@ -54058,6 +55496,7 @@ ternimators->terminators
 terninal->terminal
 terninals->terminals
 terrable->terrible
+terraformin->terraforming
 terrestial->terrestrial
 terrform->terraform
 terrformed->terraformed
@@ -54093,6 +55532,7 @@ tesselator->tessellator
 tesselators->tessellators
 tessellater->tessellator, tessellated, tessellates, tessellate,
 tessellaters->tessellators, tessellates,
+tessellatin->tessellating
 tessleate->tessellate
 tessleated->tessellated
 tessleates->tessellates
@@ -54138,6 +55578,7 @@ teusday->Tuesday
 texchnically->technically
 texline->textline
 textfrme->textframe
+textin->texting
 texual->textual
 texually->textually
 texure->texture
@@ -54152,6 +55593,7 @@ thairs->theirs, there's,
 thankfull->thankful, thankfully,
 thankfullly->thankfully
 thankfuly->thankfully
+thankin->thanking
 thann->than, thank,
 thannk->thank
 thannked->thanked
@@ -54178,6 +55620,7 @@ thats'->that's
 thats->that's
 thaught->thought, taught,
 thaughts->thoughts
+thawin->thawing
 thay->they, that,
 thck->thick
 theard->thread
@@ -54201,6 +55644,7 @@ theiv->thief, they've,
 theive->thief
 theives->thieves
 themeing->theming
+themin->theming
 themperature->temperature
 themperatures->temperatures
 themplate->template
@@ -54278,6 +55722,7 @@ thhis->this
 thi->the, this,
 thiank->thank, think,
 thianks->thanks, thinks,
+thickenin->thickening
 thicking->thinking, thickening,
 thicknes->thickness, thickens,
 thid->this
@@ -54310,6 +55755,7 @@ thiniks->thinks
 thinkabel->thinkable
 thinkg->think, thing, things,
 thinkgs->thinks, things,
+thinkin->thinking
 thinn->thin
 thirs->third, thirst,
 thirtyth->thirtieth
@@ -54377,13 +55823,17 @@ thrad->thread
 thraded->threaded, traded,
 thrading->threading, trading,
 thrads->threads
+thrallin->thralling
+thrashin->thrashing
 thre->three, there, their, the,
+threadin->threading
 threadsave->threadsafe
 threah->thread, threat,
 threashold->threshold
 threasholds->thresholds
 threated->threaded, threatened, treated,
 threatend->threatened
+threatenin->threatening
 threatment->treatment
 threatments->treatments
 threatning->threatening
@@ -54426,6 +55876,7 @@ throtte->throttle, trot,
 throtted->throttled, trotted,
 throttes->throttles, trots,
 throtting->throttling, trotting,
+throttlin->throttling
 throttoling->throttling
 throug->through
 througg->through
@@ -54447,6 +55898,7 @@ throuhput->throughput
 throuth->through
 throwed->threw, thrown,
 throwgh->through
+throwin->throwing
 thrreshold->threshold
 thrresholds->thresholds
 thrshold->threshold
@@ -54518,6 +55970,7 @@ tiggering->triggering
 tiggers->triggers
 tighly->tightly
 tightely->tightly
+tightenin->tightening
 tigth->tight
 tigthen->tighten
 tigthened->tightened
@@ -54552,6 +56005,7 @@ timesamps->timestamps
 timeschedule->time schedule
 timespanp->timespan
 timespanps->timespans
+timestampin->timestamping
 timestan->timespan
 timestanp->timestamp, timespan,
 timestanps->timestamps, timespans,
@@ -54567,6 +56021,7 @@ timestmap->timestamp
 timestmaps->timestamps
 timetamp->timestamp
 timetamps->timestamps
+timin->timing
 timmestamp->timestamp
 timmestamps->timestamps
 timming->timing, trimming,
@@ -54600,11 +56055,13 @@ tiple->triple, tuple,
 tipled->tripled, tipped,
 tiples->triples, tuples,
 tipling->tripling, tipping,
+tippin->tipping
 tirangle->triangle
 tirangles->triangles
 titel->title
 titels->titles
 titile->title
+titlin->titling
 tittled->titled
 tittling->titling
 tjat->that
@@ -54631,6 +56088,7 @@ tocken->token
 tockens->tokens
 tocksen->toxin
 todya->today
+toein->toeing
 toekn->token
 toekns->tokens
 toether->together, tether,
@@ -54646,6 +56104,7 @@ toggeles->toggles
 toggeling->toggling
 toggels->toggles
 toggleing->toggling
+togglin->toggling
 togheter->together
 toghether->together
 togle->toggle
@@ -54731,6 +56190,7 @@ tortoitse->tortoise, tortoises,
 torward->toward
 torwards->towards
 Tosday->Tuesday, today,
+totalin->totaling
 totaly->totally
 totat->total
 totation->rotation
@@ -54759,10 +56219,12 @@ tounge->tongue
 touple->tuple, couple, topple, toupee,
 touples->tuples, couples, topples, toupees,
 tourch->torch, touch,
+towin->towing
 toword->toward
 towords->towards
 towrad->toward
 toxen->toxin
+toyin->toying
 tpye->type
 tpyed->typed
 tpyes->types
@@ -54772,7 +56234,9 @@ tpyo->typo
 tpyos->typos
 trabsform->transform
 traceablity->traceability
+tracin->tracing
 trackign->tracking
+trackin->tracking
 trackling->tracking
 tracsode->transcode
 tracsoded->transcoded
@@ -54785,6 +56249,7 @@ tradditional->traditional
 tradditionally->traditionally
 tradditions->traditions
 tradgic->tragic
+tradin->trading
 tradion->tradition
 tradional->traditional
 tradionally->traditionally
@@ -54804,6 +56269,7 @@ tradtionally->traditionally
 tradtions->traditions
 trafficed->trafficked
 trafficing->trafficking
+traffickin->trafficking
 trafic->traffic
 tragectory->trajectory
 traget->target
@@ -54818,6 +56284,7 @@ traigers->triagers
 traiges->triages
 traiging->triaging
 traiing->trailing, training,
+trailin->trailing
 trailins->trailing
 trailling->trailing, trialling, trilling,
 traingle->triangle
@@ -54831,6 +56298,7 @@ traingulation->triangulation
 traingulations->triangulations
 trainig->training
 trainigs->training
+trainin->training
 trainling->training, trailing,
 trainned->trained
 trainner->trainer
@@ -55005,6 +56473,7 @@ transcations->transactions, translations,
 transcendance->transcendence
 transcendant->transcendent
 transcendentational->transcendental
+transcendin->transcending
 transcevier->transceiver
 transciever->transceiver
 transcievers->transceivers
@@ -55015,6 +56484,7 @@ transcocders->transcoders
 transcocdes->transcodes
 transcocding->transcoding
 transcocdings->transcodings
+transcodin->transcoding
 transconde->transcode
 transconded->transcoded
 transconder->transcoder
@@ -55031,6 +56501,7 @@ transcording->transcoding
 transcordings->transcodings
 transcoser->transcoder
 transcosers->transcoders
+transcribin->transcribing
 transcripting->transcribing, transcription,
 transction->transaction
 transctional->transactional
@@ -55043,6 +56514,7 @@ transferd->transferred
 transfered->transferred
 transfering->transferring
 transferrd->transferred
+transferrin->transferring
 transfert->transfer, transferred,
 transfom->transform
 transfomation->transformation
@@ -55065,6 +56537,7 @@ transformaton->transformation
 transformatons->transformations
 transformatted->transformed
 transforme->transformed, transformer, transform,
+transformin->transforming
 transfrom->transform
 transfromate->transform, transformed,
 transfromation->transformation
@@ -55087,6 +56560,7 @@ transistion->transition
 transistioned->transitioned
 transistioning->transitioning
 transistions->transitions
+transitionin->transitioning
 transitionnal->transitional
 transitionned->transitioned
 transitionning->transitioning
@@ -55099,6 +56573,7 @@ transitors->transistors
 translater->translator
 translaters->translators
 translatied->translated
+translatin->translating
 translatoin->translation
 translatoins->translations
 translteration->transliteration
@@ -55122,6 +56597,7 @@ transmitions->transmissions
 transmitsion->transmission
 transmitsions->transmissions
 transmittd->transmitted
+transmittin->transmitting
 transmittion->transmission
 transmittions->transmissions
 transmitts->transmits
@@ -55212,8 +56688,11 @@ transperencies->transparencies
 transperency->transparency
 transperent->transparent
 transperently->transparently
+transplantin->transplanting
 transporation->transportation
 transportatin->transportation
+transportin->transporting
+transposin->transposing
 transprencies->transparencies
 transprency->transparency
 transprent->transparent
@@ -55272,6 +56751,7 @@ trasformer->transformer
 trasformers->transformers
 trasforming->transforming
 trasforms->transforms
+trashin->trashing
 trasient->transient
 trasiently->transiently
 trasients->transients
@@ -55358,6 +56838,8 @@ traveerse->traverse
 traveersed->traversed
 traveerses->traverses
 traveersing->traversing
+travelin->traveling
+travellin->travelling
 traveral->traversal
 travercal->traversal
 traverce->traverse
@@ -55374,19 +56856,23 @@ travereses->traverses
 traveresing->traversing
 travering->traversing
 traverls->travels, traversals,
+traversin->traversing
 traverssal->traversal
 travesal->traversal
 travese->traverse
 travesed->traversed
 traveses->traverses
 travesing->traversing
+trawlin->trawling
 tre->tree, the,
 treadet->treated, treaded, threaded,
 treak->treat, tweak,
+treasurin->treasuring
 treate->treat
 treatement->treatment
 treatements->treatments
 treates->treats
+treatin->treating
 treee->tree
 treees->trees
 tremelo->tremolo
@@ -55413,6 +56899,9 @@ trggers->triggers
 trgistration->registration
 trhe->the
 trhough->through
+triagin->triaging
+trialin->trialing
+triallin->trialling
 trian->train, trial,
 triancle->triangle
 triancles->triangles
@@ -55430,6 +56919,7 @@ trianglulation->triangulation
 trianglulations->triangulations
 trianglutaion->triangulation
 triangulataion->triangulation
+triangulatin->triangulating
 triangultaion->triangulation
 trianing->training
 trianlge->triangle
@@ -55452,6 +56942,7 @@ trigers->triggers
 trigged->triggered
 triggerd->triggered
 triggeres->triggers
+triggerin->triggering
 triggerred->triggered
 triggerring->triggering
 triggerrs->triggers
@@ -55471,8 +56962,10 @@ triks->tricks, trikes,
 triky->tricky
 trilinar->trilinear, trillionaire,
 trilineal->trilinear
+trillin->trilling
 trimed->trimmed
 triming->trimming, timing,
+trimmin->trimming
 trimmng->trimming
 trinagle->triangle
 trinagles->triangles
@@ -55492,6 +56985,8 @@ triology->trilogy
 tripel->triple
 tripeld->tripled
 tripels->triples
+triplin->tripling
+trippin->tripping
 tripple->triple
 triptick->triptych
 triptickes->triptychs
@@ -55563,6 +57058,7 @@ trogloditic->troglodytic
 trogloditical->troglodytical
 trogloditism->troglodytism
 troling->trolling
+trollin->trolling
 trolly->trolley
 trollys->trolleys
 trooso->trousseau
@@ -55575,6 +57071,7 @@ trotskist->trotskyist
 trotskists->trotskyists
 trotskyite->trotskyist
 trotskyites->trotskyists
+trottin->trotting
 trottle->throttle
 trottled->throttled, trotted,
 trottling->throttling, trotting,
@@ -55602,6 +57099,8 @@ troubeshoots->troubleshoots
 troubing->troubling
 troublehshoot->troubleshoot
 troublehshooting->troubleshooting
+troubleshootin->troubleshooting
+troublin->troubling
 troublshoot->troubleshoot
 troublshooting->troubleshooting
 troughout->throughout, throughput,
@@ -55648,6 +57147,7 @@ tructure->structure
 tructured->structured
 tructures->structures
 tructuring->structuring
+trudgin->trudging
 truelly->truly
 truely->truly
 truged->trudged
@@ -55663,6 +57163,7 @@ trunacting->truncating
 trunaction->truncation
 truncat->truncate
 truncatd->truncated
+truncatin->truncating
 truncats->truncates
 trunctate->truncate
 trunctated->truncated
@@ -55723,7 +57224,9 @@ tung->tongue
 tunges->tongues
 tungs->tongues
 tungues->tongues
+tunin->tuning
 tunned->tuned
+tunnelin->tunneling
 tunnell->tunnel
 tunning->tuning, running,
 tuotiral->tutorial
@@ -55765,6 +57268,7 @@ tutoral->tutorial
 tutorals->tutorials
 tutoriel->tutorial
 tutoriels->tutorials
+tweakin->tweaking
 tweek->tweak
 tweeked->tweaked
 tweeking->tweaking
@@ -55791,6 +57295,7 @@ tyes->types, ties,
 tyhat->that
 tyhe->they, the, type,
 tyies->tries
+tyin->tying
 tymecode->timecode
 tyoe->type, toey, toe,
 tyoed->typed, toyed, toed,
@@ -55803,6 +57308,8 @@ typcasts->typecasts
 typcial->typical
 typcially->typically
 typdef->typedef, typed,
+typecastin->typecasting
+typecheckin->typechecking
 typechek->typecheck
 typecheking->typechecking
 typesrript->typescript
@@ -55811,6 +57318,7 @@ typicall->typically, typical,
 typicallly->typically
 typicaly->typically
 typicially->typically
+typin->typing
 typle->tuple
 typles->tuples
 typoe->typo, type, types,
@@ -56014,7 +57522,9 @@ unapprieciative->unappreciative
 unapretiated->unappreciated
 unapretiative->unappreciative
 unaquired->unacquired
+unarchivin->unarchiving
 unarchving->unarchiving
+unassignin->unassigning
 unassing->unassign
 unassinged->unassigned
 unassinging->unassigning
@@ -56074,6 +57584,7 @@ unbuntu->Ubuntu
 uncahnged->unchanged
 uncalcualted->uncalculated
 unce->once
+unceasin->unceasing
 uncehck->uncheck
 uncehcked->unchecked
 uncerain->uncertain
@@ -56109,6 +57620,7 @@ uncomented->uncommented
 uncomenting->uncommenting
 uncoments->uncomments
 uncomitted->uncommitted
+uncommentin->uncommenting
 uncommited->uncommitted
 uncommment->uncomment
 uncommmented->uncommented
@@ -56138,6 +57650,7 @@ uncompresing->uncompressing
 uncompresor->uncompressor
 uncompresors->uncompressors
 uncompressible->incompressible
+uncompressin->uncompressing
 uncomprss->uncompress
 unconcious->unconscious
 unconciousness->unconsciousness
@@ -56204,6 +57717,7 @@ undelying->underlying
 undependend->independent, nondependent,
 underfiend->undefined
 underfined->undefined
+underflowin->underflowing
 underfow->underflow
 underfowed->underflowed
 underfowing->underflowing
@@ -56222,6 +57736,7 @@ underlow->underflow
 underlowed->underflowed
 underlowing->underflowing
 underlows->underflows
+underlyin->underlying
 underlyng->underlying
 underneeth->underneath
 underrrun->underrun
@@ -56248,11 +57763,13 @@ understadning->understanding
 understadns->understands
 understads->understands
 understandig->understanding
+understandin->understanding
 understant->understand, understate,
 understantable->understandable
 understantably->understandably
 understanting->understanding, understating,
 understants->understands, understates,
+understatin->understating
 understnad->understand
 understnadable->understandable
 understnadably->understandably
@@ -56404,6 +57921,7 @@ unfilpping->unflipping
 unfilps->unflips
 unflaged->unflagged
 unflexible->inflexible
+unflippin->unflipping
 unforetunate->unfortunate
 unforetunately->unfortunately
 unforgetable->unforgettable
@@ -56463,11 +57981,13 @@ unifforms->uniforms
 unifiy->unify
 unifiying->unifying
 uniformely->uniformly
+uniformin->uniforming
 uniformy->uniformly, uniform,
 unifrom->uniform
 unifromed->uniformed
 unifromity->uniformity
 unifroms->uniforms
+unifyin->unifying
 unigned->unsigned
 unihabited->uninhabited
 unilateraly->unilaterally
@@ -56476,6 +57996,7 @@ unilatreally->unilaterally
 unimpemented->unimplemented
 unimplemeneted->unimplemented
 unimplimented->unimplemented
+uninformin->uninforming
 uninfrom->uninform, uniform,
 uninfromed->uninformed, uniformed,
 uninfromes->uninforms, uniforms,
@@ -56496,7 +58017,9 @@ uninitalize->uninitialize
 uninitalized->uninitialized
 uninitalizes->uninitializes
 uniniteresting->uninteresting
+uninitialisin->uninitialising
 uninitializaed->uninitialized
+uninitializin->uninitializing
 uninitialse->uninitialise
 uninitialsed->uninitialised
 uninitialses->uninitialises
@@ -56504,6 +58027,7 @@ uninitialze->uninitialize
 uninitialzed->uninitialized
 uninitialzes->uninitializes
 uninstalable->uninstallable
+uninstallin->uninstalling
 uninstatiated->uninstantiated
 uninstlal->uninstall
 uninstlalation->uninstallation
@@ -56518,6 +58042,7 @@ unintelligble->unintelligible
 unintented->unintended, unindented,
 unintentially->unintentionally
 uninteressting->uninteresting
+uninterestin->uninteresting
 uninterpretted->uninterpreted
 uninterruped->uninterrupted
 uninterruptable->uninterruptible
@@ -56592,6 +58117,7 @@ unknonw->unknown
 unknonwn->unknown
 unknonws->unknowns
 unknouwn->unknown
+unknowin->unknowing
 unknowngly->unknowingly
 unknwn->unknown
 unknwns->unknowns
@@ -56617,13 +58143,16 @@ unlimeted->unlimited
 unlimitied->unlimited
 unlimted->unlimited
 unline->unlike
+unloadin->unloading
 unloadins->unloading
 unmached->unmatched
 unmainted->unmaintained
 unmanouverable->unmaneuverable, unmanoeuvrable,
 unmaping->unmapping
 unmappend->unmapped
+unmappin->unmapping
 unmarsalling->unmarshalling
+unmarshallin->unmarshalling
 unmaximice->unmaximize
 unmisakable->unmistakable
 unmisakably->unmistakably
@@ -56710,6 +58239,7 @@ unorotated->unrotated
 unoticeable->unnoticeable
 unpacke->unpacked
 unpacket->unpacked
+unpackin->unpacking
 unparseable->unparsable
 unpertubated->unperturbed
 unperturb->unperturbed
@@ -56721,6 +58251,7 @@ unpleasent->unpleasant
 unplesant->unpleasant
 unplesent->unpleasant
 unpluged->unplugged
+unpluggin->unplugging
 unpluging->unplugging
 unprecendented->unprecedented
 unprecidented->unprecedented
@@ -56741,6 +58272,7 @@ unqouted->unquoted
 unqoutes->unquotes
 unqouting->unquoting
 unque->unique
+unquotin->unquoting
 unreacahable->unreachable
 unreacahble->unreachable
 unreacheable->unreachable
@@ -56762,6 +58294,7 @@ unregisted->unregistered
 unregisteing->unregistering
 unregisterd->unregistered
 unregisteres->unregisters, unregistered,
+unregisterin->unregistering
 unregistert->unregistered
 unregistes->unregisters
 unregisting->unregistering
@@ -56831,6 +58364,7 @@ unselecgtes->unselects
 unselecgting->unselecting
 unselecgts->unselects
 unselectabe->unselectable
+unselectin->unselecting
 unseless->useless
 unsepcified->unspecified
 unser->under, unset, unsure, user,
@@ -56849,6 +58383,7 @@ unshfit->unshift
 unshfited->unshifted
 unshfiting->unshifting
 unshfits->unshifts
+unshiftin->unshifting
 unsiged->unsigned
 unsigend->unsigned
 unsignd->unsigned
@@ -56904,6 +58439,7 @@ unssuported->unsupported
 unssupported->unsupported
 unstabel->unstable
 unstability->instability
+unstagin->unstaging
 unstalbe->unstable
 unstall->install, uninstall,
 unstallation->installation, uninstallation,
@@ -56930,6 +58466,7 @@ unsubscirbes->unsubscribes
 unsubscirbing->unsubscribing
 unsubscirption->unsubscription
 unsubscirptions->unsubscriptions
+unsubscribin->unsubscribing
 unsubscritpion->unsubscription
 unsubscritpions->unsubscriptions
 unsubscritpiton->unsubscription
@@ -56988,6 +58525,7 @@ unsuprisingly->unsurprisingly
 unsuprized->unsurprised
 unsuprizing->unsurprising
 unsuprizingly->unsurprisingly
+unsurprisin->unsurprising
 unsurprized->unsurprised
 unsurprizing->unsurprising
 unsurprizingly->unsurprisingly
@@ -57056,6 +58594,7 @@ unweildly->unwieldy
 unwieldly->unwieldy
 unwraped->unwrapped
 unwraping->unwrapping
+unwrappin->unwrapping
 unwrritten->unwritten
 unx->unix
 unxepected->unexpected
@@ -57088,6 +58627,7 @@ upater->updater
 upates->updates
 upating->updating
 upccoming->upcoming
+upcomin->upcoming
 upcomming->upcoming
 updae->update
 updaed->updated
@@ -57103,6 +58643,7 @@ updatees->updates
 updateing->updating
 updatess->updates
 updatig->updating
+updatin->updating
 updatr->updater, update,
 updatrs->updaters, updates,
 updats->updates
@@ -57158,6 +58699,7 @@ upgradded->upgraded
 upgraddes->upgrades
 upgradding->upgrading
 upgradei->upgrade
+upgradin->upgrading
 upgradingn->upgrading
 upgrate->upgrade
 upgrated->upgraded
@@ -57184,6 +58726,7 @@ uplaods->uploads
 upliad->upload
 uploade->upload
 uploades->uploads, uploaded,
+uploadin->uploading
 uploaed->upload, uploaded,
 uploaeded->uploaded
 uploaeding->uploading
@@ -57199,6 +58742,7 @@ uplods->uploads
 upperace->uppercase
 upperaced->uppercased
 upperacing->uppercasing
+uppercasin->uppercasing
 uppler->upper
 uppload->upload
 upploaded->uploaded
@@ -57250,6 +58794,7 @@ upsteraming->upstreaming
 upsterams->upstreams
 upstread->upstream
 upstreamedd->upstreamed
+upstreamin->upstreaming
 upstreammed->upstreamed
 upstreammer->upstreamer
 upstreamming->upstreaming
@@ -57395,6 +58940,7 @@ utililty->utility
 utilis->utilise
 utilisa->utilise
 utilisaton->utilisation
+utilisin->utilising
 utilites->utilities
 utilitisation->utilisation
 utilitise->utilise
@@ -57408,6 +58954,7 @@ utilitizing->utilizing
 utiliz->utilize
 utiliza->utilize
 utilizaton->utilization
+utilizin->utilizing
 utill->until, utils,
 utillisation->utilisation
 utillise->utilise
@@ -57465,6 +59012,7 @@ vaalue->value
 vaalued->valued
 vaalues->values
 vaaluing->valuing
+vaccinatin->vaccinating
 vaccum->vacuum
 vaccume->vacuum
 vaccumed->vacuumed
@@ -57495,6 +59043,7 @@ vacumme->vacuum
 vacummes->vacuums
 vacums->vacuums
 vacuosly->vacuously
+vacuumin->vacuuming
 vaelue->value, valued,
 vaelues->values
 vaguaries->vagaries
@@ -57564,6 +59113,7 @@ valdations->validations
 valdator->validator
 valdators->validators
 valdity->validity
+valetin->valeting
 valetta->valletta
 valeu->value
 valeud->valued
@@ -57652,6 +59202,7 @@ value-to-pack->value to pack
 valueable->valuable
 valuess->values
 valuie->value
+valuin->valuing
 valulation->valuation
 valulations->valuations
 valule->value
@@ -57796,6 +59347,7 @@ vart->cart, wart,
 vartical->vertical
 vartically->vertically
 varts->carts, warts,
+varyin->varying
 vas->was
 vasall->vassal
 vasalls->vassals
@@ -57823,6 +59375,8 @@ vecotrs->vectors
 vectices->vertices
 vectore->vector
 vectores->vectors
+vectorin->vectoring
+vectorizin->vectorizing
 vectorss->vectors
 vectror->vector
 vectrors->vectors
@@ -57874,6 +59428,7 @@ venders->vendors
 venemous->venomous
 vengance->vengeance
 vengence->vengeance
+ventilatin->ventilating
 ventillate->ventilate
 ventillated->ventilated
 ventillates->ventilates
@@ -57954,6 +59509,7 @@ verifyed->verified
 verifyes->verifies
 verifyied->verified
 verifyies->verifies
+verifyin->verifying
 verigated->variegated
 verion->version
 verions->versions
@@ -58001,6 +59557,7 @@ versiomed->versioned
 versioming->versioning
 versioms->versions
 versionaddded->versionadded
+versionin->versioning
 versionm->version
 versionms->versions
 versionn->version
@@ -58075,6 +59632,7 @@ vetically->vertically
 vetinarian->veterinarian
 vetinarians->veterinarians
 vetod->vetoed
+vetoin->vetoing
 vetor->vector, veto,
 vetored->vectored, vetoed,
 vetoring->vectoring, vetoing,
@@ -58088,6 +59646,7 @@ vewer->viewer
 vewers->viewers
 vewing->viewing, vowing, vexing,
 vews->views, vows,
+vexin->vexing
 veyr->very
 vhild->child
 viariable->variable
@@ -58106,14 +59665,17 @@ victemized->victimized
 victemizes->victimizes
 victemizing->victimizing
 victems->victims
+victimizin->victimizing
 victum->victim
 victums->victims
+videostreamin->videostreaming
 videostreamming->videostreaming
 viee->view
 viees->views
 vieport->viewport
 vieports->viewports
 vietnamesea->Vietnamese
+viewin->viewing
 viewtransfromation->viewtransformation
 vigeur->vigueur, vigour, vigor,
 vigilanties->vigilantes
@@ -58139,6 +59701,7 @@ vinyet->vignette
 vinyets->vignettes
 vioalte->violate
 vioaltion->violation
+violatin->violating
 violentce->violence
 violoated->violated
 violoating->violating
@@ -58170,9 +59733,11 @@ virtualiation->virtualization, virtualisation,
 virtualied->virtualized, virtualised,
 virtualisaion->virtualisation
 virtualisaiton->virtualisation
+virtualisin->virtualising
 virtualizaion->virtualization
 virtualizaiton->virtualization
 virtualiziation->virtualization
+virtualizin->virtualizing
 virtualy->virtually
 virtualzation->virtualization
 virtuell->virtual
@@ -58244,6 +59809,7 @@ visisble->visible
 visisbly->visibly
 visiter->visitor, visit,
 visiters->visitors, visits,
+visitin->visiting
 visitng->visiting
 visivble->visible
 vissible->visible
@@ -58276,11 +59842,13 @@ visuaized->visualized
 visuaizes->visualizes
 visuale->visual
 visuales->visuals
+visualisin->visualising
 visualizaion->visualization
 visualizaiton->visualization
 visualizaitons->visualizations
 visualizaton->visualization
 visualizatons->visualizations
+visualizin->visualizing
 visuall->visual, visually,
 visuallisation->visualisation
 visuallization->visualization
@@ -58373,6 +59941,7 @@ vocabualries->vocabularies
 vocabualry->vocabulary
 vocabularlies->vocabularies
 vocabularly->vocabulary
+voidin->voiding
 voif->void
 Voight->Voigt
 volatage->voltage
@@ -58400,11 +59969,13 @@ volounteers->volunteers
 volumn->volume
 volumne->volume
 volums->volume
+volunteerin->volunteering
 volxel->voxel
 volxels->voxels
 vonfig->config
 vor->for
 vould->would
+vowin->vowing
 voxes->voxels, voxel,
 voyour->voyeur
 voyouristic->voyeuristic
@@ -58561,14 +60132,19 @@ wahtever->whatever
 wainting->waiting
 waisline->waistline
 waislines->waistlines
+waitin->waiting
 waitting->waiting
 wakeus->wakeups, wake us, walrus,
+wakin->waking
 wakup->wakeup, walk-up,
 wakups->wakeups, walk-ups,
+walkin->walking
 walkthough->walkthrough, walk though,
 walkthoughs->walkthroughs
+wallowin->wallowing
 wallthickness->wall thickness
 wan't->want, wasn't,
+wantin->wanting
 wantto->want to
 wapped->wrapped, swapped, warped,
 wapper->wrapper
@@ -58617,6 +60193,7 @@ warnkngs->warnings
 warnned->warned
 warnning->warning
 warnnings->warnings
+warpin->warping
 warpped->wrapped, warped,
 warpper->wrapper, warper,
 warpping->wrapping, warping,
@@ -58667,12 +60244,16 @@ weaponaries->weaponry, weaponries,
 weaponary->weaponry
 weappon->weapon
 weappons->weapons
+wearin->wearing
 wearn->warn, wear, earn, learn, worn, yearn,
 wearned->warned, earned, learned, yearned,
 wearning->warning, wearing, earning, learning, yearning, wearying,
 wearnings->warnings, earnings, yearnings,
 wearns->warns, wears, earns, learns, yearns,
+wearyin->wearying
 weas->was
+weatherin->weathering
+weavin->weaving
 webage->webpage
 webages->webpages
 webaserver->web server, webserver,
@@ -58707,6 +60288,8 @@ wehre->where
 wehreas->whereas
 wehrever->wherever
 wehther->whether
+weighin->weighing
+weightin->weighting
 weigth->weight
 weigthed->weighted
 weigths->weights
@@ -58815,8 +60398,11 @@ whiped->whipped, wiped,
 whis->this, whisk,
 whish->wish, whisk,
 whishlist->wishlist
+whisperin->whispering
+whistlin->whistling
 whitch->which
 whitchever->whichever
+whitelistin->whitelisting
 whitepace->whitespace
 whitepaces->whitespaces
 whitepsace->whitespace
@@ -58935,6 +60521,7 @@ winndow->window
 winndows->windows
 winodw->window
 winodws->windows
+wipin->wiping
 wipoing->wiping
 wirded->wired, weird,
 wireframw->wireframe
@@ -58976,6 +60563,7 @@ withdrawl->withdrawal, withdraw,
 witheld->withheld
 withh->with
 withhin->within
+withholdin->withholding
 withhout->without
 withih->within
 withinn->within
@@ -59086,6 +60674,7 @@ womens->women's, women,
 wonce->once, nonce, ponce, wince,
 wonderfull->wonderful
 wonderig->wondering
+wonderin->wondering
 wonderous->wondrous
 wonderously->wondrously
 wondow->window
@@ -59145,6 +60734,7 @@ workes->works
 workfow->workflow
 workfows->workflows
 workign->working
+workin->working
 worklfow->workflow
 worklfows->workflows
 workpsace->workspace
@@ -59182,6 +60772,7 @@ worrried->worried
 worrries->worries
 worrry->worry
 worrrying->worrying
+worryin->worrying
 wors->worse, worst, works, wars, was,
 worser->worse
 worspace->workspace
@@ -59232,6 +60823,7 @@ wrapers->wrappers
 wraping->wrapping, warping,
 wrapp->wrap
 wrappered->wrapped
+wrappin->wrapping
 wrappng->wrapping
 wrappped->wrapped
 wrappper->wrapper
@@ -59245,6 +60837,7 @@ wresselers->wrestlers
 wresseling->wrestling
 wressels->wrestles
 wresters->wrestlers
+wrestlin->wrestling
 wriet->write
 wriets->writes
 writebufer->writebuffer
@@ -59254,6 +60847,8 @@ writeing->writing
 writen->written
 writet->writes
 writewr->writer
+writhin->writhing
+writin->writing
 writingm->writing
 writte->write, written,
 writter->writer, written,
@@ -59356,6 +60951,7 @@ xour->your
 xwindows->X
 xyou->you
 yaching->yachting
+yachtin->yachting
 yaer->year
 yaerly->yearly
 yaers->years
@@ -59364,6 +60960,7 @@ yatching->yachting
 yatchs->yachts
 yau->you, yaw,
 yearm->year
+yearnin->yearning
 yeasr->years
 yeild->yield
 yeilded->yielded
@@ -59426,6 +61023,7 @@ zeored->zeroed
 zeores->zeroes
 zeoring->zeroing
 zeors->zeros
+zeroin->zeroing
 zick-zack->zig-zag
 zick-zacks->zig-zags
 zimmap->zipmap
@@ -59437,6 +61035,7 @@ ziped->zipped
 ziper->zipper
 zipers->zippers
 ziping->zipping
+zippin->zipping
 zlot->slot
 zombe->zombie
 zombes->zombies


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an "*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is now a correction when it is missing a final "g". If the word without a final "g" appeared in the aspell dictionary, it was excluded.