### PR TITLE
Exclude bots from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
Similar to https://github.com/tox-dev/tox-ini-fmt/pull/120.

The generated release notes at https://github.com/codespell-project/codespell/releases/tag/v2.3.0 contains over 30 Dependabot and pre-commit updates.

These are not interesting or very useful for the reader, so let's exclude them from the next one.