### PR TITLE
Add typos found in GNU Guile

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -721,6 +721,7 @@ accesor->accessor
 accesories->accessories
 accesors->accessors
 accesory->accessory
+accessa->access a
 accessability->accessibility
 accessable->accessible
 accessbile->accessible
@@ -3365,6 +3366,8 @@ alwauys->always
 alway->always
 alwyas->always
 alwys->always
+alyer->layer
+alyers->layers
 alyways->always
 amacing->amazing
 amacingly->amazingly
@@ -4830,6 +4833,7 @@ aproch->approach
 aproched->approached
 aproches->approaches
 aproching->approaching
+aprogram->a program
 aproove->approve
 aprooved->approved
 apropiate->appropriate
@@ -8670,6 +8674,7 @@ bufferes->buffers, buffered,
 bufferin->buffering, buffer in,
 bufferred->buffered
 bufferring->buffering
+buffes->buffers
 buffeur->buffer
 bufffer->buffer
 bufffered->buffered
@@ -13341,6 +13346,7 @@ conceous->conscious
 conceousally->consciously
 conceously->consciously
 conceptification->conceptualization, conceptualisation,
+conceptionally->conceptually
 concequence->consequence
 concequences->consequences
 concered->concerned
@@ -14984,6 +14990,10 @@ contributiongs->contributions
 contributon->contribution, contributor,
 contributons->contributions, contributors,
 contries->countries
+contrieve->contrive
+contrieved->contrived
+contrieves->contrives
+contrieving->contriving
 contrinution->contribution
 contrinutions->contributions
 contritutions->contributions
@@ -15108,6 +15118,8 @@ conventience->convenience
 conventiences->conveniences
 conventient->convenient
 conventiently->conveniently
+conventioal->conventional
+conventioally->conventionally
 convenvient->convenient
 conver->convert, cover, convex, convey, confer,
 converage->coverage, converge,
@@ -22184,6 +22196,7 @@ emable->enable
 emabled->enabled
 emables->enables
 emabling->enabling
+emac->Emacs
 emai->email
 emailin->emailing, email in,
 emailling->emailing
@@ -22956,7 +22969,11 @@ envioronment->environment
 envioronmental->environmental
 envioronments->environments
 envireonment->environment
+envireonmental->environmental
+envireonments->environments
 envirionment->environment
+envirionmental->environmental
+envirionments->environments
 envirnment->environment
 envirnmental->environmental
 envirnments->environments
@@ -23230,6 +23247,10 @@ erorrs->errors
 erors->errors
 erraneous->erroneous
 erraneously->erroneously
+errect->erect
+errected->erected
+errecting->erecting
+errects->erects
 erro->error
 erroneos->erroneous
 erroneosly->erroneously
@@ -24582,6 +24603,8 @@ expanation->explanation, expansion,
 expanations->explanations, expansions,
 expanble->expandable
 expandin->expanding, expand in,
+expandr->expander
+expandrs->expanders
 expaned->expand, expanded, explained,
 expaneded->expanded
 expaneding->expanding
@@ -27617,6 +27640,10 @@ generalyl->generally
 generalyse->generalise
 generaor->generator
 generaors->generators
+generare->generate
+generared->generated
+generares->generates
+generaring->generating
 generat->generate, general,
 generatd->generated
 generater->generator, generated, generates, generate,
@@ -28297,6 +28324,7 @@ guideded->guided
 guidence->guidance
 guidline->guideline
 guidlines->guidelines
+guie->guide, guile, guise,
 Guilia->Giulia
 Guilio->Giulio
 Guiness->Guinness
@@ -29384,6 +29412,7 @@ ignord->ignored
 ignoreing->ignoring
 ignorence->ignorance
 ignorent->ignorant
+ignoret->ignored
 ignorgable->ignorable
 ignorgd->ignored
 ignorge->ignore
@@ -29677,6 +29706,8 @@ implemanting->implementing
 implemants->implements
 implemataion->implementation
 implemataions->implementations
+implemation->implementation
+implemations->implementations
 implemememnt->implement
 implemememntation->implementation
 implemement->implement
@@ -30910,6 +30941,7 @@ inherith->inherit
 inherithed->inherited
 inherithing->inheriting
 inheriths->inherits
+inheritied->inherited
 inheritin->inheriting, inherit in,
 inheritted->inherited
 inheritting->inheriting
@@ -31455,6 +31487,7 @@ initilizer->initializer
 initilizers->initializers
 initilizes->initializes
 initilizing->initializing
+inititailiaze->initialize
 initital->initial
 inititalisation->initialisation
 inititalisations->initialisations
@@ -32804,6 +32837,7 @@ intitiatives->initiatives
 intitiator->initiator
 intitiators->initiators
 intity->entity
+intoduction->introduction
 intorduce->introduce
 intorduced->introduced
 intorduces->introduces
@@ -34645,6 +34679,7 @@ longitute->longitude
 longst->longest
 longuer->longer
 longuest->longest
+longwinded->long-winded
 lonley->lonely
 lonly->lonely, only,
 looback->loopback
@@ -35605,6 +35640,7 @@ menue->menu
 menues->menus
 menutitems->menuitems
 meny->menu, many,
+meoization->memoization
 meory->memory, Maori,
 meraj->mirage
 merajes->mirages
@@ -36564,6 +36600,7 @@ montioring->monitoring
 montiors->monitors
 montly->monthly
 Montnana->Montana
+montonic->monotonic
 montor->monitor, motor, mentor,
 montored->monitored, mentored,
 montoring->monitoring, mentoring,
@@ -46577,6 +46614,7 @@ regitrations->registrations
 regitries->registries
 regitry->registry
 regluar->regular
+regluarize->regularize
 regnerate->regenerate
 regnerated->regenerated
 regnerates->regenerates
@@ -50201,6 +50239,7 @@ semgentations->segmentations
 semgented->segmented
 semgenting->segmenting
 semgents->segments
+semicoli->semicolons
 semicolor->semicolon
 semicolumn->semicolon
 semiconducter->semiconductor
@@ -53301,6 +53340,7 @@ stocastic->stochastic
 stoer->store
 stoers->stores
 stomache->stomach
+stompling->stomping
 stompted->stomped
 stong->strong
 stonger->stronger
@@ -55905,6 +55945,7 @@ texured->textured
 texures->textures
 texxt->text
 tey->they
+tge->the
 tghe->the
 tha->than, that, the,
 thair->their, there,
@@ -56139,6 +56180,7 @@ thowards->towards
 thowing->throwing, towing, showing, thawing,
 thown->thrown, town,
 thows->throws, those, tows,
+thpe->type
 thq->the
 thrad->thread
 thraded->threaded, traded,
@@ -56669,6 +56711,8 @@ trancodes->transcodes
 trancoding->transcoding
 trancodings->transcodings
 trandional->traditional
+tranducer->transducer
+tranducers->transducers
 traned->trained
 traner->trainer
 traners->trainers
@@ -58358,6 +58402,7 @@ uninstlaler->uninstaller
 uninstlaling->uninstalling
 uninstlals->uninstalls
 unint8_t->uint8_t
+uninteded->unintended
 unintelligable->unintelligible
 unintelligble->unintelligible
 unintented->unintended, unindented,
@@ -59590,6 +59635,7 @@ variabla->variable
 variablas->variables
 variablen->variable
 variablens->variables
+variablesm->variables
 variabls->variables
 varialbe->variable
 varialbes->variables


### PR DESCRIPTION
These typos were found in GNU Guile, but were not caught by codespell:
https://www.gnu.org/software/guile/

Lightly edited to add in alternatives.