### PR TITLE
These typos do not belong to code, do they?

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2790,6 +2790,7 @@ agravate->aggravate
 agravated->aggravated
 agravates->aggravates
 agravating->aggravating
+agrc->argc
 agre->agree
 agreable->agreeable
 agreableness->agreeableness
@@ -2870,6 +2871,7 @@ agruing->arguing
 agrument->argument
 agrumentative->argumentative
 agruments->arguments
+agrv->argv
 ags->tags, ages,
 agsinst->against
 agument->argument, augment,
@@ -45166,6 +45168,7 @@ pulisher->publisher
 pulishers->publishers
 pulishes->publishes
 pulishing->publishing
+pullrequenst->pull requests, pull request,
 puls->pulse, plus,
 pumkin->pumpkin
 punctation->punctuation
@@ -55967,6 +55970,8 @@ tansverse->transverse
 tarbal->tarball
 tarbals->tarballs
 tarce->trace
+tarceback->traceback
+tarcebacks->tracebacks
 tarced->traced
 tarces->traces
 tarcing->tracing

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -1,7 +1,6 @@
-agrv->argv
 alacritty->alacrity
 alloced->allocated
-amin->main
+amin->main, admin, amine,
 apoint->appoint
 arange->arrange, a range,
 assertin->asserting, assert in, assertion,
@@ -55,7 +54,6 @@ od->of
 outputof->output of, output-of,
 packat->packet
 protecten->protection, protected,
-pullrequenst->pull requests, pull request,
 pullrequest->pull request
 pullrequests->pull requests
 pysic->physic
@@ -82,8 +80,6 @@ storaget->storage
 stringly->strongly, stringy,
 subpatchs->subpatches
 sur->sure, sir,
-tarceback->traceback
-tarcebacks->tracebacks
 templace->template
 thead->thread
 theads->threads


### PR DESCRIPTION
While the suggested fixes are words often used in code, the typos themselves do not seem to be valid words - even in code.

Fixes https://github.com/codespell-project/codespell/issues/3430#issuecomment-2184969088.