### PR TITLE
Add reliabe->reliable

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -46106,6 +46106,7 @@ relfections->reflections
 relfective->reflective
 relfectivity->reflectivity
 relfects->reflects
+reliabe->reliable
 reliabily->reliably, reliability,
 reliablity->reliability
 relie->rely, relies, really, relief,


### PR DESCRIPTION
I was reviewing godotengine/godot#80372 when I stumbled upon codespell not picking up on `reliabe`.