### PR TITLE
Add corrections for all *in->*ing words starting with "Y"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -59361,6 +59361,7 @@ xour->your
 xwindows->X
 xyou->you
 yaching->yachting
+yachtin->yachting, yacht in,
 yaer->year
 yaerly->yearly
 yaers->years
@@ -59369,6 +59370,7 @@ yatching->yachting
 yatchs->yachts
 yau->you, yaw,
 yearm->year
+yearnin->yearning, yearn in,
 yeasr->years
 yeild->yield
 yeilded->yielded


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"Y" to contain the scope.