### PR TITLE
Add corrections for all *in->*ing words starting with "E"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22736,7 +22736,7 @@ entereing->entering
 enterie->entry
 enteries->entries
 enterily->entirely
-enterin->entering, enter in,
+enterin->entering, enter in, enteron, enteric,
 enternal->internal, external, eternal,
 enternally->internally, externally, eternally,
 enterprice->enterprise

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -21646,6 +21646,7 @@ earliear->earlier
 earlies->earliest
 earlist->earliest
 earlyer->earlier
+earnin->earning, earn in,
 earnt->earned
 earpeice->earpiece
 eary->early, easy, eerie,
@@ -21666,6 +21667,7 @@ easyest->easiest
 easyly->easily
 eather->either, rather, weather, feather, leather, ether, eat her, eater,
 eaturn->return, eaten, Saturn,
+eavesdroppin->eavesdropping
 eaxct->exact
 eaxctly->exactly
 eazier->easier
@@ -21731,6 +21733,7 @@ eddits->edits
 ede->edge
 edeycat->etiquette
 edeycats->etiquettes
+edgin->edging
 ediable->editable
 edige->edge
 ediges->edges
@@ -21751,6 +21754,7 @@ editiable->editable
 editible->editable
 editied->edited
 editiing->editing
+editin->editing, edit in, edition,
 editior->editor
 editiors->editors
 editoro->editor
@@ -21769,6 +21773,7 @@ ednpoint->endpoint
 ednpoints->endpoints
 edtion->edition
 edtions->editions
+educatin->educating, education,
 educte->educate
 educted->educated, deducted,
 eductes->educates
@@ -21919,6 +21924,7 @@ einstance->instance
 eisntance->instance
 eiter->either
 eith->with
+ejectin->ejecting, eject in, ejection,
 elagance->elegance
 elagant->elegant
 elagantly->elegantly
@@ -21926,6 +21932,7 @@ elamentaries->elementaries
 elamentary->elementary
 elamentries->elementaries
 elamentry->elementary
+elapsin->elapsing
 elaspe->elapse
 elasped->elapsed
 elaspes->elapses
@@ -21946,6 +21953,7 @@ eleases->releases
 eleate->relate
 electic->eclectic, electric,
 electical->electrical
+electin->electing, elect in, election,
 electirc->electric
 electircal->electrical
 electon->election, electron,
@@ -22036,6 +22044,7 @@ elimiated->eliminated
 elimiates->eliminates
 elimiating->eliminating
 elimiation->elimination
+eliminatin->eliminating, elimination,
 eliminetaion->elimination
 elimintate->eliminate
 eliminte->eliminate
@@ -22092,6 +22101,7 @@ emabled->enabled
 emables->enables
 emabling->enabling
 emai->email
+emailin->emailing, email in,
 emailling->emailing
 emasc->emacs
 embalance->imbalance
@@ -22116,6 +22126,7 @@ embarrased->embarrassed
 embarrasing->embarrassing
 embarrasingly->embarrassingly
 embarrasment->embarrassment
+embarrassin->embarrassing, embarrass in,
 embbed->embed, ebbed,
 embbedded->embedded
 embbedder->embedder
@@ -22142,6 +22153,7 @@ embeddder->embedder
 embeddders->embedders
 embeddding->embedding
 embeddeding->embedding
+embeddin->embedding
 embedds->embeds
 embeded->embedded
 embededded->embedded
@@ -22156,6 +22168,7 @@ embeedding->embedding
 embezelled->embezzled
 emblamatic->emblematic
 embold->embolden
+embracin->embracing
 embrio->embryo
 embrios->embryos
 embrodery->embroidery
@@ -22178,6 +22191,7 @@ emissed->amassed, amiss,
 emited->emitted
 emiting->emitting
 emition->emission, emotion,
+emittin->emitting
 emlation->emulation
 emmediately->immediately
 emmigrated->emigrated, immigrated,
@@ -22213,6 +22227,8 @@ emphaise->emphasise
 emphaised->emphasised
 emphaises->emphasises
 emphaising->emphasising
+emphasisin->emphasising, emphasis in,
+emphasizin->emphasizing
 emphazise->emphasize
 emphazised->emphasized
 emphazises->emphasizes
@@ -22224,6 +22240,7 @@ empirial->empirical, imperial,
 empiricaly->empirically
 emplied->implied, emptied,
 emplies->implies, empties,
+employin->employing, employ in,
 emply->employ, empty, imply,
 emplyed->employed
 emplyee->employee
@@ -22252,6 +22269,7 @@ empted->emptied
 emptniess->emptiness
 emptry->empty
 emptyed->emptied
+emptyin->emptying, empty in,
 emptyy->empty
 empy->empty
 emtied->emptied
@@ -22278,10 +22296,12 @@ enabing->enabling
 enabledi->enabled
 enableing->enabling
 enablen->enabled
+enablin->enabling
 enalbe->enable
 enalbed->enabled
 enalbes->enables
 enameld->enameled
+enamorin->enamoring, enamor in,
 enaugh->enough
 enbable->enable
 enbabled->enabled
@@ -22305,6 +22325,7 @@ encapsualted->encapsulated
 encapsualtes->encapsulates
 encapsualting->encapsulating
 encapsualtion->encapsulation
+encapsulatin->encapsulating, encapsulation,
 encapsulatzion->encapsulation
 encapsulte->encapsulate
 encapsulted->encapsulated
@@ -22322,6 +22343,8 @@ enchancement->enhancement, enchantment,
 enchancements->enhancements, enchantments,
 enchances->enhances, enchants,
 enchancing->enhancing, enchanting,
+enchantin->enchanting, enchant in,
+enclosin->enclosing
 enclosng->enclosing
 enclosue->enclosure
 enclosung->enclosing
@@ -22336,6 +22359,7 @@ encocders->encoders
 encocdes->encodes
 encocding->encoding
 encocdings->encodings
+encodin->encoding
 encodingt->encoding
 encodning->encoding
 encodnings->encodings
@@ -22350,6 +22374,7 @@ encompas->encompass
 encompased->encompassed
 encompases->encompasses
 encompasing->encompassing
+encompassin->encompassing, encompass in,
 encompus->encompass
 encompused->encompassed
 encompuses->encompasses
@@ -22383,12 +22408,14 @@ encosings->enclosings, encodings,
 encosure->enclosure
 encounted->encountered, encounter,
 encounterd->encountered
+encounterin->encountering, encounter in,
 encounting->encountering
 encountre->encounter, encountered,
 encountres->encounters
 encourae->encourage
 encouraed->encouraged
 encouraes->encourages
+encouragin->encouraging
 encouraing->encouraging
 encourge->encourage
 encourged->encouraged
@@ -22437,6 +22464,7 @@ encrypiton->encryption
 encrypte->encrypted, encrypt,
 encryptiing->encrypting
 encryptiion->encryption
+encryptin->encrypting, encrypt in, encryption,
 encryptio->encryption
 encryptiong->encryption, encrypting,
 encryt->encrypt
@@ -22470,6 +22498,8 @@ endcoding->encoding
 endcodings->encodings
 endding->ending
 ende->end
+endeavorin->endeavoring, endeavor in,
+endeavourin->endeavouring, endeavour in,
 endever->endeavor
 endevered->endeavored
 endeveres->endeavors
@@ -22487,6 +22517,7 @@ endien->endian, indian,
 endiens->endians, indians,
 endig->ending
 endiif->endif
+endin->ending, end in,
 endiness->endianness
 endnoden->endnode
 endoint->endpoint
@@ -22537,6 +22568,7 @@ enew->new
 enflamed->inflamed
 enforcable->enforceable
 enforceing->enforcing
+enforcin->enforcing
 enforcmement->enforcement
 enforcment->enforcement
 enfore->enforce
@@ -22568,6 +22600,7 @@ enginee->engine, engineer,
 engineeer->engineer
 engineeering->engineering
 engineeers->engineers
+engineerin->engineering, engineer in,
 enginees->engines, engineers,
 enginge->engine
 enginges->engines
@@ -22588,6 +22621,7 @@ enhacements->enhancements
 enhaces->enhances
 enhacing->enhancing
 enhancd->enhanced
+enhancin->enhancing
 enhancment->enhancement
 enhancments->enhancements
 enhane->enhance, ethane,
@@ -22675,6 +22709,7 @@ enpoint->endpoint
 enpoints->endpoints
 enque->enqueue
 enqueing->enqueuing
+enquirin->enquiring
 enrties->entries
 enrtries->entries
 enrtry->entry
@@ -22701,10 +22736,12 @@ entereing->entering
 enterie->entry
 enteries->entries
 enterily->entirely
+enterin->entering, enter in,
 enternal->internal, external, eternal,
 enternally->internally, externally, eternally,
 enterprice->enterprise
 enterprices->enterprises
+entertainin->entertaining, entertain in,
 entery->entry
 enteties->entities
 entety->entity
@@ -22788,12 +22825,14 @@ enumearate->enumerate
 enumearation->enumeration
 enumerater->enumerator, enumerated, enumerates, enumerate,
 enumeraters->enumerators, enumerates,
+enumeratin->enumerating, enumeration,
 enumeratior->enumerator
 enumeratiors->enumerators
 enumerble->enumerable
 enumertaion->enumeration
 enusre->ensure
 envaluation->evaluation
+envelopin->enveloping, envelop in,
 enveloppe->envelope
 envelopped->enveloped
 enveloppes->envelopes
@@ -22974,10 +23013,12 @@ equaivalent->equivalent
 equaivalently->equivalently
 equaivalents->equivalents
 equalibrium->equilibrium
+equalizin->equalizing
 equall->equal, equally,
 equallity->equality
 equalls->equals
 equaly->equally
+equatin->equating, equation,
 equavalence->equivalence
 equavalent->equivalent
 equavalently->equivalently
@@ -23017,6 +23058,7 @@ equilvalents->equivalents
 equiped->equipped
 equipmentd->equipment
 equipments->equipment
+equippin->equipping
 equippment->equipment
 equiptment->equipment
 equire->require, enquire, equine, esquire,
@@ -23083,6 +23125,7 @@ erasuer->erasure, eraser,
 eratic->erratic
 eratically->erratically
 eraticly->erratically
+erectin->erecting, erect in, erection,
 erested->arrested, erected,
 erformance->performance
 ergnomic->ergonomic
@@ -23147,6 +23190,7 @@ ervices->services, cervices,
 esacpe->escape
 esacped->escaped
 esacpes->escapes
+escalatin->escalating, escalation,
 escalte->escalate
 escalted->escalated
 escaltes->escalates
@@ -23154,6 +23198,7 @@ escalting->escalating
 escaltion->escalation
 escapeable->escapable
 escapemant->escapement
+escapin->escaping
 escartment->escarpment
 escartments->escarpments
 escased->escaped
@@ -23290,6 +23335,7 @@ establis->establish
 establised->established
 establises->establishes
 establishd->established
+establishin->establishing, establish in,
 establishs->establishes
 establising->establishing
 establsihed->established
@@ -23298,6 +23344,7 @@ estimage->estimate
 estimages->estimates
 estimater->estimator, estimated, estimates, estimate,
 estimaters->estimators, estimates,
+estimatin->estimating, estimation,
 estiomator->estimator
 estiomators->estimators
 estuwarries->estuaries
@@ -23375,6 +23422,7 @@ evaluatates->evaluates
 evaluatating->evaluating
 evaluater->evaluator, evaluated, evaluates, evaluate,
 evaluaters->evaluators, evaluates,
+evaluatin->evaluating, evaluation,
 evalueate->evaluate
 evalueated->evaluated
 evaluete->evaluate
@@ -23482,9 +23530,11 @@ eveyrthing->everything
 eveyrwhere->everywhere
 eveything->everything
 eveywhere->everywhere
+evictin->evicting, evict in, eviction,
 evidentally->evidently
 evironment->environment
 evironments->environments
+evisceratin->eviscerating, evisceration,
 eviserate->eviscerate
 eviserated->eviscerated
 eviserates->eviscerates
@@ -23501,12 +23551,14 @@ evluator->evaluator
 evluators->evaluators
 evnet->event
 evnts->events
+evokin->evoking
 evoluate->evaluate
 evoluated->evaluated
 evoluates->evaluates
 evoluation->evaluation, evolution,
 evoluations->evaluations, evolutions,
 evoluton->evolution
+evolvin->evolving
 evovler->evolver
 evovling->evolving
 evrithing->everything
@@ -23523,6 +23575,7 @@ ewhwer->where
 exaclty->exactly
 exacly->exactly
 exactely->exactly
+exactin->exacting, exact in, exaction,
 exactlly->exactly
 exacty->exactly
 exacutable->executable
@@ -23545,6 +23598,7 @@ exagerrate->exaggerate
 exagerrated->exaggerated
 exagerrates->exaggerates
 exagerrating->exaggerating
+exaggeratin->exaggerating, exaggeration,
 exameple->example
 exameples->examples
 examied->examined
@@ -23554,6 +23608,7 @@ examinated->examined
 examinates->examines
 examinating->examining
 examing->examining
+examinin->examining
 examinining->examining
 examle->example
 examles->examples
@@ -23683,6 +23738,7 @@ excedeed->exceeded
 excedes->exceeds
 exceding->exceeding
 exceds->exceeds
+exceedin->exceeding, exceed in,
 exceeed->exceed
 exceeeded->exceeded
 exceeeding->exceeding
@@ -23826,6 +23882,7 @@ exchane->exchange
 exchaned->exchanged
 exchanes->exchanges
 exchangable->exchangeable
+exchangin->exchanging
 exchaning->exchanging
 exchaust->exhaust
 exchausted->exhausted
@@ -23852,11 +23909,13 @@ exciation->excitation
 excipt->except
 exciption->exception
 exciptions->exceptions
+excisin->excising, excision,
 excist->exist, excise,
 excisted->existed, excised,
 excistence->existence
 excisting->existing, excising,
 excists->exists, excises,
+excitin->exciting
 excitment->excitement
 exclaimation->exclamation
 exclaimations->exclamations
@@ -23867,6 +23926,7 @@ excliuded->excluded
 excliudes->excludes
 excliuding->excluding
 excludde->exclude
+excludin->excluding
 excludind->excluding
 excludle->exclude
 excludled->excluded
@@ -23921,6 +23981,7 @@ exculding->excluding
 exculsive->exclusive
 exculsively->exclusively
 exculsivly->exclusively
+excusin->excusing
 excutable->executable
 excutables->executables
 excute->execute
@@ -24076,6 +24137,7 @@ executeable->executable
 executeables->executables
 executible->executable
 executign->executing
+executin->executing, execution,
 executiong->execution, executing,
 executng->executing
 executon->execution, executor,
@@ -24116,6 +24178,8 @@ exempel->example
 exempels->examples
 exemple->example
 exemples->examples
+exemplifyin->exemplifying, exemplify in,
+exemptin->exempting, exempt in, exemption,
 exended->extended
 exension->extension
 exensions->extensions
@@ -24151,6 +24215,7 @@ exerciesed->exercised
 exercieses->exercises
 exerciesing->exercising
 exerciess->exercises
+exercisin->exercising
 exercize->exercise
 exercized->exercised
 exercizes->exercises
@@ -24185,6 +24250,7 @@ exersized->exercised
 exersizes->exercises
 exersizing->exercising
 exerternal->external
+exertin->exerting, exert in, exertion,
 exeuctable->executable
 exeuctables->executables
 exeucte->execute
@@ -24218,6 +24284,7 @@ exhausion->exhaustion
 exhausive->exhaustive
 exhausively->exhaustively
 exhausiveness->exhaustiveness
+exhaustin->exhausting, exhaust in, exhaustion,
 exhauted->exhausted
 exhauting->exhausting
 exhaution->exhaustion
@@ -24227,7 +24294,9 @@ exhautiveness->exhaustiveness
 exhautivity->exhaustivity
 exhcuast->exhaust
 exhcuasted->exhausted
+exhibitin->exhibiting, exhibit in, exhibition,
 exhibtion->exhibition
+exhilaratin->exhilarating, exhilaration,
 exhilerate->exhilarate
 exhilerated->exhilarated
 exhilerates->exhilarates
@@ -24240,6 +24309,7 @@ exhisting->existing
 exhists->exists
 exhorbitent->exorbitant
 exhorbitently->exorbitantly
+exhortin->exhorting, exhort in,
 exhostive->exhaustive
 exhustiveness->exhaustiveness
 exibit->exhibit
@@ -24287,6 +24357,7 @@ exitance->existence
 exitation->excitation
 exitations->excitations
 exite->exit, excite, exits,
+exitin->exiting, exit in,
 exitsing->existing, exiting,
 exitss->exists, exits,
 exitsted->existed
@@ -24386,6 +24457,7 @@ expalnations->explanations
 expanation->explanation, expansion,
 expanations->explanations, expansions,
 expanble->expandable
+expandin->expanding, expand in,
 expaned->expand, expanded, explained,
 expaneded->expanded
 expaneding->expanding
@@ -24439,6 +24511,7 @@ expectatons->expectations
 expectd->expected
 expecte->expected
 expectes->expects
+expectin->expecting, expect in,
 expection->exception, expectation,
 expections->exceptions, expectations,
 expediated->expedited
@@ -24594,6 +24667,7 @@ experiementations->experimentations
 experiemented->experimented
 experiementing->experimenting
 experiements->experiments
+experiencin->experiencing
 experienshial->experiential
 experiensial->experiential
 experies->expires
@@ -24711,6 +24785,7 @@ experimentatlly->experimentally
 experimentatly->experimentally
 experimentel->experimental
 experimentelly->experimentally
+experimentin->experimenting, experiment in,
 experimentt->experiment
 experimentted->experimented
 experimentter->experimenter
@@ -25026,6 +25101,7 @@ expirimentations->experimentations
 expirimented->experimented
 expirimenting->experimenting
 expiriments->experiments
+expirin->expiring
 expiriy->expiry
 expite->expire, expedite,
 expited->expired, expedited,
@@ -25034,6 +25110,7 @@ explainations->explanations
 explainatory->explanatory
 explaind->explained
 explaing->explaining
+explainin->explaining, explain in,
 explanaiton->explanation
 explanaitons->explanations
 explanantion->explanation
@@ -25099,9 +25176,11 @@ explizit->explicit
 explizitly->explicitly
 explnation->explanation
 explnations->explanations
+exploitin->exploiting, exploit in,
 exploition->explosion, exploitation, exploit,
 exploitions->explosions, exploitations, exploits,
 exploititive->exploitative
+explorin->exploring
 explot->exploit, explore,
 explotation->exploitation, exploration,
 exploting->exploiting, exploring,
@@ -25141,6 +25220,8 @@ exporession->expression
 exporing->exploring, expiring, exporting, exposing,
 expors->exports
 exportet->exported, exporter,
+exportin->exporting, export in,
+exposin->exposing, expos in,
 expport->export
 exppressed->expressed
 exprect->expect
@@ -25158,6 +25239,7 @@ expresions->expressions
 expresison->expression
 expresisons->expressions
 expressable->expressible
+expressin->expressing, express in, expression,
 expressino->expression
 expressio->expression
 expressiong->expression, expressing,
@@ -25185,6 +25267,7 @@ expropiated->expropriated
 expropiates->expropriates
 expropiating->expropriating
 expropiation->expropriation
+expropriatin->expropriating, expropriation,
 exprot->export
 exproted->exported
 exproting->exporting
@@ -25272,6 +25355,7 @@ exten->extend, extent,
 extenal->external
 extendded->extended
 extendet->extended
+extendin->extending, extend in,
 extendsion->extension
 extendsions->extensions
 extened->extended
@@ -25349,6 +25433,7 @@ extited->excited, exited,
 extiting->exciting, exiting,
 extits->exits, excites,
 extnesion->extension
+extortin->extorting, extort in, extortion,
 extrac->extract
 extraced->extracted
 extracing->extracting
@@ -25368,6 +25453,7 @@ extradiction->extradition
 extraenous->extraneous
 extranous->extraneous
 extraordinarly->extraordinarily
+extrapolatin->extrapolating, extrapolation,
 extrapole->extrapolate
 extrapoled->extrapolated
 extrapoles->extrapolates
@@ -25422,6 +25508,7 @@ extrmities->extremities
 extrodinary->extraordinary
 extrordinarily->extraordinarily
 extrordinary->extraordinary
+extrudin->extruding
 extry->entry
 exturd->extrude
 exturde->extrude
@@ -25439,6 +25526,7 @@ exucution->execution
 exucutions->executions
 exucutor->executor
 exucutors->executors
+exudin->exuding
 exurpt->excerpt
 exurpts->excerpts
 eyar->year, eyas,


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"E" to contain the scope.