### PR TITLE
Move `hom` to code dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -30471,7 +30471,6 @@ hokay->okay
 holf->hold
 holliday->holiday
 hollowcost->holocaust
-hom->home, whom,
 homapage->homepage
 homapages->homepages
 hombrew->Homebrew

--- a/codespell_lib/data/dictionary_code.txt
+++ b/codespell_lib/data/dictionary_code.txt
@@ -37,6 +37,7 @@ gadjet->gadget
 gadjets->gadgets
 gae->game, Gael, gale,
 hist->heist, his,
+hom->home, whom,
 iam->I am, aim,
 iff->if
 ifset->if set


### PR DESCRIPTION
This word appears in mathematical code:
https://en.wikipedia.org/wiki/HOM