### PR TITLE
fix issue #3220: interactive model & write-changes

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1126,6 +1126,9 @@ def main(*args: str) -> int:
         for ifile, cfg_file in enumerate(used_cfg_files, start=1):
             print(f"    {ifile}: {cfg_file}")
 
+    if options.interactive > 0:
+        options.write_changes = True
+
     if options.regex and options.write_changes:
         return _usage_error(
             parser,

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -243,8 +243,6 @@ def test_interactivity(
                 cs.main("-i", "-1", fname)
             assert e.type is SystemExit
             assert e.value.code != 0
-        with FakeStdin("y\n"):
-            assert cs.main("-i", "3", fname) == 1
         with FakeStdin("n\n"):
             result = cs.main("-w", "-i", "3", fname, std=True)
             assert isinstance(result, tuple)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,6 @@ max-complexity = 45
 [tool.ruff.lint.pylint]
 allow-magic-value-types = ["bytes", "int", "str",]
 max-args = 13
-max-branches = 47
+max-branches = 48
 max-returns = 12
 max-statements = 119


### PR DESCRIPTION
fix issue #3220
By modifying the initial value of interactive and directly modifying the value of write_changes when the user selects the interactive model
But I think this is only a temporary solution, because codespell doesn't make any limitations on the value of interactive entered by the user, while the execution only supports 0, 1, 2, 3