### PR TITLE
Add reposiroty->repository

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -47363,8 +47363,8 @@ reportresouces->reportresources
 reposiotories->repositories
 reposiotory->repository
 reposiries->repositories
-reposiroty->repository
 reposiroties->repositories
+reposiroty->repository
 reposiry->repository
 repositaries->repositories
 repositary->repository

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -47363,6 +47363,8 @@ reportresouces->reportresources
 reposiotories->repositories
 reposiotory->repository
 reposiries->repositories
+reposiroty->repository
+reposiroties->repositories
 reposiry->repository
 repositaries->repositories
 repositary->repository


### PR DESCRIPTION
This misspelling is quite common:

- https://github.com/github/dmca/blob/a3bc08105f06ffdeb4da5bcb7f58104124f3ecde/2022/09/2022-09-08-source-code.md?plain=1#L15
- https://github.com/Carthage/Carthage/blob/6ea08534cf3ca68ba5873ebcc080b4fc5968e098/Source/CarthageKit/VersionFile.swift#L375
- https://github.com/aws/amazon-ecs-agent/blob/3d608ab0709f1d7be280ee60ce385abf127d857f/agent/utils/repotag.go#L15