### PR TITLE
Remove socioeconomic entries

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -50232,7 +50232,6 @@ socalist->socialist
 socalists->socialists
 socekt->socket
 socekts->sockets
-socio-economic->socioeconomic
 socities->societies
 socre->score
 socred->scored, sacred,


### PR DESCRIPTION
In American English, the term "socioeconomic" is typically written as a single word. However, in British English, it is also acceptable to use the hyphenated form "socio-economic", so it should not be considered an error.