### PR TITLE
Add corrections for all *in->*ing words starting with "U"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -56074,6 +56074,7 @@ unbuntu->Ubuntu
 uncahnged->unchanged
 uncalcualted->uncalculated
 unce->once
+unceasin->unceasing
 uncehck->uncheck
 uncehcked->unchecked
 uncerain->uncertain
@@ -56222,6 +56223,7 @@ underlow->underflow
 underlowed->underflowed
 underlowing->underflowing
 underlows->underflows
+underlyin->underlying
 underlyng->underlying
 underneeth->underneath
 underrrun->underrun
@@ -56248,11 +56250,13 @@ understadning->understanding
 understadns->understands
 understads->understands
 understandig->understanding
+understandin->understanding, understand in,
 understant->understand, understate,
 understantable->understandable
 understantably->understandably
 understanting->understanding, understating,
 understants->understands, understates,
+understatin->understating
 understnad->understand
 understnadable->understandable
 understnadably->understandably
@@ -56464,11 +56468,13 @@ unifforms->uniforms
 unifiy->unify
 unifiying->unifying
 uniformely->uniformly
+uniformin->uniforming, uniform in,
 uniformy->uniformly, uniform,
 unifrom->uniform
 unifromed->uniformed
 unifromity->uniformity
 unifroms->uniforms
+unifyin->unifying, unify in,
 unigned->unsigned
 unihabited->uninhabited
 unilateraly->unilaterally
@@ -56505,6 +56511,7 @@ uninitialze->uninitialize
 uninitialzed->uninitialized
 uninitialzes->uninitializes
 uninstalable->uninstallable
+uninstallin->uninstalling, uninstall in,
 uninstatiated->uninstantiated
 uninstlal->uninstall
 uninstlalation->uninstallation
@@ -56519,6 +56526,7 @@ unintelligble->unintelligible
 unintented->unintended, unindented,
 unintentially->unintentionally
 uninteressting->uninteresting
+uninterestin->uninteresting
 uninterpretted->uninterpreted
 uninterruped->uninterrupted
 uninterruptable->uninterruptible
@@ -56593,6 +56601,7 @@ unknonw->unknown
 unknonwn->unknown
 unknonws->unknowns
 unknouwn->unknown
+unknowin->unknowing
 unknowngly->unknowingly
 unknwn->unknown
 unknwns->unknowns
@@ -56618,6 +56627,7 @@ unlimeted->unlimited
 unlimitied->unlimited
 unlimted->unlimited
 unline->unlike
+unloadin->unloading, unload in,
 unloadins->unloading
 unmached->unmatched
 unmainted->unmaintained
@@ -56711,6 +56721,7 @@ unorotated->unrotated
 unoticeable->unnoticeable
 unpacke->unpacked
 unpacket->unpacked
+unpackin->unpacking, unpack in,
 unparseable->unparsable
 unpertubated->unperturbed
 unperturb->unperturbed
@@ -56722,6 +56733,7 @@ unpleasent->unpleasant
 unplesant->unpleasant
 unplesent->unpleasant
 unpluged->unplugged
+unpluggin->unplugging
 unpluging->unplugging
 unprecendented->unprecedented
 unprecidented->unprecedented
@@ -56742,6 +56754,7 @@ unqouted->unquoted
 unqoutes->unquotes
 unqouting->unquoting
 unque->unique
+unquotin->unquoting
 unreacahable->unreachable
 unreacahble->unreachable
 unreacheable->unreachable
@@ -56931,6 +56944,7 @@ unsubscirbes->unsubscribes
 unsubscirbing->unsubscribing
 unsubscirption->unsubscription
 unsubscirptions->unsubscriptions
+unsubscribin->unsubscribing
 unsubscritpion->unsubscription
 unsubscritpions->unsubscriptions
 unsubscritpiton->unsubscription
@@ -56989,6 +57003,7 @@ unsuprisingly->unsurprisingly
 unsuprized->unsurprised
 unsuprizing->unsurprising
 unsuprizingly->unsurprisingly
+unsurprisin->unsurprising
 unsurprized->unsurprised
 unsurprizing->unsurprising
 unsurprizingly->unsurprisingly
@@ -57057,6 +57072,7 @@ unweildly->unwieldy
 unwieldly->unwieldy
 unwraped->unwrapped
 unwraping->unwrapping
+unwrappin->unwrapping
 unwrritten->unwritten
 unx->unix
 unxepected->unexpected
@@ -57089,6 +57105,7 @@ upater->updater
 upates->updates
 upating->updating
 upccoming->upcoming
+upcomin->upcoming
 upcomming->upcoming
 updadate->update
 updadated->updated
@@ -57108,6 +57125,7 @@ updatees->updates
 updateing->updating
 updatess->updates
 updatig->updating
+updatin->updating
 updatr->updater, update,
 updatrs->updaters, updates,
 updats->updates
@@ -57163,6 +57181,7 @@ upgradded->upgraded
 upgraddes->upgrades
 upgradding->upgrading
 upgradei->upgrade
+upgradin->upgrading
 upgradingn->upgrading
 upgrate->upgrade
 upgrated->upgraded
@@ -57189,6 +57208,7 @@ uplaods->uploads
 upliad->upload
 uploade->upload
 uploades->uploads, uploaded,
+uploadin->uploading, upload in,
 uploaed->upload, uploaded,
 uploaeded->uploaded
 uploaeding->uploading
@@ -57400,6 +57420,7 @@ utililty->utility
 utilis->utilise
 utilisa->utilise
 utilisaton->utilisation
+utilisin->utilising
 utilites->utilities
 utilitisation->utilisation
 utilitise->utilise
@@ -57413,6 +57434,7 @@ utilitizing->utilizing
 utiliz->utilize
 utiliza->utilize
 utilizaton->utilization
+utilizin->utilizing
 utill->until, utils,
 utillisation->utilisation
 utillise->utilise


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"U" to contain the scope.