### PR TITLE
Add rare typo `hep->heap, help,`

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -28747,10 +28747,17 @@ henc->hence
 henderence->hindrance
 hendler->handler
 hense->hence
+heped->helped
+heper->helper
+hepers->helpers
+heping->helping
+hepl->help
 hepled->helped
 hepler->helper
 heplers->helpers
 hepling->helping
+hepls->helps
+heps->helps, heaps,
 herad->heard, Hera,
 herarchical->hierarchical
 herarchically->hierarchically

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -120,6 +120,7 @@ habitants->inhabitants
 hart->heart, harm,
 heighth->height, eight, eighth,
 heighths->heights, eights, eighths,
+hep->heap, help,
 heterogenous->heterogeneous
 hided->hidden, hid,
 hims->his, hymns,


### PR DESCRIPTION
Found in Emacs.