### PR TITLE
Add corrections for all *in->*ing words starting with "S"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -48771,6 +48771,7 @@ sabatoshed->sabotaged
 sabatoshes->sabotages
 sabatoshing->sabotaging
 sabatour->saboteur
+sabotagin->sabotaging
 sacalar->scalar
 sacalars->scalars
 sacale->scale
@@ -48778,6 +48779,7 @@ sacaled->scaled
 sacales->scales
 sacaling->scaling
 sacarin->saccharin
+sackin->sacking, sack in,
 saclar->scalar, sacral,
 saclars->scalars
 sacle->scale, sale, sable,
@@ -48788,6 +48790,7 @@ sacrafice->sacrifice
 sacreligious->sacrilegious
 Sacremento->Sacramento
 sacrifical->sacrificial
+sacrificin->sacrificing
 sacrifying->sacrificing
 sacrilegeous->sacrilegious
 sacrin->saccharin
@@ -48796,6 +48799,7 @@ sade->sad
 saem->same
 safe-pooint->safe-point
 safe-pooints->safe-points
+safeguardin->safeguarding, safeguard in,
 safeguared->safeguard, safeguarded,
 safeing->saving
 safepooint->safepoint
@@ -48809,6 +48813,7 @@ safty->safety
 saggital->sagittal
 sagital->sagittal
 Sagitarius->Sagittarius
+sailin->sailing, sail in,
 sais->says
 saleries->salaries
 salery->salary
@@ -48830,6 +48835,7 @@ sampeld->sampled
 sampels->samples
 sampes->samples
 samping->sampling
+samplin->sampling
 samue->same, Samuel,
 samwich->sandwich
 samwiched->sandwiched
@@ -48843,12 +48849,14 @@ sanatizers->sanitizers
 sanatizes->sanitizes
 sanatizing->sanitizing
 sanaty->sanity
+sanctionin->sanctioning, sanction in,
 sanctionning->sanctioning
 sandobx->sandbox
 sandwhich->sandwich, sand which,
 sandwhiched->sandwiched
 sandwhiches->sandwiches
 sandwhiching->sandwiching
+sandwichin->sandwiching, sandwich in,
 sandwitch->sandwich, sand witch,
 sandwitched->sandwiched
 sandwitches->sandwiches, sand witches,
@@ -48866,6 +48874,8 @@ sanetizers->sanitizers
 sanetizes->sanitizes
 sanetizing->sanitizing
 Sanhedrim->Sanhedrin
+sanitisin->sanitising
+sanitizin->sanitizing
 sanitizisation->sanitization
 sanizer->sanitizer
 sanpshot->snapshot
@@ -48900,6 +48910,7 @@ sapeenaing->subpoenaing
 sapeenas->subpoenas
 saphire->sapphire
 saphires->sapphires
+saplin->sapling
 sargant->sergeant
 sargeant->sergeant
 sarimonial->ceremonial
@@ -48960,6 +48971,7 @@ satisfiy->satisfy
 satisfiying->satisfying
 satisfyied->satisfied
 satisfyies->satisfies
+satisfyin->satisfying, satisfy in,
 satisied->satisfied
 satisies->satisfies
 satisifaction->satisfaction
@@ -49019,6 +49031,7 @@ savely->safely
 savere->severe
 savety->safety
 savgroup->savegroup
+savin->saving
 savve->save, savvy, salve,
 savves->saves, salves,
 savy->savvy
@@ -49034,6 +49047,7 @@ sawteing->sautéing
 sawtes->sautés
 saxaphone->saxophone
 sbsampling->subsampling
+scaffoldin->scaffolding, scaffold in,
 scafold->scaffold
 scafolded->scaffolded
 scafolder->scaffolder
@@ -49045,10 +49059,12 @@ scalarr->scalar
 scaleability->scalability
 scaleable->scalable
 scaleing->scaling
+scalin->scaling
 scalled->scaled
 scandanavia->Scandinavia
 scaned->scanned
 scaning->scanning
+scannin->scanning
 scannning->scanning
 scarch->search, scorch, scratch, starch, scarce,
 scarched->searched, scorched, scratched,
@@ -49140,6 +49156,7 @@ schedul->schedule
 scheduld->scheduled
 schedulier->scheduler
 scheduliers->schedulers
+schedulin->scheduling
 schedulling->scheduling
 scheduls->schedules
 scheduluing->scheduling
@@ -49147,6 +49164,7 @@ schem->scheme
 schematrio->schematron
 schematrion->schematron
 schemd->schemed
+schemin->scheming
 schems->schemes
 schma->schema, schwa,
 schmas->schemas, schwas,
@@ -49161,6 +49179,7 @@ scholarhips->scholarships
 scholarstic->scholastic, scholarly,
 scholdn't->shouldn't
 schoole->schools, schooled,
+schoolin->schooling, school in,
 schould->should
 schow->show, chow,
 schowing->showing, chowing,
@@ -49193,6 +49212,7 @@ sciript->script
 sciripts->scripts
 scirpt->script
 scirpts->scripts
+scissorin->scissoring, scissor in,
 scketch->sketch
 scketched->sketched
 scketches->sketches
@@ -49214,17 +49234,22 @@ scondary->secondary
 scondly->secondly
 sconds->seconds
 scopeing->scoping
+scopin->scoping
+scorchin->scorching, scorch in,
 scorebord->scoreboard
+scorin->scoring
 scource->source, scouse,
 scourced->sourced, scoured,
 scourcer->scourer, sorcerer, scouser,
 scources->sources
+scourgin->scourging
 scrach->scratch
 scrached->scratched
 scraches->scratches
 scraching->scratching
 scrachs->scratches
 scrao->scrap
+scratchin->scratching, scratch in,
 screeb->screen
 screebs->screens
 screebshot->screenshot
@@ -49256,6 +49281,7 @@ scripoting->scripting
 scripots->scripts
 scripst->scripts
 scripte->script, scripted,
+scriptin->scripting, script in,
 scriptype->scripttype
 scrit->script, scrip,
 scritp->script
@@ -49336,6 +49362,7 @@ scuccesses->successes
 scuccessully->successfully
 sculpter->sculptor, sculpture,
 sculpters->sculptors, sculptures,
+sculptin->sculpting, sculpt in,
 scupt->sculpt
 scupted->sculpted
 scupting->sculpting
@@ -49379,6 +49406,7 @@ searhers->searchers
 searhes->searches
 searhing->searching
 seatch->search
+seatin->seating, seat in,
 secceed->succeed
 secceeded->succeeded, seceded,
 secceeding->succeeding, seceding,
@@ -49390,6 +49418,7 @@ seccessfully->successfully
 seccond->second
 secconds->seconds
 secction->section
+secedin->seceding
 seceed->succeed, secede,
 seceeded->succeeded, seceded,
 secenario->scenario
@@ -49460,6 +49489,7 @@ secrity->security
 secruity->security
 sectin->section
 sectins->sections
+sectionin->sectioning, section in,
 sectionis->sections, section is,
 sectionning->sectioning
 sectiont->sectioned, section,
@@ -49507,6 +49537,7 @@ seege->siege
 seeged->sieged
 seeges->sieges
 seeging->sieging
+seein->seeing, see in,
 seelect->select
 seelected->selected
 seemes->seems
@@ -49514,6 +49545,7 @@ seemless->seamless
 seemlessly->seamlessly
 seesion->session
 seesions->sessions
+seethin->seething
 seeting->seating, setting, seething,
 seetings->settings
 seeverities->severities
@@ -49561,6 +49593,7 @@ segmenst->segments
 segmentaion->segmentation
 segmente->segment
 segmentes->segments
+segmentin->segmenting, segment in,
 segmetn->segment
 segmetned->segmented
 segmetns->segments
@@ -49570,6 +49603,7 @@ segmnetations->segmentations
 segmneted->segmented
 segmneting->segmenting
 segmnets->segments
+seguein->segueing, segue in,
 segument->segment
 seguoys->segues
 segway->segue
@@ -49585,6 +49619,7 @@ seive->sieve
 seived->sieved
 seives->sieves
 seiving->sieving
+seizin->seizing
 sekect->select
 sekected->selected
 sekects->selects
@@ -49691,6 +49726,7 @@ self-contianed->self-contained
 self-opinyonated->self-opinionated
 self-referencial->self-referential
 self-refering->self-referring
+self-referrin->self-referring
 selfs->self
 sellect->select
 sellected->selected
@@ -49750,6 +49786,7 @@ sencond->second
 sencondary->secondary
 senconds->seconds
 sendign->sending
+sendin->sending, send in,
 sendinging->sending
 sendinng->sending
 senegraph->scenegraph, scene graph,
@@ -49827,6 +49864,7 @@ separatedly->separately
 separatelly->separately
 separater->separator, separated, separates, separate,
 separaters->separators, separates,
+separatin->separating, separation,
 separatley->separately
 separatly->separately
 separato->separator
@@ -50055,6 +50093,7 @@ sequenc->sequence
 sequencial->sequential
 sequencially->sequentially
 sequencies->sequences
+sequencin->sequencing
 sequencs->sequences, sequence,
 sequene->sequence
 sequenes->sequences
@@ -50144,6 +50183,8 @@ serialiaze->serialize
 serialiazed->serialized
 serialiazes->serializes
 serialiazing->serializing
+serialisin->serialising
+serializin->serializing
 serialsiation->serialisation
 serialsie->serialise
 serialsied->serialised
@@ -50224,8 +50265,10 @@ serverles->serverless
 serverlesss->serverless
 serverlsss->serverless
 servicies->services
+servicin->servicing
 servie->service
 servies->services
+servin->serving
 servise->service
 servised->serviced
 servises->services
@@ -50301,6 +50344,7 @@ settin->setting
 settinga->settings
 settingss->settings
 settins->settings
+settlin->settling
 settlment->settlement
 settng->setting
 settngs->settings
@@ -50347,8 +50391,10 @@ shadasloo->shadaloo
 shaddow->shadow
 shadhow->shadow
 shadoloo->shadaloo
+shadowin->shadowing, shadow in,
 shal->shall
 shamen->shaman, shamans,
+shamin->shaming, sham in,
 shandeleer->chandelier
 shandeleers->chandeliers
 shandow->shadow
@@ -50359,6 +50405,7 @@ shanger->changer
 shanges->changes
 shanghi->Shanghai
 shanging->changing, shanking,
+shapin->shaping
 shapshot->snapshot
 shapshots->snapshots
 shapsnot->snapshot
@@ -50366,6 +50413,7 @@ shapsnots->snapshots
 shapt->shaped, shape,
 shareed->shared
 shareing->sharing
+sharin->sharing
 sharloton->charlatan
 sharraid->charade
 sharraids->charades
@@ -50421,6 +50469,7 @@ shepered->shepherd
 sheperedly->shepherdly
 shepereds->shepherds
 shepes->shapes
+shepherdin->shepherding, shepherd in,
 sheping->shaping
 shepperd->shepherd
 shepperded->shepherded
@@ -50440,14 +50489,18 @@ shfting->shifting
 shfts->shifts
 shgould->should
 shicane->chicane
+shieldin->shielding, shield in,
 shif->shift
 shif-tab->shift-tab
 shifed->shifted
 shifing->shifting
 shifs->shifts
+shiftin->shifting, shift in,
 shineing->shining
+shinin->shining, shin in,
 shiped->shipped
 shiping->shipping
+shippin->shipping
 shoft->shift, short,
 shoftware->software
 shoild->should
@@ -50459,6 +50512,7 @@ sholuld->should
 sholuldn't->shouldn't
 shoould->should
 shopkeeepers->shopkeepers
+shoppin->shopping
 shopuld->should
 shorctut->shortcut
 shorctuts->shortcuts
@@ -50470,6 +50524,7 @@ short-cicruits->short-circuits
 shortand->shorthand
 shortcat->shortcut
 shortcats->shortcuts
+shortcomin->shortcoming
 shortcomming->shortcoming
 shortcommings->shortcomings
 shortcutt->shortcut
@@ -50516,6 +50571,7 @@ shouuldn't->shouldn't
 shouw->show
 shouws->shows
 showfer->chauffeur, shower,
+showin->showing, show in,
 showvinism->chauvinism
 shpae->shape
 shpaes->shapes
@@ -50528,6 +50584,7 @@ shreak->shriek
 shreshold->threshold
 shriks->shrinks
 shrinked->shrunk, shrank,
+shrinkin->shrinking, shrink in,
 shrtcut->shortcut
 shrtcuts->shortcuts
 shs->ssh, NHS,
@@ -50541,6 +50598,7 @@ shtoppes->stops, shops,
 shtopping->stopping, shopping,
 shtops->stops, shops,
 shttp->https
+shuckin->shucking, shuck in,
 shudown->shutdown
 shufle->shuffle
 shuld->should
@@ -50551,6 +50609,8 @@ shurely->surely
 shutdownm->shutdown
 shuting->shutting
 shutodwn->shutdown
+shuttin->shutting
+shuttlin->shuttling
 shwo->show
 shwon->shown
 shystem->system
@@ -50560,6 +50620,7 @@ shystems->systems
 shystemwindow->systemwindow, system window,
 sibiling->sibling
 sibilings->siblings
+siblin->sibling
 sibtitle->subtitle
 sibtitles->subtitles
 sicinct->succinct
@@ -50573,6 +50634,7 @@ siduction->seduction
 sie->size, sigh, side,
 sience->science, silence,
 sies->size, sighs, sides,
+sievin->sieving
 siez->size, seize,
 sieze->seize, size,
 siezed->seized, sized,
@@ -50619,7 +50681,9 @@ sigles->singles, sigils,
 sigleton->singleton
 signabl->signable, signal,
 signales->signals
+signalin->signaling, signal in,
 signall->signal
+signallin->signalling
 signatue->signature
 signatur->signature
 signes->signs
@@ -50657,6 +50721,7 @@ signifigant->significant
 signifigantly->significantly
 signifiy->signify
 signifiying->signifying
+signifyin->signifying, signify in,
 signitories->signatories
 signitory->signatory
 signiture->signature
@@ -50684,6 +50749,7 @@ sigurets->cigarettes
 sigurette->cigarette
 silabus->syllabus
 silabuses->syllabuses
+silencin->silencing
 silentely->silently
 silenty->silently
 silhouete->silhouette
@@ -50691,6 +50757,7 @@ silhoueted->silhouetted
 silhouetes->silhouettes
 silhoueting->silhouetting
 silhouetist->silhouettist
+silhouettin->silhouetting
 silhouwet->silhouette
 silhouweted->silhouetted
 silhouwetes->silhouettes
@@ -50837,6 +50904,7 @@ simplificaitons->simplifications
 simplifing->simplifying
 simplifiy->simplify
 simplifiying->simplifying
+simplifyin->simplifying, simplify in,
 simplifys->simplifies
 simpliifcation->simplification
 simpliifcations->simplifications
@@ -50901,6 +50969,7 @@ simulatenous->simultaneous
 simulatenously->simultaneously
 simulater->simulators, simulated, simulates, simulate,
 simulaters->simulators, simulates,
+simulatin->simulating, simulation,
 simultaenous->simultaneous
 simultaenously->simultaneously
 simultanaeous->simultaneous
@@ -50948,6 +51017,7 @@ singl->single
 singlar->singular
 single-threded->single-threaded
 singlely->singly
+singlin->singling
 singls->singles, single,
 singlton->singleton
 singltons->singletons
@@ -51094,8 +51164,10 @@ sitirs->stirs
 sitl->still
 sitll->still
 sitmuli->stimuli
+sittin->sitting
 situaion->situation
 situaions->situations
+situatin->situating, situation,
 situationals->situational, situations,
 situationly->situationally, situational,
 situationnal->situational
@@ -51131,17 +51203,20 @@ sizemologists->seismologists
 sizemologogical->seismological
 sizemologogically->seismologically
 sizemology->seismology
+sizin->sizing
 sizor->sizer, scissor,
 sizors->sizers, scissors,
 sizre->size
 Skagerak->Skagerrak
 skalar->scalar
 skateing->skating
+skatin->skating
 skecth->sketch
 skecthes->sketches
 skeep->skip
 skelton->skeleton
 skept->skipped
+sketchin->sketching, sketch in,
 sketchs->sketches
 sketck->sketch, skate,
 sketcked->sketched, skated,
@@ -51156,6 +51231,7 @@ skiped->skipped, skyped,
 skiping->skipping
 skipp->skip, skipped,
 skippd->skipped
+skippin->skipping
 skippped->skipped
 skippps->skips
 skipps->skips
@@ -51204,7 +51280,9 @@ sleector->selector
 sleectors->selectors
 sleects->selects
 sleeped->slept
+sleepin->sleeping, sleep in,
 sleepp->sleep
+sleuthin->sleuthing, sleuth in,
 slewth->sleuth
 slewthed->sleuthed
 slewthing->sleuthing
@@ -51227,6 +51305,7 @@ sligt->slight
 sligth->slight
 sligthly->slightly
 sligtly->slightly
+slin->sling
 sliped->slipped
 sliseshow->slideshow
 slite->sleight, elite, slide, site,
@@ -51249,6 +51328,7 @@ smapling->sampling
 smealting->smelting
 smebody->somebody
 smehow->somehow
+smeltin->smelting, smelt in,
 smeone->someone
 smething->something
 smetime->sometime
@@ -51269,6 +51349,7 @@ smoewhere->somewhere
 smoot->smooth
 smooter->smoother
 smoothign->smoothing
+smoothin->smoothing, smooth in,
 smooting->smoothing
 smouth->smooth
 smouthness->smoothness
@@ -51280,13 +51361,16 @@ snaphots->snapshots
 snaphsot->snapshot
 snaphsots->snapshots
 snaping->snapping
+snappin->snapping
 snappng->snapping
 snapshoted->snapshotted
 snapshoting->snapshotting
 snapsnot->snapshot
 snapsnots->snapshots
+snarlin->snarling, snarl in,
 snashot->snapshot
 snashots->snapshots
+snatchin->snatching, snatch in,
 sneeks->sneaks
 snese->sneeze
 snipet->snippet
@@ -51367,10 +51451,12 @@ solate->isolate
 solated->isolated
 solates->isolates
 solating->isolating
+solderin->soldering, solder in,
 soldger->soldier
 soldgered->soldiered
 soldgering->soldiering
 soldgers->soldiers
+soldierin->soldiering, soldier in,
 soler->solver, solar, solely,
 soley->solely
 solf->solve, sold,
@@ -51401,6 +51487,7 @@ soluton->solution
 solutons->solutions
 solveable->solvable
 solveing->solving
+solvin->solving
 solwed->solved
 som->some
 sombody->somebody
@@ -51430,6 +51517,7 @@ somethign->something
 somethime->sometime
 somethimes->sometimes
 somethimg->something
+somethin->something
 somethiong->something
 sometiem->sometime, sometimes,
 sometiems->sometimes
@@ -51531,6 +51619,7 @@ sorrounds->surrounds
 sortcut->shortcut
 sortcuts->shortcuts
 sortig->sorting
+sortin->sorting, sort in,
 sortings->sorting
 sortlst->sortlist
 sortner->sorter
@@ -51563,6 +51652,7 @@ souldn't->shouldn't
 soultion->solution
 soultions->solutions
 soundard->soundcard
+soundin->sounding, sound in,
 sountrack->soundtrack
 sourbraten->sauerbraten
 sourc->source
@@ -51571,6 +51661,7 @@ sourcde->sourced, source,
 sourcedrectory->sourcedirectory
 sourcee->source
 sourcees->sources
+sourcin->sourcing
 sourcs->sources, source,
 sourcse->sources, source,
 sourct->source
@@ -51634,6 +51725,7 @@ spacifiers->specifiers, pacifiers,
 spacifies->specifies, pacifies,
 spacify->specify, pacify,
 spacifying->specifying, pacifying,
+spacin->spacing
 spaece->space
 spaeced->spaced
 spaeces->spaces
@@ -51644,6 +51736,7 @@ spagheti->spaghetti
 spagnum->sphagnum
 spainish->Spanish
 spaning->spanning
+spannin->spanning
 sparate->separate
 sparated->separated
 sparately->separately
@@ -51661,6 +51754,7 @@ spaw->spawn
 spawed->spawned
 spawing->spawning
 spawining->spawning
+spawnin->spawning, spawn in,
 spaws->spawns
 spcae->space
 spcaed->spaced
@@ -51690,6 +51784,7 @@ speading->spreading, speeding, spending, speaking,
 speads->spreads, speeds, spends, speaks, spears,
 speadsheet->spreadsheet
 speadsheets->spreadsheets
+speakin->speaking, speak in,
 spearate->separate
 spearated->separated
 spearately->separately
@@ -51739,9 +51834,11 @@ speciafied->specified
 specialiced->specialised, specialized,
 specialisaiton->specialisation
 specialisaitons->specialisations
+specialisin->specialising
 specialitzed->specialised, specialized,
 specializaiton->specialization
 specializaitons->specializations
+specializin->specializing
 speciall->special, specially,
 speciallized->specialised, specialized,
 specialy->specially
@@ -51870,6 +51967,7 @@ specift->specify
 specifyed->specified
 specifyied->specified
 specifyig->specifying
+specifyin->specifying, specify in,
 specifyinhg->specifying
 speciic->specific
 speciied->specified
@@ -51913,6 +52011,7 @@ spedified->specified
 spedify->specify
 speeak->speak
 speeaking->speaking
+speedin->speeding, speed in,
 speeed->speed
 speeeding->speeding
 speeeds->speeds
@@ -52199,7 +52298,10 @@ speicific->specific
 speicified->specified
 speicify->specify
 speling->spelling
+spellcheckin->spellchecking, spellcheck in,
+spellin->spelling, spell in,
 spellshecking->spellchecking
+spendin->spending, spend in,
 spendour->splendour
 speparate->separate
 speparated->separated
@@ -52258,6 +52360,7 @@ spezify->specify
 spicific->specific
 spicified->specified
 spicify->specify
+spielin->spieling, spiel in,
 spile->spite, spiral,
 spilts->splits
 spiltting->splitting
@@ -52278,6 +52381,7 @@ splite->split, splits, splice,
 splited->split
 spliting->splitting
 splitted->split
+splittin->splitting
 splittng->splitting
 spllitting->splitting
 spoace->space
@@ -52309,6 +52413,7 @@ spports->supports
 spreaded->spread
 spreadhseet->spreadsheet
 spreadhseets->spreadsheets
+spreadin->spreading, spread in,
 spreadsheat->spreadsheet
 spreadsheats->spreadsheets
 spreasheet->spreadsheet
@@ -52320,7 +52425,9 @@ sprecially->specially
 spred->spread
 spredsheet->spreadsheet
 spreedsheet->spreadsheet
+sprin->spring
 sprinf->sprintf
+springin->springing, spring in,
 spript->script
 spripted->scripted
 spripting->scripting
@@ -52351,9 +52458,14 @@ sqaured->squared
 sqaures->squares
 sqeuence->sequence
 sqllite->SQLite
+squarin->squaring
 squashgin->squashing
+squashin->squashing, squash in,
+squattin->squatting
+squawkin->squawking, squawk in,
 squence->sequence
 squirel->squirrel
+squirin->squiring
 squirl->squirrel
 squrared->squared
 squre->square, sure, squire,
@@ -52438,6 +52550,7 @@ stabilite->stabilize
 stabilited->stabilized
 stabilites->stabilizes
 stabiliting->stabilizing
+stabilizin->stabilizing
 stabillity->stability
 stabilty->stability
 stabilzation->stabilization
@@ -52507,6 +52620,8 @@ standalown->standalone, stand-alone,
 standar->standard
 standarad->standard
 standard-complient->standard-compliant
+standardisin->standardising
+standardizin->standardizing
 standardss->standards
 standarisation->standardisation
 standarise->standardise
@@ -52661,17 +52776,21 @@ stautses->statuses
 stawberries->strawberries
 stawberry->strawberry
 stawk->stalk
+stayin->staying, stay in,
 stcokbrush->stockbrush
 stdanard->standard
 stdanards->standards
+steamin->steaming, steam in,
 stegnographic->steganographic
 stegnography->steganography
+stemmin->stemming
 stength->strength
 steram->stream
 steramed->streamed
 steramer->streamer
 steraming->streaming
 sterams->streams
+sterilizin->sterilizing
 sterio->stereo
 steriods->steroids
 sterotype->stereotype
@@ -52682,6 +52801,7 @@ stetches->stretches, sketches, stitches, stenches,
 stetching->stretching, sketching, stitching,
 stickness->stickiness
 stickyness->stickiness
+stiffenin->stiffening, stiffen in,
 stiffneing->stiffening
 stiky->sticky
 stil->still
@@ -52693,7 +52813,9 @@ stiring->stirring
 stirng->string
 stirngs->strings
 stirr->stir
+stirrin->stirring
 stirrs->stirs
+stitchin->stitching, stitch in,
 stivk->stick
 stivks->sticks
 stle->style
@@ -52723,6 +52845,7 @@ stoopidly->stupidly
 stoped->stopped
 stoping->stopping
 stopp->stop
+stoppin->stopping
 stoppped->stopped
 stoppping->stopping
 stopps->stops
@@ -52737,6 +52860,7 @@ storege->storage
 storeing->storing
 storeis->stories, stores, store is, storeys,
 storge->storage
+storin->storing
 storise->stories
 stornegst->strongest
 storys->stories, storeys,
@@ -52756,6 +52880,7 @@ stragety->strategy
 straigh->straight
 straigh-forward->straightforward
 straighforward->straightforward
+straightenin->straightening, straighten in,
 straightfoward->straightforward
 straigt->straight
 straigtforward->straightforward
@@ -52789,6 +52914,8 @@ strcutre->structure
 strcutural->structural
 strcuture->structure
 strcutures->structures
+streamin->streaming, stream in,
+streamlinin->streamlining
 streamm->stream
 streammed->streamed
 streamming->streaming
@@ -52840,11 +52967,13 @@ strengten->strengthen
 strengtened->strengthened
 strengtening->strengthening
 strengtens->strengthens
+strengthenin->strengthening, strengthen in,
 strengts->strengths
 strenous->strenuous
 strentgh->strength
 strenth->strength
 strerrror->strerror
+stretchin->stretching, stretch in,
 striaght->straight
 striaghten->straighten
 striaghtens->straightens
@@ -52870,6 +52999,7 @@ strin->string, strine, stein,
 stringifed->stringified
 strinsg->strings
 strippen->stripped
+strippin->stripping
 stript->stripped, script,
 stripted->scripted, stripped,
 stripting->scripting, stripping,
@@ -52883,6 +53013,8 @@ stroe->store, stroke, strobe, strove, strode,
 stroed->stored, stroked, strode,
 stroes->stores, strokes, strobes,
 stroing->storing, string, strong, stroking,
+strokin->stroking
+strollin->strolling, stroll in,
 stronlgy->strongly
 stronly->strongly
 strorage->storage
@@ -52937,6 +53069,7 @@ structues->structures
 structuing->structuring
 structur->structure
 structurd->structured
+structurin->structuring
 structurs->structures
 strucur->structure
 strucural->structural
@@ -52962,6 +53095,7 @@ struggeled->struggled
 struggeles->struggles
 struggeling->struggling
 struggels->struggles
+strugglin->struggling
 strust->trust, strut,
 struttural->structural
 strutture->structure
@@ -53000,6 +53134,8 @@ studing->studying
 studis->studies, studios,
 studoi->studio
 studois->studios
+studyin->studying, study in,
+stuffin->stuffing, stuff in,
 stuggle->struggle
 stuggled->struggled
 stuggles->struggles
@@ -53040,6 +53176,7 @@ stying->staying, styling,
 styless->styles, styleless,
 stylessheet->stylesheet, stylesheets,
 stylessheets->stylesheets
+stylin->styling
 sub-lcuase->sub-clause
 subbtle->subtle
 subcatagories->subcategories
@@ -53116,6 +53253,7 @@ submited->submitted
 submiting->submitting
 submition->submission
 submitions->submissions
+submittin->submitting
 submittion->submission
 submittions->submissions
 submittted->submitted
@@ -53175,6 +53313,7 @@ suboutine->subroutine
 subpackge->subpackage
 subpackges->subpackages
 subpecies->subspecies
+subpoenain->subpoenaing, subpoena in,
 subporgram->subprogram
 subproccese->subprocess
 subpsace->subspace
@@ -53204,6 +53343,7 @@ subscirbing->subscribing
 subscirpt->subscript
 subscirption->subscription
 subscirptions->subscriptions
+subscribin->subscribing
 subscribtion->subscription
 subscribtions->subscriptions
 subscritpion->subscription
@@ -53328,6 +53468,7 @@ subtitutes->substitutes
 subtituting->substituting
 subtitution->substitution
 subtitutions->substitutions
+subtractin->subtracting, subtract in, subtraction,
 subtrafuge->subterfuge
 subtrate->substrate
 subtrates->substrates
@@ -53374,6 +53515,7 @@ succeds->succeeds
 succee->succeed
 succeedde->succeeded
 succeedes->succeeds
+succeedin->succeeding, succeed in,
 succeeed->succeed, succeeded,
 succeeeded->succeeded
 succeeeding->succeeding
@@ -53543,6 +53685,7 @@ sucsession->succession
 sucsessive->successive
 sucsessor->successor
 sucsessors->successors
+suctionin->suctioning, suction in,
 sude->sudo, side, sure, dude, suede, sued,
 sudent->student
 sudents->students
@@ -53561,6 +53704,7 @@ suffciency->sufficiency
 suffcient->sufficient
 suffciently->sufficiently
 sufferage->suffrage
+sufferin->suffering, suffer in,
 sufferred->suffered
 sufferring->suffering
 sufficate->suffocate
@@ -53580,6 +53724,8 @@ suffiency->sufficiency
 suffient->sufficient
 suffiently->sufficiently
 suffisticated->sophisticated
+suffixin->suffixing, suffix in,
+suffocatin->suffocating, suffocation,
 suficate->suffocate
 suficated->suffocated
 suficates->suffocates
@@ -53642,6 +53788,7 @@ sugguests->suggests
 suh->such
 suiete->suite
 suiteable->suitable
+sullyin->sullying, sully in,
 sumamry->summary
 sumaries->summaries
 sumarisation->summarisation
@@ -53665,7 +53812,9 @@ sumbodule->submodule
 sumbodules->submodules
 sumed-up->summed-up
 summar->summary, summer,
+summarisin->summarising
 summarizen->summarize
+summarizin->summarizing
 summay->summary
 summeries->summaries
 summerisation->summarisation
@@ -53742,6 +53891,7 @@ superintendant->superintendent
 superios->superior, superiors,
 superopeator->superoperator
 supersed->superseded
+supersedin->superseding
 superseed->supersede
 superseedd->superseded
 superseede->supersede
@@ -53808,6 +53958,8 @@ suppied->supplied
 suppier->supplier
 suppies->supplies
 supplamented->supplemented
+supplantin->supplanting, supplant in,
+supplementin->supplementing, supplement in,
 suppliad->supplied
 suppliementing->supplementing
 suppliment->supplement
@@ -53818,6 +53970,7 @@ supplimenting->supplementing
 suppliments->supplements
 suppling->supplying
 supplyed->supplied
+supplyin->supplying, supply in,
 suppoed->supposed
 suppoert->support
 suppoerted->supported
@@ -53854,6 +54007,7 @@ supposeded->supposed
 supposedely->supposedly
 supposeds->supposed
 supposedy->supposedly
+supposin->supposing
 supposingly->supposedly
 suppossed->supposed
 suppost->support, suppose, supports,
@@ -53886,6 +54040,7 @@ suppreses->suppresses
 suppresing->suppressing
 suppresion->suppression
 suppresions->suppressions
+suppressin->suppressing, suppress in, suppression,
 suppressingd->suppressing
 supprot->support
 supproted->supported
@@ -53977,6 +54132,7 @@ surounded->surrounded
 surounding->surrounding
 suroundings->surroundings
 surounds->surrounds
+surpassin->surpassing, surpass in,
 surpise->surprise
 surpised->surprised
 surpises->surprises
@@ -53991,6 +54147,7 @@ surpresses->suppresses
 surpressing->suppressing
 surpression->suppression
 surpressions->suppressions
+surprisin->surprising
 surprisinlgy->surprisingly
 surprize->surprise
 surprized->surprised
@@ -53998,6 +54155,7 @@ surprizing->surprising
 surprizingly->surprisingly
 surregat->surrogate
 surrended->surrounded, surrendered,
+surrenderin->surrendering, surrender in,
 surrepetitious->surreptitious
 surrepetitiously->surreptitiously
 surreptious->surreptitious
@@ -54013,6 +54171,7 @@ surrouded->surrounded
 surrouding->surrounding
 surroudings->surroundings
 surrouds->surrounds
+surroundin->surrounding, surround in,
 surrround->surround
 surrrounded->surrounded
 surrrounding->surrounding
@@ -54030,6 +54189,7 @@ survices->services, survives,
 surviver->survivor
 survivers->survivors
 survivied->survived
+survivin->surviving
 susbcribe->subscribe
 susbcribed->subscribed
 susbcriber->subscriber
@@ -54076,7 +54236,9 @@ susequently->subsequently
 susinct->succinct
 susinctly->succinctly
 susinkt->succinct
+suspectin->suspecting, suspect in,
 suspedn->suspend
+suspendin->suspending, suspend in,
 suspeneded->suspended
 suspention->suspension
 suspicios->suspicious
@@ -54132,6 +54294,7 @@ swalloed->swallowed
 swaped->swapped
 swapiness->swappiness
 swaping->swapping
+swappin->swapping
 swarmin->swarming
 swcloumns->swcolumns
 swepth->swept
@@ -54146,6 +54309,9 @@ swicthed->switched
 swicthes->switches
 swicthing->switching
 swiming->swimming
+swimmin->swimming
+swishin->swishing, swish in,
+switchin->switching, switch in,
 switchs->switches
 switcht->switched, switch,
 switchted->switched
@@ -54268,6 +54434,7 @@ symbo->symbol
 symbolc->symbolic
 symbole->symbol
 symboles->symbols
+symbolizin->symbolizing
 symboll->symbol
 symbollic->symbolic
 symbolls->symbols
@@ -54340,12 +54507,15 @@ synchroneous->synchronous
 synchroneously->synchronously
 synchronious->synchronous
 synchroniously->synchronously
+synchronisin->synchronising
 synchronizaton->synchronization
+synchronizin->synchronizing
 synchronsouly->synchronously
 synchronuous->synchronous
 synchronuously->synchronously
 synchronus->synchronous
 synchronusly->synchronously
+syncin->syncing, sync in,
 syncrhonisation->synchronisation
 syncrhonise->synchronise
 syncrhonised->synchronised
@@ -54447,6 +54617,8 @@ syntethics->synthetics
 syntetic->synthetic
 syntetize->synthesize
 syntetized->synthesized
+synthesisin->synthesising, synthesis in,
+synthesizin->synthesizing
 synthethic->synthetic
 synthetize->synthesize
 synthetized->synthesized
@@ -54478,6 +54650,8 @@ sysmte->system
 sysmtes->systems
 systax->syntax
 syste->system
+systematisin->systematising
+systematizin->systematizing
 systemn->system
 systemwindiow->systemwindow, system window,
 systen->system

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -49031,7 +49031,7 @@ savely->safely
 savere->severe
 savety->safety
 savgroup->savegroup
-savin->saving
+savin->saving, satin, sarin,
 savve->save, savvy, salve,
 savves->saves, salves,
 savy->savvy
@@ -49406,7 +49406,7 @@ searhers->searchers
 searhes->searches
 searhing->searching
 seatch->search
-seatin->seating, seat in,
+seatin->seating, seat in, satin, statin,
 secceed->succeed
 secceeded->succeeded, seceded,
 secceeding->succeeding, seceding,
@@ -49537,7 +49537,7 @@ seege->siege
 seeged->sieged
 seeges->sieges
 seeging->sieging
-seein->seeing, see in,
+seein->seeing, see in, seen, stein,
 seelect->select
 seelected->selected
 seemes->seems
@@ -49619,7 +49619,6 @@ seive->sieve
 seived->sieved
 seives->sieves
 seiving->sieving
-seizin->seizing
 sekect->select
 sekected->selected
 sekects->selects
@@ -50413,7 +50412,7 @@ shapsnots->snapshots
 shapt->shaped, shape,
 shareed->shared
 shareing->sharing
-sharin->sharing
+sharin->sharing, sharia, sarin,
 sharloton->charlatan
 sharraid->charade
 sharraids->charades
@@ -51210,7 +51209,7 @@ sizre->size
 Skagerak->Skagerrak
 skalar->scalar
 skateing->skating
-skatin->skating
+skatin->skating, statin,
 skecth->sketch
 skecthes->sketches
 skeep->skip
@@ -52425,7 +52424,7 @@ sprecially->specially
 spred->spread
 spredsheet->spreadsheet
 spreedsheet->spreadsheet
-sprin->spring
+sprin->spring, sprint, spin, Spain, sarin, sprig, sprit,
 sprinf->sprintf
 springin->springing, spring in,
 spript->script
@@ -52465,7 +52464,7 @@ squattin->squatting
 squawkin->squawking, squawk in,
 squence->sequence
 squirel->squirrel
-squirin->squiring
+squirin->squiring, squirm,
 squirl->squirrel
 squrared->squared
 squre->square, sure, squire,
@@ -52776,7 +52775,7 @@ stautses->statuses
 stawberries->strawberries
 stawberry->strawberry
 stawk->stalk
-stayin->staying, stay in,
+stayin->staying, stay in, stain,
 stcokbrush->stockbrush
 stdanard->standard
 stdanards->standards

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -227,6 +227,7 @@ sates->states
 savable->saveable
 scrip->script
 scrips->scripts
+seizin->seizing
 setts->sets
 shat->that, shit,
 sightly->slightly


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"S" to contain the scope.