### PR TITLE
Add corrections for all *in->*ing words starting with "Q"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -43368,6 +43368,7 @@ quadroople->quadruple
 quadroopled->quadrupled
 quadrooples->quadruples
 quadroopling->quadrupling
+quadruplin->quadrupling
 quafeur->coiffure
 quafeured->coiffured
 quailified->qualified
@@ -43376,6 +43377,7 @@ qualfy->qualify
 qualifer->qualifier
 qualifiy->qualify
 qualifiying->qualifying
+qualifyin->qualifying, qualify in,
 qualit->quality
 qualites->qualities
 qualitification->qualification
@@ -43406,6 +43408,7 @@ quantaties->quantities
 quantaty->quantity
 quantifiy->quantify
 quantifiying->quantifying
+quantifyin->quantifying, quantify in,
 quantit->quantity, quantic,
 quantites->quantities
 quantitites->quantities
@@ -43449,6 +43452,7 @@ querstionnaires->questionnaires
 querstions->questions
 quersts->quests
 queryies->queries
+queryin->querying, query in,
 queryinterace->queryinterface
 querys->queries
 quesant->croissant
@@ -43493,6 +43497,7 @@ questionaire->questionnaire
 questionaires->questionnaires
 questionare->questionnaire
 questionares->questionnaires
+questionin->questioning, question in,
 questionnair->questionnaire
 questionnairs->questionnaires
 questios->questions
@@ -43514,6 +43519,7 @@ queueu->queue
 queueud->queued
 queueuing->queuing, queueing,
 queueus->queues
+queuin->queuing
 queus->queues
 quew->queue
 quickier->quicker
@@ -43541,6 +43547,7 @@ quith->quit, with,
 quiting->quitting
 quitt->quit
 quitted->quit
+quittin->quitting
 quizes->quizzes
 quizs->quizzes
 quizzs->quizzes
@@ -43550,6 +43557,7 @@ quotaion->quotation
 quotaions->quotations
 quoteed->quoted
 quotent->quotient
+quotin->quoting, quot in,
 quottes->quotes
 quried->queried
 quries->queries


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"Q" to contain the scope.