### PR TITLE
feat: add typo spelling for capabilities

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10976,6 +10976,7 @@ capabilitiy->capability
 capabillities->capabilities
 capabillity->capability
 capabilties->capabilities
+capabiltiies->capabilities
 capabiltities->capabilities
 capabiltity->capability
 capabilty->capability

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10979,6 +10979,7 @@ capabilties->capabilities
 capabiltiies->capabilities
 capabiltities->capabilities
 capabiltity->capability
+capabiltiy->capability
 capabilty->capability
 capabitilies->capabilities
 capabitily->capability


### PR DESCRIPTION
An additional misspelling of the word "capabilities" for correction. 