### PR TITLE
Multiple spelling suggestions

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27279,6 +27279,7 @@ granuality->granularity
 granualtiry->granularity
 granularty->granularity
 granulatiry->granularity
+grap->grep, grape,
 grapgic->graphic
 grapgical->graphical
 grapgics->graphics
@@ -30057,6 +30058,10 @@ inhertiing->inheriting
 inherting->inheriting
 inhertis->inherits
 inherts->inherits
+inhibate->inhibit
+inhibated->inhibited
+inhibates->inhibits
+inhibating->inhibiting
 inhomogenous->inhomogeneous
 inialisation->initialisation
 inialisations->initialisations
@@ -31536,6 +31541,12 @@ internatioanlist->internationalist
 internatioanlists->internationalists
 internatioanlly->internationally
 internation->international
+internationnal->international
+internationnalism->internationalism
+internationnalist->internationalist
+internationnalists->internationalists
+internationnally->internationally
+internationnaly->internationally
 internel->internal
 internels->internals
 internface->interface
@@ -39888,6 +39899,8 @@ patition->partition, petition,
 patitioned->partitioned, petitioned,
 patitioning->partitioning, petitioning,
 patitions->partitions, petitions,
+patnership->partnership
+patnerships->partnerships
 patren->patron, pattern,
 patrens->patrons, patterns,
 patrent->parent, patent, patron,


### PR DESCRIPTION
A few new spelling suggestions:

```plaintext
inhibate->inhibit
internationnal->international
internationnally->internationally
patnership->partnership
grap->grep
```