### PR TITLE
Handle CTRL+C by showing a better message

### DIFF
--- a/codespell_lib/__main__.py
+++ b/codespell_lib/__main__.py
@@ -3,7 +3,4 @@ import sys
 from ._codespell import _script_main
 
 if __name__ == "__main__":
-    try:
-        sys.exit(_script_main())
-    except KeyboardInterrupt:
-        sys.exit(f"\ncancelling '{sys.argv[0]}'\n")
+    sys.exit(_script_main())

--- a/codespell_lib/__main__.py
+++ b/codespell_lib/__main__.py
@@ -6,4 +6,4 @@ if __name__ == "__main__":
     try:
         sys.exit(_script_main())
     except KeyboardInterrupt:
-        pass
+        sys.exit(f"\ncancelling '{sys.argv[0]}'\n")

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1103,7 +1103,8 @@ def _script_main() -> int:
         return main(*sys.argv[1:])
     except KeyboardInterrupt:
         # User has typed CTRL+C
-        sys.stderr.write(f"\nCancelling '{sys.argv[0]}'\n")
+        sys.stdout.write("\n")
+        sys.stderr.write(f"Cancelling '{sys.argv[0]}'\n")
         return 130
 
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1099,7 +1099,11 @@ def flatten_clean_comma_separated_arguments(
 
 def _script_main() -> int:
     """Wrap to main() for setuptools."""
-    return main(*sys.argv[1:])
+    try:
+        return main(*sys.argv[1:])
+    except KeyboardInterrupt:
+        sys.stderr.write(f"\ncancelling '{sys.argv[0]}'\n")
+        return 1
 
 
 def _usage_error(parser: argparse.ArgumentParser, message: str) -> int:

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1104,7 +1104,6 @@ def _script_main() -> int:
     except KeyboardInterrupt:
         # User has typed CTRL+C
         sys.stdout.write("\n")
-        sys.stderr.write(f"Cancelling '{sys.argv[0]}'\n")
         return 130
 
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1102,8 +1102,9 @@ def _script_main() -> int:
     try:
         return main(*sys.argv[1:])
     except KeyboardInterrupt:
-        sys.stderr.write(f"\ncancelling '{sys.argv[0]}'\n")
-        return 1
+        # User has typed CTRL+C
+        sys.stderr.write(f"\nCancelling '{sys.argv[0]}'\n")
+        return 130
 
 
 def _usage_error(parser: argparse.ArgumentParser, message: str) -> int:


### PR DESCRIPTION
This tidies-up messages while using interactive codespell, if the user decides to cancel using CTRL+C.

For example, before this PR:
```console
$ codespell -i1 file.txt
hte
	hte ==> the (Y/n) ^CTraceback (most recent call last):
  File "/tmp/py310/bin/codespell", line 8, in <module>
    sys.exit(_script_main())
  File "/home/mtoews/src/codespell/codespell_lib/_codespell.py", line 1102, in _script_main
    return main(*sys.argv[1:])
  File "/home/mtoews/src/codespell/codespell_lib/_codespell.py", line 1324, in main
    bad_count += parse_file(
  File "/home/mtoews/src/codespell/codespell_lib/_codespell.py", line 1007, in parse_file
    fix, fixword = ask_for_word_fix(
  File "/home/mtoews/src/codespell/codespell_lib/_codespell.py", line 775, in ask_for_word_fix
    r = sys.stdin.readline().strip().upper()
KeyboardInterrupt

$ echo $?
130
```
and after this PR:
```console
$ codespell -i1 file.txt
hte
	hte ==> the (Y/n) ^C
Cancelling '/tmp/py310/bin/codespell'
$ echo $?
130
```

And the same behaviour if a user starts codespell with `python -m codespell_lib ...`

---

Currently there is no test for this. It's probably possible, but not easy for me to construct. If this is important to include, I'd appreciate some tips on how to enable testing [`SIGINT`](https://docs.python.org/3/library/signal.html#signal.SIGINT).