### PR TITLE
Handle multiline options

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -160,15 +160,11 @@ class QuietLevels:
 
 
 class GlobMatch:
-    def __init__(self, pattern: Optional[List[str]]) -> None:
-        self.pattern_list: Optional[List[str]] = pattern
+    def __init__(self, pattern: List[str]) -> None:
+        self.pattern_list: List[str] = pattern
 
     def match(self, filename: str) -> bool:
-        return (
-            any(fnmatch.fnmatch(filename, p) for p in self.pattern_list)
-            if self.pattern_list
-            else False
-        )
+        return any(fnmatch.fnmatch(filename, p) for p in self.pattern_list)
 
 
 class Misspelling:
@@ -493,6 +489,7 @@ def parse_options(
         "accepts globs as well. E.g.: if you want "
         "codespell to skip .eps and .txt files, "
         'you\'d give "*.eps,*.txt" to this option.',
+        default=list(),
     )
 
     parser.add_argument(
@@ -1106,19 +1103,20 @@ def parse_file(
 
 
 def flatten_clean_comma_separated_arguments(
-    arguments: Optional[List[str]],
-) -> Optional[List[str]]:
+    arguments: List[str],
+) -> List[str]:
     """
     >>> flatten_clean_comma_separated_arguments(["a, b ,\n c, d,", "e"])
     ['a', 'b', 'c', 'd', 'e']
     >>> flatten_clean_comma_separated_arguments([])
-    >>> flatten_clean_comma_separated_arguments(None)
+    []
     """
-    return (
-        [item.strip() for argument in arguments for item in argument.split(",") if item]
-        if arguments
-        else None
-    )
+    return [
+        item.strip()
+        for argument in arguments
+        for item in argument.split(",")
+        if item
+    ]
 
 
 def _script_main() -> int:

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -489,7 +489,6 @@ def parse_options(
         "accepts globs as well. E.g.: if you want "
         "codespell to skip .eps and .txt files, "
         'you\'d give "*.eps,*.txt" to this option.',
-        default=[],
     )
 
     parser.add_argument(
@@ -1103,7 +1102,7 @@ def parse_file(
 
 
 def flatten_clean_comma_separated_arguments(
-    arguments: List[str],
+    arguments: Iterable[str],
 ) -> List[str]:
     """
     >>> flatten_clean_comma_separated_arguments(["a, b ,\n c, d,", "e"])
@@ -1263,7 +1262,9 @@ def main(*args: str) -> int:
 
     file_opener = FileOpener(options.hard_encoding_detection, options.quiet_level)
 
-    glob_match = GlobMatch(flatten_clean_comma_separated_arguments(options.skip))
+    glob_match = GlobMatch(
+        flatten_clean_comma_separated_arguments(options.skip) if options.skip else []
+    )
     try:
         glob_match.match("/random/path")  # does not need a real path
     except re.error:

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -489,7 +489,7 @@ def parse_options(
         "accepts globs as well. E.g.: if you want "
         "codespell to skip .eps and .txt files, "
         'you\'d give "*.eps,*.txt" to this option.',
-        default=list(),
+        default=[],
     )
 
     parser.add_argument(

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1112,10 +1112,7 @@ def flatten_clean_comma_separated_arguments(
     []
     """
     return [
-        item.strip()
-        for argument in arguments
-        for item in argument.split(",")
-        if item
+        item.strip() for argument in arguments for item in argument.split(",") if item
     ]
 
 

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -573,6 +573,8 @@ def test_ignore(
     (subdir / "bad.txt").write_text("abandonned")
     assert cs.main(tmp_path) == 2
     assert cs.main("--skip=bad*", tmp_path) == 0
+    assert cs.main("--skip=whatever.txt,bad*,whatelse.txt", tmp_path) == 0
+    assert cs.main("--skip=whatever.txt,\n bad* ,", tmp_path) == 0
     assert cs.main("--skip=*ignoredir*", tmp_path) == 1
     assert cs.main("--skip=ignoredir", tmp_path) == 1
     assert cs.main("--skip=*ignoredir/bad*", tmp_path) == 1
@@ -1213,7 +1215,7 @@ def test_ill_formed_ini_config_file(
     assert "ill-formed config file" in stderr
 
 
-@pytest.mark.parametrize("kind", ["cfg", "toml", "toml_list"])
+@pytest.mark.parametrize("kind", ["cfg", "cfg_multiline", "toml", "toml_list"])
 def test_config_toml(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1235,44 +1237,47 @@ def test_config_toml(
     assert "bad.txt" in stdout
     assert "abandonned.txt" in stdout
 
-    if kind == "cfg":
+    if kind.startswith("cfg"):
         conffile = tmp_path / "setup.cfg"
         args = ("--config", conffile)
-        conffile.write_text(
-            """\
+        if kind == "cfg":
+            text = """\
 [codespell]
 skip = bad.txt, whatever.txt
 count =
 """
-        )
-    elif kind == "toml":
-        assert kind == "toml"
+        else:
+            assert kind == "cfg_multiline"
+            text = """\
+[codespell]
+skip = whatever.txt,
+   bad.txt ,
+   ,
+
+count =
+"""
+        conffile.write_text(text)
+    else:
         if sys.version_info < (3, 11):
             pytest.importorskip("tomli")
         tomlfile = tmp_path / "pyproject.toml"
         args = ("--toml", tomlfile)
-        tomlfile.write_text(
-            """\
+        if kind == "toml":
+            text = """\
 [tool.codespell]
 skip = 'bad.txt,whatever.txt'
 check-filenames = false
 count = true
 """
-        )
-    else:
-        assert kind == "toml_list"
-        if sys.version_info < (3, 11):
-            pytest.importorskip("tomli")
-        tomlfile = tmp_path / "pyproject.toml"
-        args = ("--toml", tomlfile)
-        tomlfile.write_text(
-            """\
+        else:
+            assert kind == "toml_list"
+            text = """\
 [tool.codespell]
 skip = ['bad.txt', 'whatever.txt']
 check-filenames = false
 count = true
 """
-        )
+        tomlfile.write_text(text)
 
     # Should pass when skipping bad.txt or abandonned.txt
     result = cs.main(d, *args, std=True)


### PR DESCRIPTION
Clean up options expecting lists before using them, as they may contain newlines.

Examples:
* Enclosing command-line arguments in quotes may introduce newlines in option values:
  ```console
  $ codespell -S "A, B,
  >               C, D, E"
  ```
* INI files may contain multiline values:
  ```ini
  [codespell]
  skip = A, B,
         C, D, E,
   ```

In all the above cases, the option parsing mechanism keeps the newlines (and spaces) . We need to clean up, by splitting on commas and stripping each resulting item from newlines (and spaces).

Fixes #3399.

Very much related to #2767. Both pull requests introduce an option to flatten the options list after splitting on commas, and both need tests!