### PR TITLE
Add corrections for all *in->*ing words starting with "W"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -58569,7 +58569,7 @@ waislines->waistlines
 waitin->waiting, wait in,
 waitting->waiting
 wakeus->wakeups, wake us, walrus,
-wakin->waking
+wakin->waking, waken, wain, akin,
 wakup->wakeup, walk-up,
 wakups->wakeups, walk-ups,
 walkin->walking, walk in,
@@ -58578,7 +58578,7 @@ walkthoughs->walkthroughs
 wallowin->wallowing, wallow in,
 wallthickness->wall thickness
 wan't->want, wasn't,
-wantin->wanting, want in,
+wantin->wanting, want in, wanton,
 wantto->want to
 wapped->wrapped, swapped, warped,
 wapper->wrapper

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -58566,14 +58566,19 @@ wahtever->whatever
 wainting->waiting
 waisline->waistline
 waislines->waistlines
+waitin->waiting, wait in,
 waitting->waiting
 wakeus->wakeups, wake us, walrus,
+wakin->waking
 wakup->wakeup, walk-up,
 wakups->wakeups, walk-ups,
+walkin->walking, walk in,
 walkthough->walkthrough, walk though,
 walkthoughs->walkthroughs
+wallowin->wallowing, wallow in,
 wallthickness->wall thickness
 wan't->want, wasn't,
+wantin->wanting, want in,
 wantto->want to
 wapped->wrapped, swapped, warped,
 wapper->wrapper
@@ -58622,6 +58627,7 @@ warnkngs->warnings
 warnned->warned
 warnning->warning
 warnnings->warnings
+warpin->warping, warp in,
 warpped->wrapped, warped,
 warpper->wrapper, warper,
 warpping->wrapping, warping,
@@ -58672,12 +58678,16 @@ weaponaries->weaponry, weaponries,
 weaponary->weaponry
 weappon->weapon
 weappons->weapons
+wearin->wearing, wear in,
 wearn->warn, wear, earn, learn, worn, yearn,
 wearned->warned, earned, learned, yearned,
 wearning->warning, wearing, earning, learning, yearning, wearying,
 wearnings->warnings, earnings, yearnings,
 wearns->warns, wears, earns, learns, yearns,
+wearyin->wearying, weary in,
 weas->was
+weatherin->weathering, weather in,
+weavin->weaving
 webage->webpage
 webages->webpages
 webaserver->web server, webserver,
@@ -58712,6 +58722,8 @@ wehre->where
 wehreas->whereas
 wehrever->wherever
 wehther->whether
+weighin->weighing, weigh in,
+weightin->weighting, weight in,
 weigth->weight
 weigthed->weighted
 weigths->weights
@@ -58820,8 +58832,11 @@ whiped->whipped, wiped,
 whis->this, whisk,
 whish->wish, whisk,
 whishlist->wishlist
+whisperin->whispering, whisper in,
+whistlin->whistling
 whitch->which
 whitchever->whichever
+whitelistin->whitelisting, whitelist in,
 whitepace->whitespace
 whitepaces->whitespaces
 whitepsace->whitespace
@@ -58940,6 +58955,7 @@ winndow->window
 winndows->windows
 winodw->window
 winodws->windows
+wipin->wiping
 wipoing->wiping
 wirded->wired, weird,
 wireframw->wireframe
@@ -58981,6 +58997,7 @@ withdrawl->withdrawal, withdraw,
 witheld->withheld
 withh->with
 withhin->within
+withholdin->withholding, withhold in,
 withhout->without
 withih->within
 withinn->within
@@ -59091,6 +59108,7 @@ womens->women's, women,
 wonce->once, nonce, ponce, wince,
 wonderfull->wonderful
 wonderig->wondering
+wonderin->wondering, wonder in,
 wonderous->wondrous
 wonderously->wondrously
 wondow->window
@@ -59150,6 +59168,7 @@ workes->works
 workfow->workflow
 workfows->workflows
 workign->working
+workin->working, work in,
 worklfow->workflow
 worklfows->workflows
 workpsace->workspace
@@ -59187,6 +59206,7 @@ worrried->worried
 worrries->worries
 worrry->worry
 worrrying->worrying
+worryin->worrying, worry in,
 wors->worse, worst, works, wars, was,
 worser->worse
 worspace->workspace
@@ -59237,6 +59257,7 @@ wrapers->wrappers
 wraping->wrapping, warping,
 wrapp->wrap
 wrappered->wrapped
+wrappin->wrapping
 wrappng->wrapping
 wrappped->wrapped
 wrappper->wrapper
@@ -59250,6 +59271,7 @@ wresselers->wrestlers
 wresseling->wrestling
 wressels->wrestles
 wresters->wrestlers
+wrestlin->wrestling
 wriet->write
 wriets->writes
 writebufer->writebuffer
@@ -59259,6 +59281,8 @@ writeing->writing
 writen->written
 writet->writes
 writewr->writer
+writhin->writhing
+writin->writing, writ in,
 writingm->writing
 writte->write, written,
 writter->writer, written,


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"W" to contain the scope.