### PR TITLE
Add corrections for all *in->*ing words starting with "M"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -34555,6 +34555,7 @@ maibox->mailbox
 mailformed->malformed
 mailicious->malicious
 mailiciously->maliciously
+mailin->mailing, mail in,
 mailling->mailing
 maillinglist->mailing list
 maillinglists->mailing lists
@@ -34586,6 +34587,7 @@ maintaince->maintenance
 maintainces->maintenances
 maintainence->maintenance
 maintaing->maintaining
+maintainin->maintaining, maintain in,
 maintaint->maintain
 maintainted->maintained
 maintainter->maintainer
@@ -34639,6 +34641,7 @@ makeing->making
 makfile->makefile
 makfiles->makefiles
 makign->making
+makin->making
 makretplace->marketplace
 makro->macro
 makros->macros
@@ -34655,6 +34658,7 @@ maliciusly->maliciously
 malicous->malicious
 malicousally->maliciously
 malicously->maliciously
+malignin->maligning, malign in,
 maline->malign
 malined->maligned
 malining->maligning
@@ -34690,6 +34694,7 @@ managenment->management
 managerment->management
 managet->manager
 managets->managers
+managin->managing
 managmenet->management
 managment->management
 manaise->mayonnaise
@@ -34721,6 +34726,7 @@ manetainer->maintainer
 manetainers->maintainers
 manetaining->maintaining
 manetains->maintains
+maneuverin->maneuvering, maneuver in,
 manfest->manifest
 manfested->manifested
 manfesting->manifesting
@@ -34757,6 +34763,7 @@ manifacturer->manufacturer
 manifacturers->manufacturers
 manifactures->manufactures
 manifect->manifest
+manifestin->manifesting, manifest in,
 manifiest->manifest
 manifiested->manifested
 manifiesting->manifesting
@@ -34794,6 +34801,7 @@ mannually->manually
 mannualy->manually
 manoeuverability->maneuverability
 manoeuvering->maneuvering
+manoeuvrin->manoeuvring
 manouevring->manoeuvring
 manouver->maneuver, manoeuvre,
 manouverability->maneuverability, manoeuvrability,
@@ -34837,6 +34845,7 @@ manufactuer->manufacture, manufacturer,
 manufactuerd->manufactured
 manufactuers->manufactures, manufacturers,
 manufacturedd->manufactured
+manufacturin->manufacturing
 manufature->manufacture
 manufatured->manufactured
 manufaturer->manufacturer
@@ -34873,9 +34882,11 @@ mapp->map
 mappble->mappable
 mappeds->mapped
 mappeed->mapped
+mappin->mapping
 mappped->mapped
 mappping->mapping
 mapppings->mappings
+marchin->marching, march in,
 marger->merger, marker,
 margers->mergers, markers,
 marging->margin, merging,
@@ -34890,6 +34901,7 @@ marixsts->marxists
 marjority->majority
 markaup->markup
 markes->marks, marked, markers,
+marketin->marketing, market in,
 marketting->marketing
 markey->marquee
 markeys->marquees
@@ -34898,6 +34910,7 @@ marrage->marriage
 marraige->marriage
 marrtyred->martyred
 marryied->married
+marshalin->marshaling, marshal in,
 marshmellow->marshmallow
 marshmellows->marshmallows
 marter->martyr
@@ -34920,11 +34933,13 @@ maskerading->masquerading
 maskeraid->masquerade
 masos->macos
 masquarade->masquerade
+masqueradin->masquerading
 masqurade->masquerade
 Massachusettes->Massachusetts
 Massachussets->Massachusetts
 Massachussetts->Massachusetts
 massagebox->messagebox
+massagin->massaging
 massectomy->mastectomy
 massewer->masseur
 massmedia->mass media
@@ -34941,6 +34956,7 @@ masterbation->masturbation
 mastquerade->masquerade
 mastter->master
 mastters->masters
+masturbatin->masturbating, masturbation,
 mata->meta, mater,
 mata-data->meta-data
 matadata->metadata
@@ -35036,6 +35052,7 @@ maximimum->maximum
 maximimums->maximums
 maximium->maximum
 maximiums->maximums
+maximizin->maximizing
 maximnum->maximum
 maximnums->maximums
 maximuim->maximum
@@ -35143,6 +35160,7 @@ measureable->measurable
 measureably->measurably
 measuremenet->measurement
 measuremenets->measurements
+measurin->measuring
 measurmenet->measurement
 measurmenets->measurements
 measurment->measurement
@@ -35247,6 +35265,7 @@ meethod->method
 meethodology->methodology
 meethods->methods
 meetign->meeting
+meetin->meeting, meet in,
 meganism->mechanism
 mege->merge
 meged->merged
@@ -35318,6 +35337,7 @@ memner->member
 memoery->memory
 memomry->memory
 memor->memory
+memorizin->memorizing
 memoty->memory
 memove->memmove
 mempry->memory
@@ -35326,6 +35346,7 @@ memwar->memoir
 memwars->memoirs
 memwoir->memoir
 memwoirs->memoirs
+menacin->menacing
 menaing->meaning, menacing, mending,
 menaings->meanings
 menally->mentally
@@ -35335,6 +35356,7 @@ menber->member
 menbers->members
 menbership->membership
 menberships->memberships
+mendin->mending, mend in,
 menetion->mention
 menetioned->mentioned
 menetioning->mentioning
@@ -35356,9 +35378,11 @@ menthod->method, menthol,
 menthods->methods
 mentiond->mentioned
 mentione->mentioned
+mentionin->mentioning, mention in,
 mentionned->mentioned
 mentionning->mentioning
 mentionnned->mentioned
+mentorin->mentoring, mentor in,
 menual->manual
 menue->menu
 menues->menus
@@ -35379,6 +35403,8 @@ merget->merged, merger, merge,
 mergge->merge
 mergged->merged
 mergging->merging
+mergin->merging
+meritin->meriting, merit in,
 merly->merely, formerly,
 mermory->memory
 merory->memory
@@ -35394,6 +35420,8 @@ meshe->mesh, meshed, meshes,
 meskeeto->mosquito
 meskeetoes->mosquitoes
 meskeetos->mosquitos
+mesmerisin->mesmerising
+mesmerizin->mesmerizing
 mesoneen->mezzanine
 mesoneens->mezzanines
 messae->message, messy,
@@ -35431,6 +35459,7 @@ messge->message
 messged->messaged, messed,
 messges->messages, messes,
 messging->messaging, messing,
+messin->messing, mess in,
 messsage->message
 messsaged->messaged
 messsages->messages
@@ -35453,6 +35482,7 @@ mesurment->measurement
 meta-attrubute->meta-attribute
 meta-attrubutes->meta-attributes
 meta-progamming->meta-programming
+meta-programmin->meta-programming
 metacharater->metacharacter
 metacharaters->metacharacters
 metadat->metadata
@@ -35593,6 +35623,7 @@ mige->midge
 miges->midges
 migh->might
 migrateable->migratable
+migratin->migrating, migration,
 migt->might, midget,
 migth->might
 miht->might
@@ -35680,6 +35711,7 @@ mimatching->mismatching
 mimiced->mimicked
 mimicing->mimicking
 mimick->mimic
+mimickin->mimicking
 mimicks->mimics
 mimima->minima
 mimimal->minimal
@@ -35723,7 +35755,9 @@ MingGW->MinGW
 minimam->minimum
 minimial->minimal
 minimim->minimum
+minimisin->minimising
 minimium->minimum
+minimizin->minimizing
 minimsation->minimisation
 minimse->minimise
 minimsed->minimised
@@ -35817,6 +35851,7 @@ mirorrs->mirrors
 mirors->mirrors, minors,
 mirro->mirror
 mirroed->mirrored
+mirrorin->mirroring, mirror in,
 mirrorn->mirror
 mirrorr->mirror
 mirrorred->mirrored
@@ -35869,6 +35904,7 @@ misinterpert->misinterpret
 misinterperted->misinterpreted
 misinterperting->misinterpreting
 misinterperts->misinterprets
+misinterpretin->misinterpreting, misinterpret in,
 misinterprett->misinterpret
 misinterpretted->misinterpreted
 misinterpretting->misinterpreting
@@ -35878,12 +35914,14 @@ misions->missions, minions, visions,
 misisng->missing
 misison->mission
 misisons->missions
+misleadin->misleading, mislead in,
 mismach->mismatch
 mismached->mismatched
 mismaches->mismatches
 mismaching->mismatching
 mismactch->mismatch
 mismatchd->mismatched
+mismatchin->mismatching, mismatch in,
 mismatchs->mismatches
 mismatich->mismatch
 Misouri->Missouri
@@ -35893,6 +35931,7 @@ mispelling->misspelling
 mispellings->misspellings
 mispells->misspells
 mispelt->misspelt
+misplacin->misplacing
 mispronounciation->mispronunciation
 misquito->mosquito
 misquitoes->mosquitoes
@@ -35934,6 +35973,7 @@ misspel->misspell
 misspeled->misspelled
 misspeling->misspelling
 misspelings->misspellings
+misspellin->misspelling, misspell in,
 misspels->misspells
 missplace->misplace
 missplaced->misplaced
@@ -35985,6 +36025,8 @@ mistrows->maestros
 misue->misuse
 misued->misused
 misuing->misusing
+misunderstandin->misunderstanding, misunderstand in,
+misusin->misusing
 mitake->mistake
 mitaken->mistaken
 mitakes->mistakes
@@ -35994,6 +36036,7 @@ miticateing->mitigating
 miticates->mitigates
 miticating->mitigating
 miticator->mitigator
+mitigatin->mitigating, mitigation,
 mittigate->mitigate
 miximum->maximum
 mixted->mixed
@@ -36042,8 +36085,10 @@ modefiers->modifiers
 modefies->modifies
 modefy->modify
 modefying->modifying
+modelin->modeling, model in,
 modelinng->modeling
 modell->model
+modellin->modelling
 modellinng->modelling
 modellled->modelled
 modellling->modelling
@@ -36053,6 +36098,7 @@ modernination->modernization
 moderninations->modernizations
 moderninationz->modernizations
 modernizationz->modernizations
+modernizin->modernizing
 modesettting->modesetting
 modeul->module
 modeuls->modules
@@ -36154,6 +36200,7 @@ modifyed->modified
 modifyer->modifier
 modifyers->modifiers
 modifyes->modifies
+modifyin->modifying, modify in,
 modiification->modification
 modiifications->modifications
 modiified->modified
@@ -36259,6 +36306,7 @@ monitered->monitored
 monitering->monitoring
 moniters->monitors
 monitoing->monitoring
+monitorin->monitoring, monitor in,
 monitring->monitoring
 monkies->monkeys
 monlayer->monolayer
@@ -36350,6 +36398,7 @@ motivaiton->motivation
 motiviated->motivated
 motiviation->motivation
 motononic->monotonic
+motorin->motoring, motor in,
 motoroloa->motorola
 moudle->module
 moudles->modules
@@ -36358,6 +36407,7 @@ moudules->modules
 mounth->month, mouth,
 mounths->months, mouths,
 mountian->mountain
+mountin->mounting, mount in,
 mountpiont->mountpoint
 mountpionts->mountpoints
 mouspointer->mousepointer
@@ -36559,6 +36609,7 @@ multipllication->multiplication
 multiplyed->multiplied
 multiplyer->multiplier, multiplayer,
 multiplyers->multipliers
+multiplyin->multiplying, multiply in,
 multipresistion->multiprecision
 multipul->multiple
 multipy->multiply
@@ -36620,6 +36671,7 @@ muncipality->municipality
 municiple->municipal
 munnicipality->municipality
 munute->minute
+murderin->murdering, murder in,
 murr->myrrh
 muscel->muscle, mussel,
 muscels->mussels, muscles,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -34641,7 +34641,7 @@ makeing->making
 makfile->makefile
 makfiles->makefiles
 makign->making
-makin->making
+makin->making, main,
 makretplace->marketplace
 makro->macro
 makros->macros
@@ -35403,7 +35403,7 @@ merget->merged, merger, merge,
 mergge->merge
 mergged->merged
 mergging->merging
-mergin->merging
+mergin->merging, margin,
 meritin->meriting, merit in,
 merly->merely, formerly,
 mermory->memory
@@ -36407,7 +36407,7 @@ moudules->modules
 mounth->month, mouth,
 mounths->months, mouths,
 mountian->mountain
-mountin->mounting, mount in,
+mountin->mounting, mountain, mountie, mount in,
 mountpiont->mountpoint
 mountpionts->mountpoints
 mouspointer->mousepointer


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"M" to contain the scope.