### PR TITLE
Add corrections for all *in->*ing words starting with "T"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -54877,7 +54877,7 @@ taht->that
 tailred->tailored
 tained->tainted, stained,
 taked->took, taken,
-takin->taking
+takin->taking, taken, akin,
 taks->task, tasks, takes,
 takslet->tasklet
 talbe->table
@@ -55480,6 +55480,8 @@ tesselatad->tessellated
 tesselate->tessellate
 tesselated->tessellated
 tesselates->tessellates
+tesselatin->tessellating
+tesselating->tessellating
 tesselation->tessellation
 tesselations->tessellations
 tesselator->tessellator
@@ -55973,7 +55975,7 @@ timestmap->timestamp
 timestmaps->timestamps
 timetamp->timestamp
 timetamps->timestamps
-timin->timing
+timin->timing, timid,
 timmestamp->timestamp
 timmestamps->timestamps
 timming->timing, trimming,
@@ -56040,7 +56042,7 @@ tocken->token
 tockens->tokens
 tocksen->toxin
 todya->today
-toein->toeing, toe in,
+toein->toeing, toe in, toxin,
 toekn->token
 toekns->tokens
 toether->together, tether,
@@ -56171,12 +56173,12 @@ tounge->tongue
 touple->tuple, couple, topple, toupee,
 touples->tuples, couples, topples, toupees,
 tourch->torch, touch,
-towin->towing, tow in,
+towin->towing, tow in, town, toxin,
 toword->toward
 towords->towards
 towrad->toward
 toxen->toxin
-toyin->toying, toy in,
+toyin->toying, toy in, toyon, toxin,
 tpye->type
 tpyed->typed
 tpyes->types
@@ -57175,7 +57177,7 @@ tung->tongue
 tunges->tongues
 tungs->tongues
 tungues->tongues
-tunin->tuning, tun in,
+tunin->tuning, tun in, tunic,
 tunned->tuned
 tunnelin->tunneling, tunnel in,
 tunnell->tunnel
@@ -57246,7 +57248,7 @@ tyes->types, ties,
 tyhat->that
 tyhe->they, the, type,
 tyies->tries
-tyin->tying
+tyin->tying, thin, twin, tin,
 tymecode->timecode
 tyoe->type, toey, toe,
 tyoed->typed, toyed, toed,

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -54853,6 +54853,7 @@ tabualtor->tabulator
 tabualtors->tabulators
 tabulater->tabulator, tabulated, tabulates, tabulate,
 tabulaters->tabulators, tabulates,
+tabulatin->tabulating, tabulation,
 tage->stage, take, tag, tagged,
 taged->tagged
 tages->tags, stages,
@@ -54876,11 +54877,13 @@ taht->that
 tailred->tailored
 tained->tainted, stained,
 taked->took, taken,
+takin->taking
 taks->task, tasks, takes,
 takslet->tasklet
 talbe->table
 talbes->tables
 talekd->talked
+talkin->talking, talk in,
 tallerable->tolerable
 tamplate->template
 tamplated->templated
@@ -54940,6 +54943,7 @@ targered->targeted
 targering->targeting
 targers->targets, taggers,
 targest->targets, largest,
+targetin->targeting, target in,
 targetted->targeted
 targetting->targeting
 targettting->targeting
@@ -54990,6 +54994,7 @@ te->the, be, we, to,
 teacer->teacher
 teacers->teachers
 teached->taught
+teachin->teaching, teach in,
 teachnig->teaching
 teaher->teacher
 teahers->teachers
@@ -55277,6 +55282,7 @@ temprorily->temporarily
 temprory->temporary
 temproy->temporary
 temptatation->temptation
+temptin->tempting, tempt in,
 tempurature->temperature
 tempuratures->temperatures
 tempurture->temperature
@@ -55374,6 +55380,7 @@ termimals->terminals
 terminatd->terminated
 terminater->terminator, terminated, terminates, terminate,
 terminaters->terminators, terminates,
+terminatin->terminating, termination,
 terminats->terminates
 termindate->terminate
 termine->determine
@@ -55479,6 +55486,7 @@ tesselator->tessellator
 tesselators->tessellators
 tessellater->tessellator, tessellated, tessellates, tessellate,
 tessellaters->tessellators, tessellates,
+tessellatin->tessellating, tessellation,
 tessleate->tessellate
 tessleated->tessellated
 tessleates->tessellates
@@ -55524,6 +55532,7 @@ teusday->Tuesday
 texchnically->technically
 texline->textline
 textfrme->textframe
+textin->texting, text in,
 texual->textual
 texually->textually
 texure->texture
@@ -55538,6 +55547,7 @@ thairs->theirs, there's,
 thankfull->thankful, thankfully,
 thankfullly->thankfully
 thankfuly->thankfully
+thankin->thanking, thank in,
 thann->than, thank,
 thannk->thank
 thannked->thanked
@@ -55564,6 +55574,7 @@ thats'->that's
 thats->that's
 thaught->thought, taught,
 thaughts->thoughts
+thawin->thawing, thaw in,
 thay->they, that,
 thck->thick
 theard->thread
@@ -55664,6 +55675,7 @@ thhis->this
 thi->the, this,
 thiank->thank, think,
 thianks->thanks, thinks,
+thickenin->thickening, thicken in,
 thicking->thinking, thickening,
 thicknes->thickness, thickens,
 thid->this
@@ -55696,6 +55708,7 @@ thiniks->thinks
 thinkabel->thinkable
 thinkg->think, thing, things,
 thinkgs->thinks, things,
+thinkin->thinking, think in,
 thinn->thin
 thirs->third, thirst,
 thirtyth->thirtieth
@@ -55763,13 +55776,17 @@ thrad->thread
 thraded->threaded, traded,
 thrading->threading, trading,
 thrads->threads
+thrallin->thralling, thrall in,
+thrashin->thrashing, thrash in,
 thre->three, there, their, the,
+threadin->threading, thread in,
 threadsave->threadsafe
 threah->thread, threat,
 threashold->threshold
 threasholds->thresholds
 threated->threaded, threatened, treated,
 threatend->threatened
+threatenin->threatening, threaten in,
 threatment->treatment
 threatments->treatments
 threatning->threatening
@@ -55812,6 +55829,7 @@ throtte->throttle, trot,
 throtted->throttled, trotted,
 throttes->throttles, trots,
 throtting->throttling, trotting,
+throttlin->throttling
 throttoling->throttling
 throug->through
 througg->through
@@ -55833,6 +55851,7 @@ throuhput->throughput
 throuth->through
 throwed->threw, thrown,
 throwgh->through
+throwin->throwing, throw in,
 thrreshold->threshold
 thrresholds->thresholds
 thrshold->threshold
@@ -55904,6 +55923,7 @@ tiggering->triggering
 tiggers->triggers
 tighly->tightly
 tightely->tightly
+tightenin->tightening, tighten in,
 tigth->tight
 tigthen->tighten
 tigthened->tightened
@@ -55953,6 +55973,7 @@ timestmap->timestamp
 timestmaps->timestamps
 timetamp->timestamp
 timetamps->timestamps
+timin->timing
 timmestamp->timestamp
 timmestamps->timestamps
 timming->timing, trimming,
@@ -55986,11 +56007,13 @@ tiple->triple, tuple,
 tipled->tripled, tipped,
 tiples->triples, tuples,
 tipling->tripling, tipping,
+tippin->tipping
 tirangle->triangle
 tirangles->triangles
 titel->title
 titels->titles
 titile->title
+titlin->titling
 tittled->titled
 tittling->titling
 tjat->that
@@ -56017,6 +56040,7 @@ tocken->token
 tockens->tokens
 tocksen->toxin
 todya->today
+toein->toeing, toe in,
 toekn->token
 toekns->tokens
 toether->together, tether,
@@ -56032,6 +56056,7 @@ toggeles->toggles
 toggeling->toggling
 toggels->toggles
 toggleing->toggling
+togglin->toggling
 togheter->together
 toghether->together
 togle->toggle
@@ -56117,6 +56142,7 @@ tortoitse->tortoise, tortoises,
 torward->toward
 torwards->towards
 Tosday->Tuesday, today,
+totalin->totaling, total in,
 totaly->totally
 totat->total
 totation->rotation
@@ -56145,10 +56171,12 @@ tounge->tongue
 touple->tuple, couple, topple, toupee,
 touples->tuples, couples, topples, toupees,
 tourch->torch, touch,
+towin->towing, tow in,
 toword->toward
 towords->towards
 towrad->toward
 toxen->toxin
+toyin->toying, toy in,
 tpye->type
 tpyed->typed
 tpyes->types
@@ -56158,7 +56186,9 @@ tpyo->typo
 tpyos->typos
 trabsform->transform
 traceablity->traceability
+tracin->tracing
 trackign->tracking
+trackin->tracking, track in,
 trackling->tracking
 tracsode->transcode
 tracsoded->transcoded
@@ -56171,6 +56201,7 @@ tradditional->traditional
 tradditionally->traditionally
 tradditions->traditions
 tradgic->tragic
+tradin->trading, trad in,
 tradion->tradition
 tradional->traditional
 tradionally->traditionally
@@ -56190,6 +56221,7 @@ tradtionally->traditionally
 tradtions->traditions
 trafficed->trafficked
 trafficing->trafficking
+traffickin->trafficking
 trafic->traffic
 tragectory->trajectory
 traget->target
@@ -56204,6 +56236,7 @@ traigers->triagers
 traiges->triages
 traiging->triaging
 traiing->trailing, training,
+trailin->trailing, trail in,
 trailins->trailing
 trailling->trailing, trialling, trilling,
 traingle->triangle
@@ -56217,6 +56250,7 @@ traingulation->triangulation
 traingulations->triangulations
 trainig->training
 trainigs->training
+trainin->training, train in,
 trainling->training, trailing,
 trainned->trained
 trainner->trainer
@@ -56391,6 +56425,7 @@ transcations->transactions, translations,
 transcendance->transcendence
 transcendant->transcendent
 transcendentational->transcendental
+transcendin->transcending, transcend in,
 transcevier->transceiver
 transciever->transceiver
 transcievers->transceivers
@@ -56417,6 +56452,7 @@ transcording->transcoding
 transcordings->transcodings
 transcoser->transcoder
 transcosers->transcoders
+transcribin->transcribing
 transcripting->transcribing, transcription,
 transction->transaction
 transctional->transactional
@@ -56429,6 +56465,7 @@ transferd->transferred
 transfered->transferred
 transfering->transferring
 transferrd->transferred
+transferrin->transferring
 transfert->transfer, transferred,
 transfom->transform
 transfomation->transformation
@@ -56451,6 +56488,7 @@ transformaton->transformation
 transformatons->transformations
 transformatted->transformed
 transforme->transformed, transformer, transform,
+transformin->transforming, transform in,
 transfrom->transform
 transfromate->transform, transformed,
 transfromation->transformation
@@ -56473,6 +56511,7 @@ transistion->transition
 transistioned->transitioned
 transistioning->transitioning
 transistions->transitions
+transitionin->transitioning, transition in,
 transitionnal->transitional
 transitionned->transitioned
 transitionning->transitioning
@@ -56485,6 +56524,7 @@ transitors->transistors
 translater->translator
 translaters->translators
 translatied->translated
+translatin->translating, translation,
 translatoin->translation
 translatoins->translations
 translteration->transliteration
@@ -56508,6 +56548,7 @@ transmitions->transmissions
 transmitsion->transmission
 transmitsions->transmissions
 transmittd->transmitted
+transmittin->transmitting
 transmittion->transmission
 transmittions->transmissions
 transmitts->transmits
@@ -56598,8 +56639,11 @@ transperencies->transparencies
 transperency->transparency
 transperent->transparent
 transperently->transparently
+transplantin->transplanting, transplant in,
 transporation->transportation
 transportatin->transportation
+transportin->transporting, transport in,
+transposin->transposing
 transprencies->transparencies
 transprency->transparency
 transprent->transparent
@@ -56658,6 +56702,7 @@ trasformer->transformer
 trasformers->transformers
 trasforming->transforming
 trasforms->transforms
+trashin->trashing, trash in,
 trasient->transient
 trasiently->transiently
 trasients->transients
@@ -56744,6 +56789,8 @@ traveerse->traverse
 traveersed->traversed
 traveerses->traverses
 traveersing->traversing
+travelin->traveling, travel in,
+travellin->travelling
 traveral->traversal
 travercal->traversal
 traverce->traverse
@@ -56760,19 +56807,23 @@ travereses->traverses
 traveresing->traversing
 travering->traversing
 traverls->travels, traversals,
+traversin->traversing
 traverssal->traversal
 travesal->traversal
 travese->traverse
 travesed->traversed
 traveses->traverses
 travesing->traversing
+trawlin->trawling, trawl in,
 tre->tree, the,
 treadet->treated, treaded, threaded,
 treak->treat, tweak,
+treasurin->treasuring
 treate->treat
 treatement->treatment
 treatements->treatments
 treates->treats
+treatin->treating, treat in,
 treee->tree
 treees->trees
 tremelo->tremolo
@@ -56799,6 +56850,8 @@ trggers->triggers
 trgistration->registration
 trhe->the
 trhough->through
+trialin->trialing, trial in,
+triallin->trialling
 trian->train, trial,
 triancle->triangle
 triancles->triangles
@@ -56816,6 +56869,7 @@ trianglulation->triangulation
 trianglulations->triangulations
 trianglutaion->triangulation
 triangulataion->triangulation
+triangulatin->triangulating, triangulation,
 triangultaion->triangulation
 trianing->training
 trianlge->triangle
@@ -56838,6 +56892,7 @@ trigers->triggers
 trigged->triggered
 triggerd->triggered
 triggeres->triggers
+triggerin->triggering, trigger in,
 triggerred->triggered
 triggerring->triggering
 triggerrs->triggers
@@ -56857,8 +56912,10 @@ triks->tricks, trikes,
 triky->tricky
 trilinar->trilinear, trillionaire,
 trilineal->trilinear
+trillin->trilling, trill in, trillion,
 trimed->trimmed
 triming->trimming, timing,
+trimmin->trimming
 trimmng->trimming
 trinagle->triangle
 trinagles->triangles
@@ -56878,6 +56935,8 @@ triology->trilogy
 tripel->triple
 tripeld->tripled
 tripels->triples
+triplin->tripling
+trippin->tripping
 tripple->triple
 triptick->triptych
 triptickes->triptychs
@@ -56949,6 +57008,7 @@ trogloditic->troglodytic
 trogloditical->troglodytical
 trogloditism->troglodytism
 troling->trolling
+trollin->trolling, troll in,
 trolly->trolley
 trollys->trolleys
 trooso->trousseau
@@ -56961,6 +57021,7 @@ trotskist->trotskyist
 trotskists->trotskyists
 trotskyite->trotskyist
 trotskyites->trotskyists
+trottin->trotting
 trottle->throttle
 trottled->throttled, trotted,
 trottling->throttling, trotting,
@@ -56988,6 +57049,8 @@ troubeshoots->troubleshoots
 troubing->troubling
 troublehshoot->troubleshoot
 troublehshooting->troubleshooting
+troubleshootin->troubleshooting, troubleshoot in,
+troublin->troubling
 troublshoot->troubleshoot
 troublshooting->troubleshooting
 troughout->throughout, throughput,
@@ -57035,6 +57098,7 @@ tructure->structure
 tructured->structured
 tructures->structures
 tructuring->structuring
+trudgin->trudging
 truelly->truly
 truely->truly
 truged->trudged
@@ -57050,6 +57114,7 @@ trunacting->truncating
 trunaction->truncation
 truncat->truncate
 truncatd->truncated
+truncatin->truncating, truncation,
 truncats->truncates
 trunctate->truncate
 trunctated->truncated
@@ -57110,7 +57175,9 @@ tung->tongue
 tunges->tongues
 tungs->tongues
 tungues->tongues
+tunin->tuning, tun in,
 tunned->tuned
+tunnelin->tunneling, tunnel in,
 tunnell->tunnel
 tunning->tuning, running,
 tuotiral->tutorial
@@ -57152,6 +57219,7 @@ tutoral->tutorial
 tutorals->tutorials
 tutoriel->tutorial
 tutoriels->tutorials
+tweakin->tweaking, tweak in,
 tweek->tweak
 tweeked->tweaked
 tweeking->tweaking
@@ -57178,6 +57246,7 @@ tyes->types, ties,
 tyhat->that
 tyhe->they, the, type,
 tyies->tries
+tyin->tying
 tymecode->timecode
 tyoe->type, toey, toe,
 tyoed->typed, toyed, toed,
@@ -57190,6 +57259,7 @@ typcasts->typecasts
 typcial->typical
 typcially->typically
 typdef->typedef, typed,
+typecastin->typecasting, typecast in,
 typechek->typecheck
 typecheking->typechecking
 typesrript->typescript
@@ -57198,6 +57268,7 @@ typicall->typically, typical,
 typicallly->typically
 typicaly->typically
 typicially->typically
+typin->typing
 typle->tuple
 typles->tuples
 typoe->typo, type, types,


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"T" to contain the scope.