### PR TITLE
Add corrections for all *in->*ing words starting with "I"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -29140,6 +29140,7 @@ identifyed->identified
 identifyer->identifier
 identifyers->identifiers
 identifyes->identifies
+identifyin->identifying, identify in,
 identiication->identification
 identiications->identifications
 identiied->identified
@@ -29227,6 +29228,7 @@ ignorgg->ignoring
 ignorgig->ignoring
 ignorging->ignoring
 ignorgs->ignores
+ignorin->ignoring
 ignormable->ignorable
 ignormd->ignored
 ignorme->ignore
@@ -29363,6 +29365,7 @@ imigrated->immigrated, emigrated,
 imigration->immigration, emigration,
 imilar->similar
 iminent->imminent, immanent, eminent,
+imitatin->imitating, imitation,
 imlement->implement
 imlementation->implementation
 imlementations->implementations
@@ -29440,6 +29443,7 @@ imortes->imports
 imorting->importing
 imorts->imports
 imovable->immovable
+impactin->impacting, impact in,
 impcat->impact
 impcated->impacted
 impcating->impacting
@@ -29476,6 +29480,7 @@ impementing->implementing
 impementling->implementing
 impementor->implementer
 impements->implements
+impendin->impending, impend in,
 imperiaal->imperial
 imperical->empirical, imperial,
 imperically->empirically
@@ -29590,6 +29595,7 @@ implementeed->implemented
 implementeing->implementing
 implementes->implements
 implementet->implemented
+implementin->implementing, implement in,
 implemention->implementation
 implementions->implementations
 implementtaion->implementation
@@ -29684,6 +29690,7 @@ implmented->implemented
 implmenting->implementing
 implments->implements
 imploys->employs
+implyin->implying, imply in,
 imporance->importance
 imporant->important
 imporantly->importantly
@@ -29713,6 +29720,7 @@ importence->importance, impotence,
 importend->important, imported,
 importent->important, impotent,
 importently->importantly, impotently,
+importin->importing, import in,
 importnce->importance
 importnt->important
 importntly->importantly
@@ -29752,6 +29760,7 @@ imprements->implements, improvements,
 impres->impress
 impresive->impressive
 impressario->impresario
+impressin->impressing, impress in, impression,
 impreve->improve
 impreved->improved
 imprevement->improvement
@@ -29807,11 +29816,13 @@ improvemnt->improvement
 improvemnts->improvements
 improvent->improvement, improvident,
 improvents->improvements
+improvin->improving
 improvision->improvisation
 improvmenet->improvement
 improvmenets->improvements
 improvment->improvement
 improvments->improvements
+impugnin->impugning, impugn in,
 impune->impugn
 impuned->impugned
 impuner->impugner
@@ -29819,6 +29830,7 @@ impunes->impugns
 impuning->impugning
 impuns->impugns
 imput->input
+imputin->imputing
 imputs->inputs, imputes,
 imputted->inputted, imputed,
 imputting->inputting, imputing,
@@ -29890,6 +29902,7 @@ inbrio->embryo
 inbrios->embryos
 inbulit->inbuilt, built-in,
 incalid->invalid
+incapacitatin->incapacitating, incapacitation,
 incarcirated->incarcerated
 incase->in case
 incatation->incantation
@@ -29904,6 +29917,7 @@ incemental->incremental
 incementally->incrementally
 incemented->incremented
 incements->increments
+incensin->incensing
 incerase->increase
 incerased->increased
 incerasing->increasing
@@ -29939,6 +29953,7 @@ includeing->including
 includied->included
 includig->including
 includign->including
+includin->including
 includng->including
 includs->includes
 inclue->include
@@ -29974,6 +29989,7 @@ incombatible->incompatible
 incombatibly->incompatibly
 incomfort->discomfort, uncomfortable, in comfort,
 incomfortable->uncomfortable
+incomin->incoming
 incomming->incoming
 incommplete->incomplete
 incompaitible->incompatible
@@ -30141,6 +30157,7 @@ incorperated->incorporated
 incorperates->incorporates
 incorperating->incorporating
 incorperation->incorporation
+incorporatin->incorporating, incorporation,
 incorportae->incorporate
 incorportaed->incorporated
 incorportaes->incorporates
@@ -30200,6 +30217,7 @@ increamenting->incrementing
 increaments->increments
 increas->increase
 increasd->increased
+increasin->increasing
 increate->increase, in create,
 increated->increased, in created,
 increates->increases
@@ -30216,6 +30234,7 @@ incremenetd->incremented
 incremeneted->incremented
 incrementall->incremental, incrementally,
 incrementaly->incrementally
+incrementin->incrementing, increment in,
 incremet->increment
 incremetal->incremental
 incremeted->incremented
@@ -30397,6 +30416,7 @@ indeveres->endeavours, endeavors,
 indevering->endeavouring, endeavoring,
 indevers->endeavours, endeavors,
 indexig->indexing
+indexin->indexing, index in,
 indexs->indexes, indices,
 indext->index, indent,
 indiactor->indicator
@@ -30410,6 +30430,7 @@ indicateds->indicated, indicates,
 indicatee->indicates, indicated,
 indicater->indicator, indicated, indicates, indicate,
 indicaters->indicators, indicates,
+indicatin->indicating, indication,
 indicationg->indicating, indication,
 indicatior->indicator
 indicatiors->indicators
@@ -30491,6 +30512,7 @@ indroduces->introduces
 indroducing->introducing
 indroduction->introduction
 indroductions->introductions
+inducin->inducing
 indulgue->indulge
 indure->endure
 indutrial->industrial
@@ -30570,6 +30592,7 @@ inferfacing->interfacing
 infering->inferring
 inferrable->inferable
 inferrence->inference
+inferrin->inferring
 infex->index
 infilitrate->infiltrate
 infilitrated->infiltrated
@@ -30588,6 +30611,7 @@ infintesimal->infinitesimal
 infinty->infinity
 infite->infinite
 inflamation->inflammation
+inflatin->inflating, inflation,
 inflatoin->inflation
 inflexable->inflexible
 influece->influence
@@ -30639,6 +30663,7 @@ informaton->information
 informatonal->informational
 informfation->information
 informfational->informational
+informin->informing, inform in,
 informtion->information
 informtional->informational
 inforrmation->information
@@ -30675,6 +30700,7 @@ infrustructure->infrastructure
 infrustructures->infrastructures
 ingegral->integral
 ingenius->ingenious
+ingestin->ingesting, ingest in, ingestion,
 ingnorar->ignore, ignorant,
 ingnore->ignore
 ingnored->ignored
@@ -30706,6 +30732,7 @@ inherith->inherit
 inherithed->inherited
 inherithing->inheriting
 inheriths->inherits
+inheritin->inheriting, inherit in,
 inheritted->inherited
 inheritting->inheriting
 inherrit->inherit
@@ -31057,6 +31084,7 @@ initialiseing->initialising
 initialisiation->initialisation
 initialisiations->initialisations
 initialisiert->initialised, initialized,
+initialisin->initialising
 initialisong->initialising
 initialiss->initialise, initialises,
 initialistion->initialisation
@@ -31088,6 +31116,7 @@ initializedd->initialized
 initializeing->initializing
 initializiation->initialization
 initializiations->initializations
+initializin->initializing
 initializong->initializing
 initializs->initialize, initializes,
 initializtion->initialization
@@ -31152,6 +31181,7 @@ initiatiats->initiates
 initiatie->initiate
 initiatied->initiated
 initiaties->initiates
+initiatin->initiating, initiation,
 initiatve->initiative, initiate,
 initiatves->initiatives, initiates,
 initiaze->initialize
@@ -31335,6 +31365,7 @@ inizializes->initializes
 inizializing->initializing
 inizially->initially
 inizials->initials
+injectin->injecting, inject in, injection,
 inlalid->invalid
 inlclude->include
 inlcluded->included
@@ -31488,6 +31519,7 @@ inpu->input
 inpust->input, inputs,
 inputed->inputted
 inputsream->inputstream
+inputtin->inputting
 inpuut->input
 inrement->increment
 inrements->increments
@@ -31596,6 +31628,7 @@ insitution->institution
 insitutional->institutional
 insitutions->institutions
 insonsistency->inconsistency
+inspectin->inspecting, inspect in, inspection,
 inspite->in spite, inspire,
 instaance->instance
 instabce->instance
@@ -31633,6 +31666,7 @@ installator->installer
 installators->installers
 installe->installer, installed, install,
 installes->installs
+installin->installing, install in,
 installion->installation, installing,
 installl->install
 installlation->installation
@@ -31667,6 +31701,7 @@ instantating->instantiating
 instantation->instantiation
 instantations->instantiations
 instantiaties->instantiates
+instantiatin->instantiating
 instanze->instance
 instatance->instance
 instatiate->instantiate
@@ -31712,6 +31747,7 @@ insterters->inserters
 insterting->inserting
 instertion->insertion
 insterts->inserts
+instillin->instilling, instill in,
 institue->institute
 institues->institutes
 instituion->institution
@@ -31793,12 +31829,14 @@ instrucitonal->instructional
 instrucitons->instructions
 instructer->instructor, instructed, instruct,
 instructers->instructors, instructs,
+instructin->instructing, instruct in, instruction,
 instrumenet->instrument
 instrumenetation->instrumentation
 instrumenetd->instrumented
 instrumeneted->instrumented
 instrumentaion->instrumentation
 instrumentaiton->instrumentation
+instrumentin->instrumenting, instrument in,
 instrumnet->instrument
 instrumnets->instruments
 instrut->instruct
@@ -31925,6 +31963,7 @@ integrading->integrating
 integradion->integration
 integradions->integrations
 integrat->integrate, integral,
+integratin->integrating, integration,
 integrats->integrates, integrals,
 integreate->integrate
 integreated->integrated
@@ -31963,6 +32002,7 @@ intendation->indentation, intention,
 intendations->indentations, intentions,
 intendend->intended
 intendet->intended
+intendin->intending, intend in,
 inteneded->intended
 intenet->internet, intent,
 intenisty->intensity
@@ -32015,6 +32055,7 @@ interacsion->interaction
 interacsions->interactions
 interacteve->interactive
 interactevely->interactively
+interactin->interacting, interact in, interaction,
 interactionn->interaction
 interactionns->interactions
 interactiv->interactive
@@ -32131,10 +32172,12 @@ interesseted->interested
 interesst->interest
 interessted->interested
 interessting->interesting
+interestin->interesting, interest in,
 intereview->interview
 interfac->interface
 interfacce->interface
 interfacces->interfaces
+interfacin->interfacing
 interfacs->interfaces
 interfact->interact, interface,
 interfacts->interacts, interfaces,
@@ -32156,6 +32199,7 @@ interfer->interfere
 interferance->interference
 interferd->interfered
 interfereing->interfering
+interferin->interfering
 interfernce->interference
 interferred->interfered
 interferring->interfering
@@ -32186,6 +32230,8 @@ interitance->inheritance
 interited->inherited
 interiting->inheriting
 interits->inherits
+interlacin->interlacing
+interleavin->interleaving
 interliveing->interleaving
 interlly->internally
 interm->interim, intern,
@@ -32208,6 +32254,7 @@ internatioanlist->internationalist
 internatioanlists->internationalists
 internatioanlly->internationally
 internation->international
+internationalizin->internationalizing
 internationnal->international
 internationnalism->internationalism
 internationnalist->internationalist
@@ -32247,6 +32294,7 @@ interpolaed->interpolated
 interpolaion->interpolation
 interpolaiton->interpolation
 interpolar->interpolator
+interpolatin->interpolating, interpolation,
 interpolayed->interpolated
 interpoloate->interpolate
 interpoloated->interpolated
@@ -32270,6 +32318,7 @@ interpretatons->interpretations
 interprete->interpret
 interpretes->interprets
 interpretet->interpreted
+interpretin->interpreting, interpret in,
 interpretion->interpretation
 interpretions->interpretations
 interpretor->interpreter
@@ -32305,6 +32354,7 @@ interruped->interrupted
 interruping->interrupting
 interrups->interrupts
 interruptable->interruptible
+interruptin->interrupting, interrupt in, interruption,
 interruptors->interrupters
 interruptted->interrupted
 interrut->interrupt
@@ -32316,6 +32366,7 @@ interseccting->intersecting
 intersecction->intersection
 interseccts->intersects
 intersecrion->intersection
+intersectin->intersecting, intersect in, intersection,
 intersecton->intersection
 intersectons->intersections
 intersepts->intercepts, intersteps,
@@ -32324,6 +32375,7 @@ intersperese->intersperse
 intersperesed->interspersed
 interspereses->intersperses
 intersperesing->interspersing
+interspersin->interspersing, interspersion,
 interst->interest
 intersted->interested
 intersting->interesting
@@ -32345,6 +32397,7 @@ interuupt->interrupt
 intervall->interval
 intervalls->intervals
 interveening->intervening
+intervenin->intervening
 intervines->intervenes
 intesection->intersection
 intesity->intensity
@@ -32492,6 +32545,7 @@ intilizer->initializer
 intilizers->initializers
 intilizes->initializes
 intilizing->initializing
+intimidatin->intimidating, intimidation,
 intimitading->intimidating
 intimite->intimate
 intinite->infinite
@@ -32597,12 +32651,14 @@ intrfacing->interfacing
 intriduce->introduce
 intriduced->introduced
 intriduction->introduction
+intriguin->intriguing
 intrisic->intrinsic
 intrisically->intrinsically
 intrisics->intrinsics
 intrisinc->intrinsic
 intrisincally->intrinsically
 intrisincs->intrinsics
+introducin->introducing
 introducted->introduced
 introducting->introducing
 introductionary->introductory
@@ -32694,6 +32750,7 @@ invaldates->invalidates
 invalde->invalid
 invalidaiton->invalidation
 invalidaitons->invalidations
+invalidatin->invalidating, invalidation,
 invalidatiopn->invalidation
 invalide->invalid
 invalidiate->invalidate
@@ -32718,6 +32775,7 @@ inverions->inversions
 invers->inverse, invert,
 invertedd->inverted
 invertibrates->invertebrates
+invertin->inverting, invert in,
 invertion->inversion
 invertions->inversions
 inverval->interval
@@ -32733,6 +32791,7 @@ investiage->investigate
 investiaged->investigated
 investiages->investigates
 investiaging->investigating
+investigatin->investigating, investigation,
 investingate->investigate
 investingated->investigated
 investingates->investigates
@@ -32766,6 +32825,7 @@ invokable->invocable
 invokation->invocation
 invokations->invocations
 invokee->invoked, invoke,
+invokin->invoking
 invokve->invoke
 invokved->invoked
 invokves->invokes
@@ -32778,6 +32838,7 @@ involing->involving
 involtue->involute
 involtued->involuted
 involtues->involutes
+involvin->involving
 involvment->involvement
 invove->involve, invoke,
 invoved->involved, invoked,
@@ -32828,6 +32889,7 @@ irradated->irradiated
 irradates->irradiates
 irradating->irradiating
 irradation->irradiation
+irradiatin->irradiating, irradiation,
 irraditate->irradiate
 irraditated->irradiated
 irraditates->irradiates
@@ -32847,6 +32909,7 @@ irresistable->irresistible
 irresistably->irresistibly
 irrevelant->irrelevant, irreverent,
 irreversable->irreversible
+irritatin->irritating, irritation,
 is'nt->isn't
 isalha->isalpha
 isconnection->isconnected
@@ -32874,6 +32937,7 @@ isntalls->installs
 isntance->instance
 isntances->instances
 isntead->instead, isn't read,
+isolatin->isolating, isolation,
 isotrophically->isotropically
 ispatches->dispatches
 isplay->display
@@ -32884,6 +32948,7 @@ isssue->issue
 isssued->issued
 isssues->issues
 issueing->issuing
+issuin->issuing
 issus->issues
 issuse->issue, issues,
 issused->issued
@@ -32919,6 +32984,7 @@ ists->its, lists,
 istself->itself
 isue->issue
 isues->issues
+italicizin->italicizing
 itearte->iterate
 itearted->iterated
 iteartes->iterates
@@ -32975,6 +33041,7 @@ iterater->iterator, iterated, iterates, iterate,
 iteraterate->iterate
 iteratered->iterated
 iteraters->iterators, iterates,
+iteratin->iterating, iteration,
 iteratior->iterator
 iteratiors->iterators
 iteratoin->iteration

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32199,7 +32199,7 @@ interfer->interfere
 interferance->interference
 interferd->interfered
 interfereing->interfering
-interferin->interfering
+interferin->interfering, interferon,
 interfernce->interference
 interferred->interfered
 interferring->interfering


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"I" to contain the scope.