### PR TITLE
docs: indentation error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,10 +151,10 @@ Words should be separated by a comma.
 
 2. ignore multiple words:
 
-    .. code-block:: python
-
-         def wrod(wrods) # codespell:ignore
-              pass
+   .. code-block:: python
+       
+       def wrod(wrods) # codespell:ignore
+           pass
 
 Using a config file
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Words should be separated by a comma.
 2. ignore multiple words:
 
    .. code-block:: python
-       
+
        def wrod(wrods) # codespell:ignore
            pass
 


### PR DESCRIPTION
I saw that the second example was 1 space too far so badly inerpreted as a quote