### PR TITLE
Add spelling correction for specialiaze/specialiase and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -52194,6 +52194,14 @@ specfiying->specifying
 specfy->specify
 specfying->specifying
 speciafied->specified
+specialiase->specialise
+specialiased->specialised
+specialiases->specialises
+specialiasing->specialising
+specialiaze->specialize
+specialiazed->specialized
+specialiazes->specializes
+specialiazing->specializing
 specialiced->specialised, specialized,
 specialisaiton->specialisation
 specialisaitons->specialisations


### PR DESCRIPTION
See e.g.:
- https://grep.app/search?q=specialiaze&words=true
- https://grep.app/search?q=specialiazed&words=true
- https://grep.app/search?q=specialiazes&words=true (No hits found so far but probably just a matter of time)
- https://grep.app/search?q=specialiazing&words=true