### PR TITLE
Add metadataa typo

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -34685,6 +34685,7 @@ meta-progamming->meta-programming
 metacharater->metacharacter
 metacharaters->metacharacters
 metadat->metadata
+metadataa->metadata
 metadta->metadata
 metalic->metallic
 metalurgic->metallurgic


### PR DESCRIPTION
I found a few cases on github but not that many actually. Quote often people just make a variable metadataA and alike.

may be should not bother? or move to another dictionary?