### PR TITLE
Add thrustworth(y|iness)->trustworth(y|iness).

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -58119,6 +58119,8 @@ thruogh->through
 thruoghout->throughout
 thruoghput->throughput
 thruout->throughout
+thrustworthiness->trustworthiness
+thrustworthy->trustworthy
 ths->the, this,
 Thse->these, this,
 thses->these


### PR DESCRIPTION
Similar to #3482 for another variant, see e.g. (Note: grep.app results are low but GitHub code search shows way more):
- https://grep.app/search?q=thrustworthy
- https://grep.app/search?q=thrustworthiness
- https://github.com/search?q=thrustworthy&type=code
- https://github.com/search?q=thrustworthiness&type=code

Note: Not sure if we should also add `thrust-worthy` and `thrust-worthiness` as correction alternatives?