### PR TITLE
Fix "dubious ownership" error in dev containers

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,3 +1,5 @@
+git config --global --add safe.directory /workspaces/codespell
+
 sudo apt-get update
 sudo apt-get install -y libaspell-dev
 


### PR DESCRIPTION
Add repo as safe directory to Git config in dev container to fix "dubious ownership" error that can cause the `pre-commit install` to fail later in the script which can crop up on certain operating systems and file locations.

[Issue documenting this.](https://github.com/microsoft/vscode-remote-release/issues/8656#:~:text=1%20Initialise%20a%20new%20Git%20repository%20or%20clone,the%20container%20for%20the%20first%20time.%20More%20items)