### PR TITLE
Add corrections for all *in->*ing words starting with "J"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32463,7 +32463,9 @@ jkd->jdk
 jodpers->jodhpurs
 Johanine->Johannine
 joineable->joinable
+joinin->joining, join in,
 joinning->joining
+jointin->jointing, joint in,
 jont->joint
 jonts->joints
 jornal->journal
@@ -32486,6 +32488,7 @@ jounaling->journaling
 jounals->journals
 jouney->journey
 jouneys->journeys
+journeyin->journeying, journey in,
 journied->journeyed
 journies->journeys
 journing->journeying
@@ -32511,6 +32514,7 @@ juli->July
 jumo->jump
 jumoed->jumped
 jumpimng->jumping
+jumpin->jumping, jump in,
 jumpt->jumped, jump,
 juni->June
 jupyther->Jupyter
@@ -32553,6 +32557,7 @@ justifcations->justifications
 justifed->justified
 justifes->justifies, justices,
 justifing->justifying
+justifyin->justifying, justify in,
 justs->just
 juxt->just
 juxtification->justification


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"J" to contain the scope.