### PR TITLE
Add typos for expration(s)

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -25224,6 +25224,8 @@ exportin->exporting, export in,
 exposin->exposing, expos in,
 expport->export
 exppressed->expressed
+expration->expiration
+exprations->expirations
 exprect->expect
 exprectation->expectation
 exprectations->expectations


### PR DESCRIPTION
It seems very common to write `expration` instead of `expiration`: https://grep.app/search?q=expration&words=true

Nevertheless, it could also be a misspelling of `exploration`. So put the two options.