### PR TITLE
Remove reoccurrence from the dictionary.txt -- LGTM and popular word

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -47054,7 +47054,6 @@ rentime->runtime
 rentors->renters
 renumberin->renumbering, renumber in,
 reoadmap->roadmap
-reoccurrence->recurrence
 reoccurrin->reoccurring
 reocmpression->recompression
 reocurring->reoccurring, recurring,


### PR DESCRIPTION
Originally spotted by @MatthiasWiesmann in review of

- https://github.com/schemaorg/schemaorg/pull/3474

And indeed, "reoccurrence" has different meaning from "recurrence" and also formally listed in dictionaries, e.g.

- https://www.oed.com/dictionary/reoccurrence_n?tl=true
- https://en.wiktionary.org/wiki/reoccurrence

In search trends
https://trends.google.com/trends/explore?geo=US&q=reoccurrence,recurrence&hl=en it is only 3 to 79 so ~25 times less "popular" than "recurrence".

Overall -- LGTM, used widely enough, and thus IMHO should not be listed as a typo.


It was added long ago in "original" 19e0f4920