### PR TITLE
Add corrections for all *in->*ing words starting with "G"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27343,7 +27343,7 @@ gatable->gateable
 gateing->gating
 gatherig->gathering
 gatherin->gathering, gather in,
-gatin->gating
+gatin->gating, latin, satin, gain, gratin,
 gatway->gateway
 gauage->gauge
 gauarana->guaraná
@@ -27748,7 +27748,7 @@ gitub->GitHub
 gived->given, gave,
 giveing->giving
 givem->given, give them, give 'em,
-givin->giving
+givin->giving, given,
 givne->given
 givveing->giving
 givven->given
@@ -27870,7 +27870,7 @@ grabed->grabbed
 grabing->grabbing
 gracefull->graceful
 gracefuly->gracefully
-gracin->gracing
+gracin->gracing, gain, gratin,
 gradiant->gradient, radiant,
 gradiants->gradients
 gradualy->gradually
@@ -27921,7 +27921,7 @@ graphci->graphic
 graphcial->graphical
 graphcis->graphics
 graphial->graphical
-graphin->graphing, graph in,
+graphin->graphing, graphic, graph in,
 graphis->graphics
 grapic->graphic
 grapical->graphical
@@ -27975,7 +27975,7 @@ groupin->grouping, group in,
 groupped->grouped
 groupping->grouping
 groupt->grouped
-growin->growing, grow in,
+growin->growing, grow in, groin,
 growtesk->grotesque
 growteskly->grotesquely
 grpah->graph
@@ -28006,7 +28006,7 @@ guaranteing->guaranteeing
 guarantes->guarantees
 guarantie->guarantee
 guarbage->garbage
-guardin->guarding, guard in,
+guardin->guarding, guard in, guardian,
 guared->guard, guarded,
 guareded->guarded
 guareente->guarantee

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27342,6 +27342,8 @@ gastly->ghastly, vastly,
 gatable->gateable
 gateing->gating
 gatherig->gathering
+gatherin->gathering, gather in,
+gatin->gating
 gatway->gateway
 gauage->gauge
 gauarana->guaraná
@@ -27460,6 +27462,8 @@ generaging->generating
 generaing->generating
 generaion->generation
 generaions->generations
+generalisin->generalising
+generalizin->generalizing
 generall->generally, general,
 generallly->generally
 generaly->generally
@@ -27707,6 +27711,7 @@ getoject->getobject
 gettetx->gettext
 gettig->getting
 gettign->getting
+gettin->getting
 gettings->getting, settings,
 gettitem->getitem, get item,
 gettitems->getitems, get items,
@@ -27743,11 +27748,13 @@ gitub->GitHub
 gived->given, gave,
 giveing->giving
 givem->given, give them, give 'em,
+givin->giving
 givne->given
 givveing->giving
 givven->given
 givving->giving
 glamourous->glamorous
+glancin->glancing
 glight->flight
 gloab->globe
 gloabal->global
@@ -27779,6 +27786,7 @@ glyped->glyphed
 glyphes->glyphs
 glyping->glyphing
 glyserin->glycerin
+gnarlin->gnarling, gnarl in,
 gnawwed->gnawed
 gneral->general
 gnerally->generally
@@ -27857,10 +27865,12 @@ govorment->government
 govormental->governmental
 govornment->government
 grabage->garbage
+grabbin->grabbing
 grabed->grabbed
 grabing->grabbing
 gracefull->graceful
 gracefuly->gracefully
+gracin->gracing
 gradiant->gradient, radiant,
 gradiants->gradients
 gradualy->gradually
@@ -27911,6 +27921,7 @@ graphci->graphic
 graphcial->graphical
 graphcis->graphics
 graphial->graphical
+graphin->graphing, graph in,
 graphis->graphics
 grapic->graphic
 grapical->graphical
@@ -27960,9 +27971,11 @@ groubpy->groupby
 groupd->grouped
 groupe->grouped, group,
 groupes->groups, grouped,
+groupin->grouping, group in,
 groupped->grouped
 groupping->grouping
 groupt->grouped
+growin->growing, grow in,
 growtesk->grotesque
 growteskly->grotesquely
 grpah->graph
@@ -27987,11 +28000,13 @@ Guadulupe->Guadalupe, Guadeloupe,
 guage->gauge
 guarante->guarantee
 guaranted->guaranteed
+guaranteein->guaranteeing, guarantee in,
 guaranteey->guaranty
 guaranteing->guaranteeing
 guarantes->guarantees
 guarantie->guarantee
 guarbage->garbage
+guardin->guarding, guard in,
 guared->guard, guarded,
 guareded->guarded
 guareente->guarantee


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"G" to contain the scope.