### PR TITLE
Add corrections for all *in->*ing words starting with "B"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7519,6 +7519,7 @@ bassic->basic
 bassically->basically
 bassics->basics
 bassis->basis
+bastardisin->bastardising
 bastardizin->bastardizing
 bastract->abstract
 bastracted->abstracted
@@ -7572,7 +7573,7 @@ beastiaries->bestiaries
 beastiary->bestiary
 beatiful->beautiful
 beatifully->beautifully
-beatin->beating, beat in,
+beatin->beating, beat in, beaten,
 beauquet->bouquet
 beauquets->bouquets
 beauracracy->bureaucracy
@@ -7960,9 +7961,9 @@ bi-langual->bi-lingual
 bianries->binaries
 bianry->binary
 biappicative->biapplicative
-biasin->biasing, bias in,
+biasin->biasing, bias in, basin,
 bicyclin->bicycling
-biddin->bidding
+biddin->bidding, bidden,
 biddings->bidding
 bidimentionnal->bidimensional
 bidings->bindings, bidding,
@@ -7993,7 +7994,7 @@ binanaries->binaries
 binanary->binary
 binar->binary
 binay->binary
-bindin->binding, bind in,
+bindin->binding, bind in, bindi, bindis,
 bindins->bindings
 binidng->binding
 binominal->binomial
@@ -8043,7 +8044,7 @@ biulds->builds
 biult->built, build,
 bivouaced->bivouacked
 bivouacing->bivouacking
-bivouackin->bivouacking
+bivouackin->bivouacking, bivouac in,
 bivwack->bivouac
 biyou->bayou
 biyous->bayous
@@ -8154,7 +8155,7 @@ bobard->board, bombard,
 bocome->become
 boddy->body
 bodiese->bodies
-bodin->boding, bod in,
+bodin->boding, bod in, bodkin, boudin,
 bodydbuilder->bodybuilder
 boelean->boolean
 boeleans->booleans
@@ -8417,7 +8418,7 @@ brach->branch
 brached->branched, breached,
 braches->branches, breaches,
 braching->branching, breaching,
-bracin->bracing
+bracin->bracing, brain,
 brackeds->brackets
 bracketwith->bracket with
 brackground->background
@@ -8745,7 +8746,7 @@ bumber->bumper, bomber, bummer, number,
 bumbing->bumping, bombing,
 bumby->bumpy
 bumpded->bumped
-bumpin->bumping, bump in,
+bumpin->bumping, bump in, bumpkin,
 bumpt->bump
 bumpted->bumped
 bumpter->bumper

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7374,6 +7374,7 @@ backslases->backslashes
 backslashs->backslashes
 backtic->backtick
 backtics->backticks
+backtrackin->backtracking, backtrack in,
 backupped->backed-up, backed up,
 backwad->backwards
 backwar->backward
@@ -7405,6 +7406,7 @@ bahavior->behavior
 bahavioral->behavioral
 bahaviors->behaviors
 bahaviour->behaviour
+bailin->bailing, bail in,
 bais->bias, basis, bails, baits,
 baisc->basic
 baiscally->basically
@@ -7412,6 +7414,7 @@ baiscs->basics
 baised->raised, biased, braised, bailed, baited,
 baises->raises, biases, braises,
 baising->raising, biasing, braising, bailing, baiting,
+baitin->baiting, bait in,
 bakc->back
 bakcend->backend
 bakcends->backends
@@ -7436,6 +7439,7 @@ balacer->balancer
 balacers->balancers
 balaces->balances
 balacing->balancing
+balancin->balancing
 balaster->baluster
 balasters->balusters
 balck->black, balk,
@@ -7515,6 +7519,7 @@ bassic->basic
 bassically->basically
 bassics->basics
 bassis->basis
+bastardizin->bastardizing
 bastract->abstract
 bastracted->abstracted
 bastracter->abstracter
@@ -7567,6 +7572,7 @@ beastiaries->bestiaries
 beastiary->bestiary
 beatiful->beautiful
 beatifully->beautifully
+beatin->beating, beat in,
 beauquet->bouquet
 beauquets->bouquets
 beauracracy->bureaucracy
@@ -7619,6 +7625,7 @@ bechmarking->benchmarking
 bechmarks->benchmarks
 becoem->become
 becomeing->becoming
+becomin->becoming
 becomme->become
 becommes->becomes
 becomming->becoming
@@ -7631,6 +7638,7 @@ becuase->because
 becuse->because
 becuz->because
 becxause->because
+beddin->bedding
 beding->bedding, begging,
 bedore->before
 beecause->because
@@ -7711,6 +7719,7 @@ behaivour->behaviour
 behaivoural->behavioural
 behaivours->behaviours
 behavies->behaves
+behavin->behaving
 behavio->behavior
 behavioal->behavioral
 behavios->behaviors
@@ -7760,6 +7769,7 @@ behvioural->behavioural
 behviours->behaviours
 beigin->begin
 beiginning->beginning
+bein->being, be in,
 beind->behind, being,
 beinning->beginning
 bejond->beyond
@@ -7794,6 +7804,7 @@ beliefe->believe, belief,
 beliefed->believed
 beliefes->beliefs, believes,
 beliefing->believing
+believin->believing
 beligum->belgium
 beling->belong
 beliv->believe, belief,
@@ -7812,6 +7823,7 @@ belog->belong
 beloging->belonging
 belogs->belongs
 belond->belong
+belongin->belonging, belong in,
 beloning->belonging
 belove->below, beloved,
 belowe->below
@@ -7830,6 +7842,7 @@ benchamrk->benchmark
 benchamrked->benchmarked
 benchamrking->benchmarking
 benchamrks->benchmarks
+benchin->benching, bench in,
 benchmkar->benchmark
 benchmkared->benchmarked
 benchmkaring->benchmarking
@@ -7848,6 +7861,7 @@ benefical->beneficial
 beneficary->beneficiary
 benefied->benefited
 benefitial->beneficial
+benefitin->benefiting, benefit in,
 beneits->benefits
 benerate->generate, venerate,
 benetif->benefit
@@ -7895,6 +7909,7 @@ beseiging->besieging
 besic->basic
 besically->basically
 besics->basics
+besiegin->besieging
 besure->be sure
 beteeen->between
 beteen->between
@@ -7945,6 +7960,9 @@ bi-langual->bi-lingual
 bianries->binaries
 bianry->binary
 biappicative->biapplicative
+biasin->biasing, bias in,
+bicyclin->bicycling
+biddin->bidding
 biddings->bidding
 bidimentionnal->bidimensional
 bidings->bindings, bidding,
@@ -7975,6 +7993,7 @@ binanaries->binaries
 binanary->binary
 binar->binary
 binay->binary
+bindin->binding, bind in,
 bindins->bindings
 binidng->binding
 binominal->binomial
@@ -8007,6 +8026,7 @@ bitamps->bitmaps
 bitap->bitmap
 bitfileld->bitfield
 bitfilelds->bitfields
+bitin->biting, bit in,
 bitis->bits
 bitmast->bitmask
 bitnaps->bitmaps
@@ -8023,6 +8043,7 @@ biulds->builds
 biult->built, build,
 bivouaced->bivouacked
 bivouacing->bivouacking
+bivouackin->bivouacking
 bivwack->bivouac
 biyou->bayou
 biyous->bayous
@@ -8057,7 +8078,9 @@ blcokers->blockers
 blcoking->blocking
 blcoks->blocks
 bleading->bleeding
+bleedin->bleeding, bleed in,
 blessd->blessed
+blessin->blessing, bless in,
 blessure->blessing
 bletooth->Bluetooth
 bleutooth->Bluetooth
@@ -8125,11 +8148,13 @@ bnecause->because
 bnndler->bundler
 boads->boards
 boardcast->broadcast
+boardin->boarding, board in,
 boaut->bout, boat, about,
 bobard->board, bombard,
 bocome->become
 boddy->body
 bodiese->bodies
+bodin->boding, bod in,
 bodydbuilder->bodybuilder
 boelean->boolean
 boeleans->booleans
@@ -8147,6 +8172,7 @@ boleen->boolean
 bolor->color
 bombardement->bombardment
 bombarment->bombardment
+bombin->bombing, bomb in,
 bondary->boundary
 Bonnano->Bonanno
 bood->boot
@@ -8160,6 +8186,7 @@ boofays->buffets
 bookeeping->bookkeeping
 bookkeeing->bookkeeping
 bookkeeiping->bookkeeping
+bookkeepin->bookkeeping
 bookkepp->bookkeep
 bookmakr->bookmark
 bookmar->bookmark
@@ -8242,6 +8269,7 @@ bootstraped->bootstrapped
 bootstraper->bootstrapper
 bootstrapers->bootstrappers
 bootstraping->bootstrapping
+bootstrappin->bootstrapping
 bootstras->bootstraps
 bootup->boot up, boot-up,
 booundaries->boundaries
@@ -8324,6 +8352,7 @@ bounaries->boundaries
 bounary->boundary
 bounbdaries->boundaries
 bounbdary->boundary
+bouncin->bouncing
 boundares->boundaries
 boundaryi->boundary
 boundarys->boundaries
@@ -8388,6 +8417,7 @@ brach->branch
 brached->branched, breached,
 braches->branches, breaches,
 braching->branching, breaching,
+bracin->bracing
 brackeds->brackets
 bracketwith->bracket with
 brackground->background
@@ -8396,6 +8426,7 @@ bracnhed->branched
 bracnhes->branches
 bracnhing->branching
 bradcast->broadcast
+braisin->braising
 braket->bracket, brake,
 brakets->brackets, brakes,
 brakpoint->breakpoint
@@ -8408,6 +8439,7 @@ branchces->branches
 branche->branch, branches, branched,
 branchesonly->branches only
 brancheswith->branches with
+branchin->branching, branch in,
 branchs->branches
 branchsi->branches
 brancing->branching, bracing,
@@ -8422,6 +8454,7 @@ braodcasts->broadcasts
 Brasillian->Brazilian
 brazeer->brassiere
 brazillian->Brazilian
+breachin->breaching, breach in,
 breack->break, brake,
 breacket->bracket
 breackets->brackets
@@ -8433,6 +8466,7 @@ breackthrough->breakthrough
 breackthroughs->breakthroughs
 breaked->broken
 breakes->breaks
+breakin->breaking, break in,
 breakthough->breakthrough
 breakthoughs->breakthroughs
 breakthrought->breakthrough
@@ -8441,6 +8475,7 @@ breakthruogh->breakthrough
 breakthruoghs->breakthroughs
 breal->break
 breanches->branches
+breathin->breathing, breath in,
 breating->breathing, beating,
 breef->brief, beef,
 breefly->briefly
@@ -8472,6 +8507,7 @@ brigher->brighter
 brighest->brightest
 brighly->brightly
 brighness->brightness
+brightenin->brightening, brighten in,
 brightnesss->brightness
 brigth->bright
 brigthen->brighten
@@ -8510,6 +8546,7 @@ broadacasting->broadcasting
 broadcas->broadcast
 broadcase->broadcast
 broadcasti->broadcast
+broadcastin->broadcasting, broadcast in,
 broadcat->broadcast
 broady->broadly
 broardcast->broadcast
@@ -8555,6 +8592,7 @@ brower->browser
 browers->browsers
 browing->browsing
 browseable->browsable
+browsin->browsing, brows in,
 browswable->browsable
 browswe->browse
 browswed->browsed
@@ -8563,6 +8601,7 @@ browswers->browsers
 browswing->browsing
 bruse->bruise
 bruses->bruises
+brushin->brushing, brush in,
 brusk->brusque
 brutaly->brutally
 brwosable->browsable
@@ -8584,6 +8623,7 @@ bufers->buffers
 buffereed->buffered
 bufferent->buffered
 bufferes->buffers, buffered,
+bufferin->buffering, buffer in,
 bufferred->buffered
 bufferring->buffering
 buffeur->buffer
@@ -8634,6 +8674,7 @@ buildding->building
 builddings->buildings
 buildds->builds
 builded->built
+buildin->building, build in,
 buildpackge->buildpackage
 buildpackges->buildpackages
 buildt->built, build,
@@ -8704,6 +8745,7 @@ bumber->bumper, bomber, bummer, number,
 bumbing->bumping, bombing,
 bumby->bumpy
 bumpded->bumped
+bumpin->bumping, bump in,
 bumpt->bump
 bumpted->bumped
 bumpter->bumper
@@ -8722,6 +8764,7 @@ bundeles->bundles
 bundeling->bundling
 bundels->bundles
 bunding->binding, bundling, bounding,
+bundlin->bundling
 bunds->binds, bounds,
 bunji->bungee
 bunlde->bundle
@@ -8734,11 +8777,13 @@ bureauracy->bureaucracy
 buring->burying, burning, burin, during,
 burjun->burgeon
 burjuns->burgeons
+burnin->burning, burn in,
 buro->bureau, burro,
 burocratic->bureaucratic
 buros->bureaus, burros,
 burried->buried
 burtst->burst
+buryin->burying, bury in,
 burzwah->bourgeois
 busines->business
 busineses->business, businesses,
@@ -8781,6 +8826,7 @@ byciclist->bicyclist
 bypas->bypass
 bypased->bypassed
 bypasing->bypassing
+bypassin->bypassing, bypass in,
 byte-comiler->byte-compiler
 byte-compilier->byte-compiler
 byte-complier->byte-compiler


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"B" to contain the scope.