### PR TITLE
Add machine-readable output format, and test

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -465,6 +465,13 @@ def parse_options(
         default=False,
         help="print summary of fixes",
     )
+    parser.add_argument(
+        "-m",
+        "--machine-readable",
+        action="store_true",
+        default=False,
+        help="Use alternate output format intended for parsing",
+    )
 
     parser.add_argument(
         "--count",
@@ -1018,6 +1025,15 @@ def parse_file(
 
                 if (not context_shown) and (context is not None):
                     print_context(lines, i, context)
+
+                if options.machine_readable:
+                    mrreason = f" ({reason})" if reason else ""
+                    print(
+                        f"@{filename}: line {i + 1}, col {match.start() + 1}, "
+                        f"{word} ==> {fixword}{mrreason}"
+                    )
+                    continue
+
                 if filename != "-":
                     print(
                         f"{cfilename}:{cline}: {cwrongword} "


### PR DESCRIPTION
Passing `--machine-readable` / `-m` to codespell, or setting `machine-readable = true` in the config file, will enable an output format designed to be more easily parsed, and containing the start column of the match (usually not output).

Inspired by the `eslint -f compact` format (which is no longer part of standard eslint), but with an added `@` at the start of each line. (Useful when combined with context or summary options, to parse only the lines containing error data).

Intended primarily for actions-codespell and other wrapper scripts.

A new test, `test_machine_readable`, is added to `test_basic.py` to verify basic functionality of the new option.

The output, specifically, takes the form:
```text
@./path/file.xtn: line 1, col 1, wrongword => rightword (reason if defined)
```

Line and column numbers are 1-based (`i + 1` and `match.start() + 1` in the code, respectively).