### PR TITLE
Consistent error messages

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1081,29 +1081,29 @@ def main(*args: str) -> int:
             print(f"    {ifile}: {cfg_file}")
 
     if options.regex and options.write_changes:
+        parser.print_usage()
         print(
             "ERROR: --write-changes cannot be used together with --regex",
             file=sys.stderr,
         )
-        parser.print_help()
         return EX_USAGE
     word_regex = options.regex or word_regex_def
     try:
         word_regex = re.compile(word_regex)
     except re.error as e:
+        parser.print_usage()
         print(f'ERROR: invalid --regex "{word_regex}" ({e})', file=sys.stderr)
-        parser.print_help()
         return EX_USAGE
 
     if options.ignore_regex:
         try:
             ignore_word_regex = re.compile(options.ignore_regex)
         except re.error as e:
+            parser.print_usage()
             print(
                 f'ERROR: invalid --ignore-regex "{options.ignore_regex}" ({e})',
                 file=sys.stderr,
             )
-            parser.print_help()
             return EX_USAGE
     else:
         ignore_word_regex = None
@@ -1117,11 +1117,11 @@ def main(*args: str) -> int:
         )
         for ignore_words_file in ignore_words_files:
             if not os.path.isfile(ignore_words_file):
+                parser.print_usage()
                 print(
                     f"ERROR: cannot find ignore-words file: {ignore_words_file}",
                     file=sys.stderr,
                 )
-                parser.print_help()
                 return EX_USAGE
             build_ignore_words(ignore_words_file, ignore_words, ignore_words_cased)
 
@@ -1129,11 +1129,11 @@ def main(*args: str) -> int:
     try:
         uri_regex = re.compile(uri_regex)
     except re.error as e:
+        parser.print_usage()
         print(
             f'ERROR: invalid --uri-regex "{uri_regex}" ({e})',
             file=sys.stderr,
         )
-        parser.print_help()
         return EX_USAGE
 
     uri_ignore_words = set(
@@ -1155,19 +1155,19 @@ def main(*args: str) -> int:
                         )
                         break
                 else:
+                    parser.print_usage()
                     print(
                         f"ERROR: Unknown builtin dictionary: {u}",
                         file=sys.stderr,
                     )
-                    parser.print_help()
                     return EX_USAGE
         else:
             if not os.path.isfile(dictionary):
+                parser.print_usage()
                 print(
                     f"ERROR: cannot find dictionary file: {dictionary}",
                     file=sys.stderr,
                 )
-                parser.print_help()
                 return EX_USAGE
             use_dictionaries.append(dictionary)
     misspellings: Dict[str, Misspelling] = {}
@@ -1182,12 +1182,12 @@ def main(*args: str) -> int:
     context = None
     if options.context is not None:
         if (options.before_context is not None) or (options.after_context is not None):
+            parser.print_usage()
             print(
                 "ERROR: --context/-C cannot be used together with "
                 "--context-before/-B or --context-after/-A",
                 file=sys.stderr,
             )
-            parser.print_help()
             return EX_USAGE
         context_both = max(0, options.context)
         context = (context_both, context_both)
@@ -1214,6 +1214,7 @@ def main(*args: str) -> int:
     try:
         glob_match.match("/random/path")  # does not need a real path
     except re.error:
+        parser.print_usage()
         print(
             "ERROR: --skip/-S has been fed an invalid glob, "
             "try escaping special characters",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,6 @@ max-complexity = 45
 [tool.ruff.lint.pylint]
 allow-magic-value-types = ["bytes", "int", "str",]
 max-args = 13
-max-branches = 51
+max-branches = 46
 max-returns = 11
 max-statements = 119


### PR DESCRIPTION
The argparse error messages look like this:

	usage: codespell [-h] [--version] ...
	                 [files ...]
	codespell: error: argument -i/--interactive: invalid choice: -1 (choose from 0, 1, 2, 3)

For codespell error messages consistent with argparse error messages:
- Use `ArgumentParser.print_usage()` instead of `ArgumentParser.print_help()`.
- Print usage first and error message last.

Noticed these while  finalising #3344.