### PR TITLE
Add typos found in Emacs and elsewhere

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2319,6 +2319,7 @@ affortable->affordable
 afforts->affords, efforts,
 affraid->afraid
 affter->after
+afganistan->Afghanistan
 afile->a file, agile,
 afinity->affinity
 afor->for
@@ -3305,6 +3306,7 @@ alternatievly->alternatively
 alternatievs->alternatives
 alternatin->alternating, alternation,
 alternativ->alternative
+alternativelly->alternatively
 alternativey->alternatively
 alternativley->alternatively
 alternativly->alternatively
@@ -3727,6 +3729,8 @@ androidextra->androidextras
 androind->android
 androinds->androids
 andthe->and the
+andtoid->android
+andtoids->androids
 ane->and
 aneel->anneal
 aneeled->annealed
@@ -4794,6 +4798,13 @@ approxmately->approximately
 approxmates->approximates
 approxmation->approximation
 approxmations->approximations
+approxmiate->approximate
+approxmiated->approximated
+approxmiately->approximately
+approxmiates->approximates
+approxmiating->approximating
+approxmiation->approximation
+approxmiations->approximations
 approxmimate->approximate
 approxmimated->approximated
 approxmimately->approximately
@@ -4864,6 +4875,10 @@ aqcuire->acquire
 aqcuired->acquired
 aqcuires->acquires
 aqcuiring->acquiring
+aqquire->acquire
+aqquired->acquired
+aqquires->acquires
+aqquiring->acquiring
 aquaduct->aqueduct
 aquaint->acquaint
 aquaintance->acquaintance
@@ -7212,6 +7227,7 @@ avalability->availability
 avalable->available
 avalaibility->availability
 avalaible->available
+avalaibles->available
 avalance->avalanche
 avaliability->availability
 avaliable->available
@@ -7297,6 +7313,7 @@ awfull->awful, awfully,
 awfullly->awfully
 awfuly->awfully
 awkard->awkward
+awkardly->awkwardly
 awming->awning
 awmings->awnings
 awnin->awning, awn in,
@@ -7542,6 +7559,7 @@ basci->basic
 bascially->basically
 bascktrack->backtrack
 basf->base
+basially->basically
 basicallly->basically
 basicaly->basically
 basiclly->basically
@@ -10040,6 +10058,8 @@ cecksum->checksum
 cecksums->checksums
 cedential->credential
 cedentials->credentials
+ceeling->ceiling
+ceelings->ceilings
 cehck->check
 cehckbox->checkbox
 cehckboxes->checkboxes
@@ -13104,6 +13124,14 @@ compontent->component
 compontents->components
 comporator->comparator
 comporators->comparators
+comporess->compress
+comporessed->compressed
+comporesser->compressor
+comporessers->compressors
+comporesses->compresses
+comporessing->compressing
+comporessor->compressor
+comporessors->compressors
 comporison->comparison
 comporisons->comparisons
 composablity->composability
@@ -13318,6 +13346,8 @@ concatonate->concatenate
 concatonated->concatenated
 concatonates->concatenates
 concatonating->concatenating
+concecutive->consecutive
+concecutively->consecutively
 conceed->concede
 conceedd->conceded
 conceeding->conceding
@@ -14462,6 +14492,9 @@ constaints->constraints
 constallation->constellation
 constallations->constellations
 constan->constant
+constand->constant
+constandly->constantly
+constands->constants
 constanly->constantly
 constans->constants, constant, Constance,
 constantsm->constants
@@ -15407,6 +15440,7 @@ copmilers->compilers
 copmiles->compiles
 copmiling->compiling
 copmonent->component
+copmonents->components
 copmutations->computations
 copntroller->controller
 coponent->component
@@ -15519,6 +15553,8 @@ corespondences->correspondences
 coresponding->corresponding
 corespondingly->correspondingly
 coresponds->corresponds
+coreutil's->coreutils
+coreutil->coreutils
 corfirms->confirms
 coridal->cordial
 corispond->correspond
@@ -16092,6 +16128,7 @@ countain->contain
 countainer->container
 countainers->containers
 countains->contains
+counter-intuitivelly->counter-intuitively
 countere->counter
 counteres->counters
 counterfit->counterfeit
@@ -16992,6 +17029,7 @@ dancin->dancing
 dandidates->candidates
 dandlin->dandling
 dangereous->dangerous
+dangerouns->dangerous
 daplicating->duplicating
 daquiri->daiquiri
 daquiris->daiquiris
@@ -18517,6 +18555,12 @@ derefence->dereference
 derefenced->dereferenced
 derefences->dereferences
 derefencing->dereferencing
+derefenrecable->dereferenceable
+derefenrece->dereference
+derefenreceable->dereferenceable
+derefenreced->dereferenced
+derefenreces->dereferences
+derefenrecing->dereferencing
 derefenrence->dereference
 dereferance->dereference
 dereferanced->dereferenced
@@ -19061,6 +19105,8 @@ destionation->destination
 destionations->destinations
 destkop->desktop
 destkops->desktops
+destnation->destination
+destnations->destinations
 destop->desktop
 destops->desktops
 destoried->destroyed
@@ -19276,6 +19322,7 @@ deubug->debug
 deubuging->debugging
 deug->debug
 deugging->debugging
+devangari->Devanagari
 devastatin->devastating, devastation,
 devasted->devastated
 devation->deviation
@@ -19624,6 +19671,7 @@ dicussing->discussing
 dicussion->discussion
 dicussions->discussions
 did'nt->didn't
+didactical->didactic
 didi->did
 didnt'->didn't
 didnt't->didn't
@@ -19720,6 +19768,7 @@ differenes->differences
 differenly->differently
 differens->difference
 differense->difference
+differente->different, difference,
 differentes->differences, difference, different,
 differentiater->differentiator, differentiated, differentiates, differentiate,
 differentiaters->differentiators, differentiates,
@@ -20071,6 +20120,7 @@ directsions->directions
 directtories->directories
 directtory->directory
 directy->directly
+directyory->directory
 direectly->directly
 diregard->disregard
 direktly->directly
@@ -20421,6 +20471,7 @@ disired->desired
 disires->desires
 disiring->desiring
 disitributions->distributions
+disjointness->disjointedness
 diskrete->discrete
 diskretion->discretion
 diskretization->discretization
@@ -20849,6 +20900,7 @@ distrobuting->distributing
 distrobution->distribution
 distrobutions->distributions
 distrobuts->distributes
+Distrobxx->Distrobox
 distroname->distro name
 distroy->destroy
 distroyed->destroyed
@@ -20905,6 +20957,7 @@ disutils->distutils
 ditance->distance
 ditial->digital
 ditinguishes->distinguishes
+dito->ditto
 ditorconfig->editorconfig
 ditribute->distribute
 ditributed->distributed
@@ -21864,6 +21917,7 @@ eduction->education, reduction, deduction, seduction,
 eductions->reductions, deductions, educations, seductions,
 edxpected->expected
 eearly->early
+eeded->needed, heeded, seeded, weeded,
 eeeprom->EEPROM
 eeger->eager
 eegerly->eagerly
@@ -22362,6 +22416,8 @@ emtpies->empties
 emtpy->empty
 emty->empty
 emtying->emptying
+emualtor->emulator
+emualtors->emulators
 emulater->emulator, emulated, emulates, emulate,
 emulaters->emulators, emulates,
 emultor->emulator
@@ -24254,6 +24310,7 @@ executding->executing
 executeable->executable
 executeables->executables
 executible->executable
+executig->executing
 executign->executing
 executin->executing, execution,
 executiong->execution, executing,
@@ -24372,6 +24429,8 @@ exersizes->exercises
 exersizing->exercising
 exerternal->external
 exertin->exerting, exert in, exertion,
+exessive->excessive
+exessively->excessively
 exeuctable->executable
 exeuctables->executables
 exeucte->execute
@@ -25700,6 +25759,7 @@ facour->favour
 facourite->favourite
 facourites->favourites
 facours->favours
+facsimilie->facsimile
 factization->factorization
 factorin->factoring, factor in,
 factorizaiton->factorization
@@ -25766,6 +25826,8 @@ faktoring->factoring
 faktors->factors
 falback->fallback
 falbacks->fallbacks
+fale->false, fail,
+fales->false, fails,
 falg->flag
 falgs->flags
 falied->failed
@@ -26798,6 +26860,14 @@ formmatters->formatters
 formmatting->formatting
 formost->foremost
 formt->format, form,
+formtat->format
+formtated->formatted
+formtating->formatting
+formtats->formats
+formtatted->formatted
+formtatter->formatter
+formtatters->formatters
+formtatting->formatting
 formts->formats, forms,
 formtted->formatted
 formtter->formatter
@@ -27052,6 +27122,9 @@ frivilously->frivolously
 frmat->format
 frmo->from
 froce->force
+froced->forced
+froces->forces
+frocing->forcing
 froget->forget
 frogetting->forgetting
 frogot->forgot
@@ -28776,6 +28849,7 @@ highligher->highlighter
 highlighers->highlighters
 highlighing->highlighting
 highlighs->highlights
+highlightes->highlights, highlighted,
 highlightin->highlighting
 highlightning->highlighting
 highligjt->highlight
@@ -29378,6 +29452,7 @@ ignesting->ingesting
 ignests->ingests
 ignnore->ignore
 ignoded->ignored
+ignoerd->ignored
 ignonre->ignore
 ignora->ignore
 ignord->ignored
@@ -30756,6 +30831,7 @@ inexpirienced->inexperienced
 infact->in fact
 infalability->infallibility
 infallable->infallible
+infalliable->infallible
 infaltable->inflatable, infallible,
 infalte->inflate
 infalted->inflated
@@ -31455,6 +31531,7 @@ initilizer->initializer
 initilizers->initializers
 initilizes->initializes
 initilizing->initializing
+inititailiaze->initialize
 initital->initial
 inititalisation->initialisation
 inititalisations->initialisations
@@ -32203,6 +32280,7 @@ intenationally->internationally
 intendation->indentation, intention,
 intendations->indentations, intentions,
 intendend->intended
+intendes->intends, intended,
 intendet->intended
 intendin->intending, intend in,
 inteneded->intended
@@ -32938,6 +33016,7 @@ intterupted->interrupted
 intterupting->interrupting
 intterupts->interrupts
 intuative->intuitive
+intuitivelly->intuitively
 inturpratasion->interpretation
 inturpratation->interpretation
 inturprett->interpret
@@ -33725,6 +33804,7 @@ kubermetes->Kubernetes
 kubernates->Kubernetes
 kubernests->Kubernetes
 kubernete->Kubernetes
+kubernets->Kubernetes
 kuberntes->Kubernetes
 kwno->know
 kwnoledge->knowledge
@@ -34120,6 +34200,7 @@ levetating->levitating
 levitatin->levitating, levitation,
 levl->level
 levle->level
+levls->levels
 lew->lieu, hew, sew, dew,
 lewchemia->leukaemia, leukemia,
 lewow->luau
@@ -35453,6 +35534,7 @@ medhod->method
 medhods->methods
 mediciney->medicine, medicinal,
 mediciny->medicine, medicinal,
+medicore->mediocre, Medicare,
 medievel->medieval
 medifor->metaphor
 medifors->metaphors
@@ -35879,6 +35961,7 @@ milimetre->millimetre
 milimetres->millimetres
 milimiters->millimeters
 milion->million
+milions->millions
 miliraty->military
 milisecond->millisecond
 miliseconds->milliseconds
@@ -36221,6 +36304,7 @@ missunderstood->misunderstood
 missuse->misuse
 missused->misused
 missusing->misusing
+mistankely->mistakenly
 mistatch->mismatch
 mistatchd->mismatched
 mistatched->mismatched
@@ -37155,6 +37239,7 @@ natioanlly->nationally
 natioanls->nationals
 nationalisin->nationalising
 nationalizin->nationalizing
+nativelly->natively
 nativelyx->natively
 natrual->natural
 natrually->naturally
@@ -39161,6 +39246,7 @@ openned->opened
 openning->opening
 openscource->open-source, open source, opensource,
 openscourced->open-sourced, open sourced, opensourced,
+opentememetry->OpenTelemetry
 operaand->operand
 operaands->operands
 operaion->operation
@@ -41208,6 +41294,8 @@ pendig->pending
 pendin->pending, pend in,
 pendning->pending
 penerator->penetrator
+pengiun->penguin
+pengiuns->penguins
 pengwen->penguin
 pengwens->penguins
 pengwin->penguin
@@ -42786,6 +42874,7 @@ precceding->preceding
 precding->preceding
 preced->precede
 precedencs->precedence
+precedense->precedence
 precedessor->predecessor
 precedin->preceding
 preceds->precedes
@@ -43008,6 +43097,7 @@ prejudgudicing->prejudicing
 prejudicin->prejudicing
 preliferation->proliferation
 prelimitary->preliminary
+prematurelly->prematurely
 premeire->premiere
 premeired->premiered
 premillenial->premillennial
@@ -43063,6 +43153,7 @@ preprares->prepares
 prepraring->preparing
 preprend->prepend
 preprended->prepended
+preprepared->prepared
 prepresent->represent
 prepresented->represented
 prepresents->represents
@@ -45752,6 +45843,7 @@ reciprocoal->reciprocal
 reciprocoals->reciprocals
 recipt->receipt, recipe,
 recipts->receipts, recipes,
+recivable->receivable
 recive->receive
 recived->received
 reciver->receiver
@@ -46672,6 +46764,7 @@ reguster->register
 rehearsin->rehearsing, rehears in,
 rehersal->rehearsal
 rehersing->rehearsing
+rehighlightes->rehighlights, rehighlighted,
 reicarnation->reincarnation
 reight->right, eight, freight,
 reigining->reigning
@@ -49165,6 +49258,7 @@ runnig->running
 runnign->running
 runnigng->running
 runnin->running
+runnining->running
 runnint->running
 runnner->runner
 runnners->runners
@@ -49389,6 +49483,7 @@ satements->statements
 saterday->Saturday
 saterdays->Saturdays
 satifaction->satisfaction
+satifactory->satisfactory
 satified->satisfied
 satifies->satisfies
 satifsy->satisfy
@@ -49520,6 +49615,7 @@ scavanged->scavenged
 scavanger->scavenger
 scavangers->scavengers
 scavanges->scavenges
+scavanging->scavenging
 sccess->success
 sccesses->successes
 sccessful->successful
@@ -50421,6 +50517,7 @@ seperare->separate
 seperared->separated
 seperares->separates
 seperat->separate
+seperatable->separable
 seperataed->separated
 seperatally->separately
 seperataly->separately
@@ -50530,6 +50627,7 @@ sequelce->sequence
 sequemce->sequence
 sequemces->sequences
 sequenc->sequence
+sequencess->sequences
 sequencial->sequential
 sequencially->sequentially
 sequencies->sequences
@@ -51011,7 +51109,7 @@ shouuldn't->shouldn't
 shouw->show
 shouws->shows
 showfer->chauffeur, shower,
-showin->showing, show in,
+showin->showing, show in, shown,
 showvinism->chauvinism
 shpae->shape
 shpaes->shapes
@@ -51041,6 +51139,8 @@ shttp->https
 shuckin->shucking, shuck in,
 shudown->shutdown
 shufle->shuffle
+shuit->shut, suit, shit,
+shuits->shuts, suits, shits,
 shuld->should
 shuold->should
 shuoldnt->shouldn't
@@ -52425,6 +52525,7 @@ specifyied->specified
 specifyig->specifying
 specifyin->specifying, specify in,
 specifyinhg->specifying
+specifyng->specifying
 speciic->specific
 speciied->specified
 speciifc->specific
@@ -53058,6 +53159,7 @@ staition->station
 staitions->stations
 stalagtite->stalactite
 stamement's->statement's, statements, statement,
+stampeed->stampede, stamped,
 stanalone->standalone
 stanard->standard
 stanardisation->standardisation
@@ -53224,6 +53326,7 @@ stattistic->statistic
 stattistical->statistical
 stattistically->statistically
 stattistics->statistics
+statu->status, statue,
 statubar->statusbar
 statuline->statusline
 statulines->statuslines
@@ -53247,6 +53350,7 @@ stayin->staying, stay in, stain,
 stcokbrush->stockbrush
 stdanard->standard
 stdanards->standards
+stdoud->stdout
 steamin->steaming, steam in,
 stegnographic->steganographic
 stegnography->steganography
@@ -53275,6 +53379,12 @@ stil->still
 stilus->stylus
 stingent->stringent
 stip->strip, stop,
+stiple->stipple
+stipled->stippled
+stipler->stippler
+stiplers->stipplers
+stiples->stipples
+stipling->stippling
 stipped->stripped
 stiring->stirring
 stirng->string
@@ -53706,7 +53816,9 @@ subjet->subject
 subjudgation->subjugation
 sublass->subclass
 sublasse->subclasse
+sublassed->subclassed
 sublasses->subclasses
+sublassing->subclassing
 sublcass->subclass
 sublcasses->subclasses
 sublcuase->subclause
@@ -55474,6 +55586,7 @@ temaplate->template
 temaplated->templated
 temaplates->templates
 temaplating->templating
+tememetry->telemetry
 temeprature->temperature
 temepratures->temperatures
 temerature->temperature
@@ -55576,6 +55689,7 @@ temporily->temporarily
 tempororaries->temporaries
 tempororarily->temporarily
 tempororary->temporary
+tempororay->temporary
 temporories->temporaries
 tempororily->temporarily
 temporory->temporary
@@ -58200,6 +58314,8 @@ unexpacted->unexpected
 unexpactedly->unexpectedly
 unexpcted->unexpected
 unexpctedly->unexpectedly
+unexpeced->unexpected
+unexpecedly->unexpectedly
 unexpecetd->unexpected
 unexpecetdly->unexpectedly
 unexpect->unexpected
@@ -58260,6 +58376,7 @@ unfortuante->unfortunate
 unfortuantely->unfortunately
 unfortuate->unfortunate
 unfortuately->unfortunately
+unfortunaletly->unfortunately
 unfortunalte->unfortunate
 unfortunaltely->unfortunately
 unfortunaly->unfortunately
@@ -58358,6 +58475,7 @@ uninstlaler->uninstaller
 uninstlaling->uninstalling
 uninstlals->uninstalls
 unint8_t->uint8_t
+uninteded->unintended
 unintelligable->unintelligible
 unintelligble->unintelligible
 unintented->unintended, unindented,
@@ -58669,6 +58787,7 @@ unsaged->unsaved, unstaged,
 unsages->usages, unstages,
 unsaging->unstaging
 unsanfe->unsafe
+unsatifactory->unsatisfactory
 unsccessful->unsuccessful
 unscubscribe->subscribe
 unscubscribed->subscribed

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -114,6 +114,7 @@ girds->grids
 guarantied->guaranteed
 guerilla->guerrilla
 guerillas->guerrillas
+göyph->glyph
 habitant->inhabitant
 habitants->inhabitants
 hart->heart, harm,


### PR DESCRIPTION
These typos were found in Emacs as well as my dayjob.

Edited to add in alternatives as well as for consistency.