### PR TITLE
Add corrections for all *in->*ing words starting with "Z"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -59431,6 +59431,7 @@ zeored->zeroed
 zeores->zeroes
 zeoring->zeroing
 zeors->zeros
+zeroin->zeroing, zero in,
 zick-zack->zig-zag
 zick-zacks->zig-zags
 zimmap->zipmap
@@ -59442,6 +59443,7 @@ ziped->zipped
 ziper->zipper
 zipers->zippers
 ziping->zipping
+zippin->zipping
 zlot->slot
 zombe->zombie
 zombes->zombies


### PR DESCRIPTION
In my experience and in my personal projects, a common mistake is to write an
"*ing" word (e.g. jumping) without the final "g" (e.g. jumpin).

Using a quick and dirty script, for every *ing word in the dictionary, there is
now a correction when it is missing a final "g". If the word without a final
"g" appeared in the aspell dictionary, it was excluded.

This changes only contains words starting with the letter
"Z" to contain the scope.