### PR TITLE
Add spelling correction for separately.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -52335,6 +52335,8 @@ seplicurally->sepulchrally
 seplicuraly->sepulchrally
 seplicurlly->sepulchrally
 seporate->separate
+sepparatelly->separately
+sepparately->separately
 sepparation->separation
 sepparations->separations
 sepperate->separate


### PR DESCRIPTION
See e.g. (For the first there are not that much hits but a few are there):
- https://github.com/search?q=sepparatelly&type=code
- https://grep.app/search?q=sepparatelly
- https://github.com/search?q=sepparately&type=code
- https://grep.app/search?q=sepparately