### PR TITLE
Add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage
+.venv
 build
 dist
 ld


### PR DESCRIPTION
This is a directory that a lot of developers use for their virtual environment, so it would be useful to have it ignored.