### PR TITLE
Add stuty -> study and variations

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -55547,7 +55547,11 @@ stuructured->structured
 stuructures->structures
 sturucturing->structuring
 stutdown->shutdown
+stutied->studied
+stuties->studies
 stutus->status
+stuty->study
+stutying->studying
 styed->stayed, styled,
 styhe->style
 styile->style


### PR DESCRIPTION
It seems common to write "study" with a T instead of D:

- `stuty` appears in https://github.com/boschresearch/cx-testdata-2-edc/blob/e06311fea52ceb8263351c169b4bf4eda2acc742/dependencies.py#L45
- `stutying` appears in https://github.com/lukas-brn/lukas-brn/blob/9ff9ef645dcc9b820d027917cfb1b0597094dae6/README.md?plain=1#L33
- `stuties` appears in https://github.com/sanket293/shiv-pooja-angular-/blob/a22010662385646650a182a9eb4af571a597a3d5/todo.txt#L18