### PR TITLE
Add corrections for all *in->*ing words starting with "O"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -38683,7 +38683,7 @@ oger->ogre
 ogerish->ogreish
 ogers->ogres
 oging->going, ogling,
-oglin->ogling
+oglin->ogling, goblin,
 oher->other, her,
 oherwise->otherwise
 ohter->other

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -38303,6 +38303,7 @@ obeserves->observes
 obeserving->observing
 obession->obsession
 obessions->obsessions
+obeyin->obeying, obey in,
 obgect->object
 obgects->objects
 obhect->object
@@ -38328,6 +38329,8 @@ objctives->objectives
 objcts->objects
 objec->object
 objecs->objects
+objectifyin->objectifying, objectify in,
+objectin->objecting, object in, objection,
 objectss->objects
 objejct->object
 objekt->object
@@ -38359,6 +38362,7 @@ obseravtion->observation
 obseravtions->observations
 observ->observe
 observered->observed
+observin->observing
 obsevrer->observer
 obsevrers->observers
 obslete->obsolete
@@ -38379,6 +38383,7 @@ obssessed->obsessed
 obstacal->obstacle
 obstancles->obstacles
 obstruced->obstructed
+obstructin->obstructing, obstruct in, obstruction,
 obsure->obscure
 obtaien->obtain, obtained,
 obtaiend->obtained
@@ -38386,6 +38391,7 @@ obtaiens->obtains
 obtaine->obtain, obtained, obtains,
 obtaines->obtains
 obtainig->obtaining
+obtainin->obtaining, obtain in,
 obtaion->obtain
 obtaioned->obtained
 obtaions->obtains
@@ -38489,6 +38495,7 @@ occuppiers->occupiers
 occuppies->occupies
 occuppy->occupy
 occuppying->occupying
+occupyin->occupying, occupy in,
 occuracy->accuracy
 occurance->occurrence
 occurances->occurrences
@@ -38506,6 +38513,7 @@ occurrance->occurrence
 occurrances->occurrences
 occurrencies->occurrences
 occurrencs->occurrences
+occurrin->occurring
 occurrred->occurred
 occurrrence->occurrence
 occurrrences->occurrences
@@ -38579,6 +38587,7 @@ ofcource->of course
 off-laod->off-load
 off-laoded->off-loaded
 off-laoding->off-loading
+off-loadin->off-loading, off-load in,
 offcers->officers
 offcial->official
 offcially->officially
@@ -38589,6 +38598,7 @@ offenest->oftenest
 offens->offend, offense, offends, offers,
 offerd->offered
 offereings->offerings
+offerin->offering, offer in,
 offest->offset
 offests->offsets
 offet->offset, offer,
@@ -38631,6 +38641,7 @@ offisionados->aficionados
 offlaod->offload
 offlaoded->offloaded
 offlaoding->offloading
+offloadin->offloading, offload in,
 offloded->offloaded
 offred->offered
 offsence->offence
@@ -38643,6 +38654,7 @@ offseted->offsetted
 offseting->offsetting
 offsetp->offset
 offsett->offset
+offsettin->offsetting
 offstets->offsets
 offten->often
 oficial->official
@@ -38671,6 +38683,7 @@ oger->ogre
 ogerish->ogreish
 ogers->ogres
 oging->going, ogling,
+oglin->ogling
 oher->other, her,
 oherwise->otherwise
 ohter->other
@@ -38727,6 +38740,7 @@ omision->omission
 omited->omitted
 omiting->omitting
 omitt->omit
+omittin->omitting
 omlet->omelet
 omlets->omelets
 omlette->omelette
@@ -38767,6 +38781,7 @@ onedimenionsal->one-dimensional
 oneliners->one-liners
 oneyway->oneway
 ongly->only
+ongoin->ongoing
 onl->only
 onlie->online, only,
 onliene->online
@@ -39142,6 +39157,7 @@ opportunites->opportunities
 opportunties->opportunities
 opportunty->opportunity
 opportuny->opportunity
+opposin->opposing
 opposit->opposite
 oppositition->opposition
 opposits->opposites
@@ -39227,6 +39243,7 @@ optimiced->optimized, optimised,
 optimier->optimizer, optimiser,
 optimimum->optimum
 optimisim->optimism
+optimisin->optimising
 optimisitc->optimistic
 optimisitic->optimistic
 optimissm->optimism
@@ -39244,6 +39261,7 @@ optimizier->optimizer
 optimiziers->optimizers
 optimizies->optimizes
 optimiziing->optimizing
+optimizin->optimizing
 optimiztaion->optimization
 optimiztaions->optimizations
 optimiztion->optimization
@@ -39344,8 +39362,10 @@ orcestrated->orchestrated
 orcestrates->orchestrates
 orcestrating->orchestrating
 orcestrator->orchestrator
+orchestratin->orchestrating, orchestration,
 orded->ordered
 orderd->ordered
+orderin->ordering, order in,
 ordert->ordered
 orderves->hors d'oeuvre
 ording->ordering
@@ -39360,10 +39380,12 @@ orgamise->organise
 organim->organism
 organisaion->organisation
 organisaions->organisations
+organisin->organising
 organistion->organisation
 organistions->organisations
 organizaion->organization
 organizaions->organizations
+organizin->organizing
 organiztion->organization
 organiztions->organizations
 organsiation->organisation
@@ -39456,6 +39478,7 @@ origiginally->originally
 origiginals->originals
 originall->original, originally,
 originaly->originally
+originatin->originating, origination,
 originial->original
 originially->originally
 originiated->originated
@@ -39510,6 +39533,7 @@ oscilating->oscillating
 oscilator->oscillator
 oscillater->oscillator, oscillated, oscillates, oscillate,
 oscillaters->oscillators, oscillates,
+oscillatin->oscillating, oscillation,
 oscilliscope->oscilloscope
 oscilliscopes->oscilloscopes
 osffset->offset
@@ -39676,10 +39700,14 @@ oustanding->outstanding
 oustide->outside
 outbut->output
 outbuts->outputs
+outdoin->outdoing, outdo in,
 outgoign->outgoing
+outgoin->outgoing, outgo in,
 outher->other, outer,
 outherwise->otherwise
+outin->outing, out in,
 outisde->outside
+outlinin->outlining
 outllook->outlook
 outloud->out loud
 outoign->outgoing
@@ -39693,6 +39721,7 @@ outperfomeing->outperforming
 outperfoming->outperforming
 outperfomr->outperform
 outperfomring->outperforming
+outperformin->outperforming, outperform in,
 outpout->output
 outpouts->outputs
 outpu->output
@@ -39702,9 +39731,11 @@ outpust->output, outputs,
 outpusts->outputs
 outputed->outputted
 outputing->outputting
+outputtin->outputting
 outrside->outside, other side,
 outselves->ourselves
 outsid->outside
+outstandin->outstanding
 outter->outer
 outtermost->outermost
 outupt->output
@@ -39731,6 +39762,7 @@ oveloading->overloading
 oveloads->overloads
 over-engeneer->over-engineer
 over-engeneering->over-engineering
+over-engineerin->over-engineering, over-engineer in,
 overaall->overall
 overal->overall
 overcompansate->overcompensate
@@ -39739,9 +39771,11 @@ overcompansates->overcompensates
 overcompansating->overcompensating
 overcompansation->overcompensation
 overcompansations->overcompensations
+overcompensatin->overcompensating, overcompensation,
 overengeneer->overengineer
 overengeneering->overengineering
 overfl->overflow
+overflowin->overflowing, overflow in,
 overflw->overflow
 overfow->overflow
 overfowed->overflowed
@@ -39758,6 +39792,7 @@ overiding->overriding
 overlaped->overlapped
 overlaping->overlapping
 overlapp->overlap
+overlappin->overlapping
 overlayed->overlaid
 overlflow->overflow
 overlflowed->overflowed
@@ -39769,6 +39804,7 @@ overlfowing->overflowing
 overlfows->overflows
 overloade->overload
 overloades->overloads, overloaded,
+overloadin->overloading, overload in,
 overlodaded->overloaded
 overloded->overloaded
 overlodes->overloads
@@ -39791,6 +39827,7 @@ overrided->overrode, overridden,
 overriden->overridden
 overrident->overridden
 overridiing->overriding
+overridin->overriding
 overrids->overrides
 overrie->override, ovary,
 overries->overrides, ovaries,
@@ -39811,6 +39848,7 @@ oversubscibe->oversubscribe
 oversubscibed->oversubscribed
 oversubscirbe->oversubscribe
 oversubscirbed->oversubscribed
+oversubscribin->oversubscribing
 overthere->over there
 overun->overrun
 overvise->otherwise
@@ -39822,6 +39860,7 @@ overvrites->overwrites
 overwelm->overwhelm
 overwelming->overwhelming
 overwheliming->overwhelming
+overwhelmin->overwhelming, overwhelm in,
 overwiew->overview
 overwirte->overwrite
 overwirting->overwriting
@@ -39839,6 +39878,7 @@ overwriding->overwriting, overriding,
 overwriteable->overwritable
 overwrited->overwritten, overwrote,
 overwriten->overwritten
+overwritin->overwriting
 overwritren->overwritten
 overwritte->overwrite
 overwrittes->overwrites
@@ -39903,6 +39943,7 @@ ownder->owner
 ownerhsip->ownership
 ownersip->ownership
 ownes->owns, ones,
+ownin->owning, own in,
 ownload->download, own load,
 ownloaded->downloaded, own loaded,
 ownloader->downloader, own loader,


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"O" to contain the scope.