### PR TITLE
Add corrections for all *in->*ing words starting with "V"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -59053,7 +59053,7 @@ valdations->validations
 valdator->validator
 valdators->validators
 valdity->validity
-valetin->valeting, valet in,
+valetin->valeting, valet in, valentine,
 valetta->valletta
 valeu->value
 valeud->valued
@@ -59911,7 +59911,7 @@ volxels->voxels
 vonfig->config
 vor->for
 vould->would
-vowin->vowing, vow in,
+vowin->vowing, vow in, no-win,
 voxes->voxels, voxel,
 voyour->voyeur
 voyouristic->voyeuristic

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -58952,6 +58952,7 @@ vaalue->value
 vaalued->valued
 vaalues->values
 vaaluing->valuing
+vaccinatin->vaccinating, vaccination,
 vaccum->vacuum
 vaccume->vacuum
 vaccumed->vacuumed
@@ -58982,6 +58983,7 @@ vacumme->vacuum
 vacummes->vacuums
 vacums->vacuums
 vacuosly->vacuously
+vacuumin->vacuuming, vacuum in,
 vaelue->value, valued,
 vaelues->values
 vaguaries->vagaries
@@ -59051,6 +59053,7 @@ valdations->validations
 valdator->validator
 valdators->validators
 valdity->validity
+valetin->valeting, valet in,
 valetta->valletta
 valeu->value
 valeud->valued
@@ -59139,6 +59142,7 @@ value-to-pack->value to pack
 valueable->valuable
 valuess->values
 valuie->value
+valuin->valuing
 valulation->valuation
 valulations->valuations
 valule->value
@@ -59283,6 +59287,7 @@ vart->cart, wart,
 vartical->vertical
 vartically->vertically
 varts->carts, warts,
+varyin->varying, vary in,
 vas->was
 vasall->vassal
 vasalls->vassals
@@ -59310,6 +59315,7 @@ vecotrs->vectors
 vectices->vertices
 vectore->vector
 vectores->vectors
+vectorin->vectoring, vector in,
 vectorss->vectors
 vectror->vector
 vectrors->vectors
@@ -59361,6 +59367,7 @@ venders->vendors
 venemous->venomous
 vengance->vengeance
 vengence->vengeance
+ventilatin->ventilating, ventilation,
 ventillate->ventilate
 ventillated->ventilated
 ventillates->ventilates
@@ -59441,6 +59448,7 @@ verifyed->verified
 verifyes->verifies
 verifyied->verified
 verifyies->verifies
+verifyin->verifying, verify in,
 verigated->variegated
 verion->version
 verions->versions
@@ -59488,6 +59496,7 @@ versiomed->versioned
 versioming->versioning
 versioms->versions
 versionaddded->versionadded
+versionin->versioning, version in,
 versionm->version
 versionms->versions
 versionn->version
@@ -59562,6 +59571,7 @@ vetically->vertically
 vetinarian->veterinarian
 vetinarians->veterinarians
 vetod->vetoed
+vetoin->vetoing, veto in,
 vetor->vector, veto,
 vetored->vectored, vetoed,
 vetoring->vectoring, vetoing,
@@ -59575,6 +59585,7 @@ vewer->viewer
 vewers->viewers
 vewing->viewing, vowing, vexing,
 vews->views, vows,
+vexin->vexing, vex in,
 veyr->very
 vhild->child
 viariable->variable
@@ -59593,6 +59604,7 @@ victemized->victimized
 victemizes->victimizes
 victemizing->victimizing
 victems->victims
+victimizin->victimizing
 victum->victim
 victums->victims
 videostreamming->videostreaming
@@ -59601,6 +59613,7 @@ viees->views
 vieport->viewport
 vieports->viewports
 vietnamesea->Vietnamese
+viewin->viewing, view in,
 viewtransfromation->viewtransformation
 vigeur->vigueur, vigour, vigor,
 vigilanties->vigilantes
@@ -59626,6 +59639,7 @@ vinyet->vignette
 vinyets->vignettes
 vioalte->violate
 vioaltion->violation
+violatin->violating, violation,
 violentce->violence
 violoated->violated
 violoating->violating
@@ -59731,6 +59745,7 @@ visisble->visible
 visisbly->visibly
 visiter->visitor, visit,
 visiters->visitors, visits,
+visitin->visiting, visit in,
 visitng->visiting
 visivble->visible
 vissible->visible
@@ -59763,11 +59778,13 @@ visuaized->visualized
 visuaizes->visualizes
 visuale->visual
 visuales->visuals
+visualisin->visualising
 visualizaion->visualization
 visualizaiton->visualization
 visualizaitons->visualizations
 visualizaton->visualization
 visualizatons->visualizations
+visualizin->visualizing
 visuall->visual, visually,
 visuallisation->visualisation
 visuallization->visualization
@@ -59860,6 +59877,7 @@ vocabualries->vocabularies
 vocabualry->vocabulary
 vocabularlies->vocabularies
 vocabularly->vocabulary
+voidin->voiding, void in,
 voif->void
 Voight->Voigt
 volatage->voltage
@@ -59887,11 +59905,13 @@ volounteers->volunteers
 volumn->volume
 volumne->volume
 volums->volume
+volunteerin->volunteering, volunteer in,
 volxel->voxel
 volxels->voxels
 vonfig->config
 vor->for
 vould->would
+vowin->vowing, vow in,
 voxes->voxels, voxel,
 voyour->voyeur
 voyouristic->voyeuristic


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"V" to contain the scope.