### PR TITLE
Add 'croporate->corporate', 'incroporate->incorporate' and variants

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -16373,6 +16373,9 @@ croozed->cruised
 croozer->cruiser
 croozes->cruises
 croozing->cruising
+croporate->corporate
+croporation->corporation
+croporations->corporations
 croppin->cropping
 croppped->cropped
 cros->cross
@@ -30264,6 +30267,11 @@ incrmentally->incrementally
 incrmented->incremented
 incrmenting->incrementing
 incrments->increments
+incroporate->incorporate
+incroporated->incorporated
+incroporates->incorporates
+incroporating->incorporating
+incroporation->incorporation
 inctance->instance
 inctroduce->introduce
 inctroduced->introduced


### PR DESCRIPTION
`Croporation` appears for example in
- https://github.com/lenovoDTC/dubbo-G/blob/fa1ffea64ad2f7b3b4fc1a56b1a285d23e9cb27b/dubbo-admin/src/main/java/com/alibaba/dubbo/registry/common/domain/Access.java#L7

`incroporate` appears for example in
- https://github.com/google/CommonLoopUtils/blob/c50acb760902c94a89ad3f605edc2d094bc2a7a1/clu/metrics.py#L524
- https://github.com/bazelbuild/remote-apis-sdks/blob/bcc51f0003b6989bf970cd769b0b2e3fb17f271f/go/pkg/cas/upload.go#L519
- https://github.com/ksanjeevan/randomforest-density-python/blob/445db31bdf2adc0343e4fe463917dd4aaee223f8/README.md#L91