### PR TITLE
Add corrections for all *in->*ing words starting with "N"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -36846,7 +36846,7 @@ namesd->named, names,
 namess->names
 namesspace->namespace
 namesspaces->namespaces
-namin->naming
+namin->naming, admin,
 namme->name
 nammed->named
 nammes->names
@@ -36923,6 +36923,7 @@ natioanlist->nationalist
 natioanlists->nationalists
 natioanlly->nationally
 natioanls->nationals
+nationalisin->nationalising
 nationalizin->nationalizing
 nativelyx->natively
 natrual->natural
@@ -37793,7 +37794,7 @@ nomrals->normals
 non-alphanumunder->non-alphanumeric
 non-asii->non-ascii
 non-assiged->non-assigned
-non-blockin->non-blocking, non-block in,
+non-blockin->non-blocking
 non-bloking->non-blocking
 non-compleeted->non-completed
 non-complient->non-compliant
@@ -37853,7 +37854,7 @@ non-negotitated->non-negotiated
 non-negotited->non-negotiated
 non-negoziable->non-negotiable
 non-negoziated->non-negotiated
-non-neighborin->non-neighboring, non-neighbor in,
+non-neighborin->non-neighboring
 non-persistant->non-persistent
 non-priviliged->non-privileged
 non-referenced-counted->non-reference-counted

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -36826,6 +36826,7 @@ naiborhoods->neighborhoods, neighbourhoods,
 naiborly->neighborly, neighbourly,
 naibors->neighbors, neighbours,
 naieve->naive
+nailin->nailing, nail in,
 naivity->naivety
 nam->name
 namaed->named
@@ -36845,6 +36846,7 @@ namesd->named, names,
 namess->names
 namesspace->namespace
 namesspaces->namespaces
+namin->naming
 namme->name
 nammed->named
 nammes->names
@@ -36866,6 +36868,7 @@ nanosencond->nanosecond
 nanosenconds->nanoseconds
 nanoseond->nanosecond
 nanoseonds->nanoseconds
+napalmin->napalming, napalm in,
 Naploeon->Napoleon
 Napolean->Napoleon
 Napoleonian->Napoleonic
@@ -36920,6 +36923,7 @@ natioanlist->nationalist
 natioanlists->nationalists
 natioanlly->nationally
 natioanls->nationals
+nationalizin->nationalizing
 nativelyx->natively
 natrual->natural
 natrually->naturally
@@ -36953,6 +36957,7 @@ naviagtor->navigator
 naviagtors->navigators
 navigater->navigator, navigated, navigates, navigate,
 navigaters->navigators, navigates,
+navigatin->navigating, navigation,
 navigaton->navigation, navigator,
 navitvely->natively
 navtive->native
@@ -37091,6 +37096,7 @@ neede->needed, need, needle,
 needeed->needed
 needeing->needing
 needes->needs, needed, needles,
+needin->needing, need in,
 neeed->need, needed,
 neeeded->needed
 neeeding->needing
@@ -37252,6 +37258,7 @@ negothiator->negotiator
 negothiators->negotiators
 negotiater->negotiator, negotiated, negotiates, negotiate,
 negotiaters->negotiators, negotiates,
+negotiatin->negotiating, negotiation,
 negotible->negotiable
 negoticable->negotiable
 negoticate->negotiate
@@ -37466,6 +37473,7 @@ neighborhoor->neighbor
 neighborhoors->neighbors
 neighborhoud->neighborhood
 neighborhouds->neighborhoods
+neighborin->neighboring, neighbor in,
 neighbos->neighbors
 neighbot->neighbor
 neighbothood->neighborhood
@@ -37492,6 +37500,7 @@ neighbourhoor->neighbour
 neighbourhoors->neighbours
 neighbourhoud->neighbourhood
 neighbourhouds->neighbourhoods
+neighbourin->neighbouring, neighbour in,
 neighbous->neighbours
 neighbout->neighbour
 neighbouthood->neighbourhood
@@ -37725,6 +37734,7 @@ nnovisheate->novitiate
 nnovisheates->novitiates
 nnumber->number
 no-overide->no-override
+noddin->nodding
 nodel->model, nodal,
 nodels->models
 nodess->nodes
@@ -37783,6 +37793,7 @@ nomrals->normals
 non-alphanumunder->non-alphanumeric
 non-asii->non-ascii
 non-assiged->non-assigned
+non-blockin->non-blocking, non-block in,
 non-bloking->non-blocking
 non-compleeted->non-completed
 non-complient->non-compliant
@@ -37842,6 +37853,7 @@ non-negotitated->non-negotiated
 non-negotited->non-negotiated
 non-negoziable->non-negotiable
 non-negoziated->non-negotiated
+non-neighborin->non-neighboring, non-neighbor in,
 non-persistant->non-persistent
 non-priviliged->non-privileged
 non-referenced-counted->non-reference-counted
@@ -37912,6 +37924,8 @@ normaizes->normalizes
 normaizing->normalizing
 normale->normal
 normales->normals
+normalisin->normalising
+normalizin->normalizing
 normall->normal, normally,
 normallisation->normalisation
 normallise->normalise
@@ -37969,6 +37983,7 @@ notbooks->notebooks, not books,
 notce->notice, notch, note, nonce,
 notced->noticed, notched, noted,
 notces->notices, notches, notes, nonces,
+notchin->notching, notch in,
 notcing->noticing, nothing, notching, noting,
 noteable->notable
 noteably->notably
@@ -38001,6 +38016,7 @@ noticications->notifications
 noticied->noticed, notified,
 noticies->notices, notifies,
 noticiing->noticing
+noticin->noticing
 noticy->notify, notice,
 noticying->notifying
 notidication->notification
@@ -38052,8 +38068,10 @@ notifycation->notification
 notifycations->notifications
 notifyed->notified
 notifyes->notifies
+notifyin->notifying, notify in,
 notigication->notification
 notigications->notifications
+notin->noting, not in, notion,
 notitication->notification
 notitications->notifications
 notitied->notified
@@ -38080,6 +38098,8 @@ notticed->noticed
 nottices->notices
 notticing->noticing
 notwhithstanding->notwithstanding
+notwithstandin->notwithstanding
+nourishin->nourishing, nourish in,
 noveau->nouveau
 novemeber->November
 Novemer->November
@@ -38149,6 +38169,7 @@ numberators->numerators
 numberic->numeric
 numberical->numerical
 numberically->numerically
+numberin->numbering, number in,
 numberous->numerous
 numberr->number
 numberred->numbered
@@ -38209,6 +38230,7 @@ nurisher->nourisher
 nurishes->nourishes
 nurishing->nourishing
 nurishment->nourishment
+nurturin->nurturing
 nusance->nuisance
 nutral->neutral
 nutrally->neutrally


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"N" to contain the scope.