### PR TITLE
add enrol->enroll to en-GB to en-US dictionary

### DIFF
--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -144,6 +144,7 @@ endeavour->endeavor
 endeavoured->endeavored
 endeavouring->endeavoring
 endeavours->endeavors
+enrol->enroll
 equalisation->equalization
 equalise->equalize
 equalised->equalized

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -145,6 +145,9 @@ endeavoured->endeavored
 endeavouring->endeavoring
 endeavours->endeavors
 enrol->enroll
+enrolment->enrollment
+enrolments->enrollments
+enrols->enrolls
 equalisation->equalization
 equalise->equalize
 equalised->equalized


### PR DESCRIPTION
Google books graphs source showing that enrol is common in British English while enroll is used in American English: https://books.google.com/ngrams/graph?content=enrol%2Cenroll&year_start=1800&year_end=2019&corpus=en-GB-2019&smoothing=3