### PR TITLE
Workaround for reST rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,10 +151,10 @@ Words should be separated by a comma.
 
 2. ignore multiple words:
 
-    .. code-block:: python
+   .. code-block:: python
 
-         def wrod(wrods) # codespell:ignore
-              pass
+       def wrod(wrods) # codespell:ignore
+           pass
 
 Using a config file
 -------------------


### PR DESCRIPTION
GitHub does not render reST `code::block::` properly, with most language specifiers. Remove language specifiers for now, until GitHub fix this issue.

Fixes https://github.com/codespell-project/codespell/pull/3390#issuecomment-2020705461.