### PR TITLE
Add corrections for all *in->*ing words starting with "K"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -32570,10 +32570,12 @@ kalidescopes->kaleidoscopes
 karisma->charisma
 karismatic->charismatic
 karismatically->charismatically
+kayakin->kayaking, kayak in,
 kazakstan->Kazakhstan
 keboard->keyboard
 keboards->keyboards
 keep-alives->keep-alive
+keepin->keeping, keep in,
 keept->kept
 keesh->quiche
 kenel->kernel, kennel,
@@ -32645,6 +32647,7 @@ kidknapper->kidnapper
 kidknappers->kidnappers
 kidknapping->kidnapping
 kidknaps->kidnaps
+kidnappin->kidnapping
 kighbosh->kibosh
 kighboshed->kiboshed
 kighboshes->kiboshes
@@ -32679,6 +32682,7 @@ knarled->gnarled
 knarling->gnarling
 knarls->gnarls
 knarly->gnarly
+kneadin->kneading, knead in,
 knive->knife
 kno->know
 knockous->noxious
@@ -32686,6 +32690,7 @@ knockously->noxiously
 knoing->knowing
 knoledge->knowledge
 knoledgeable->knowledgeable
+knowin->knowing, know in,
 knowladge->knowledge
 knowladgeable->knowledgeable
 knowlage->knowledge


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"K" to contain the scope.