### PR TITLE
fix(rare): remove loath->loathe, as loath is as common as loathe

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -159,7 +159,6 @@ lien->line
 liens->lines
 lightening->lightning, lighting,
 loafing->loading
-loath->loathe
 lod->load, loud, lode,
 loner->longer
 loos->loose, lose,


### PR DESCRIPTION
resolves #3522

I committed a false positive when checking Python peps because `loath` was rewritten to `loathe` and I wasn't aware that `loath` is a thing. It's the adjective, whereas `loathe` is a verb.

Per Google ngram, loath is as common as loathe, so it shouldn't be a clear rewrite. It should simply be removed as it's not a clear typo nor is one much more common than the other.

<img width="2165" alt="Google Chrome 2024-08-18 18 48 17" src="https://github.com/user-attachments/assets/258c49dd-1884-44a9-a383-ebc3717d5b17">

https://books.google.com/ngrams/graph?content=loath%2Cloathe&year_start=1800&year_end=2022&corpus=en&smoothing=3

See https://github.com/python/peps/commit/ee430d694f88eff4181e9c06d28104b4697d9cfe where this happened live.

https://github.com/codespell-project/codespell/blame/f0695997de58d3b9c790a940cbb94e14640bdc97/codespell_lib/data/dictionary_rare.txt#L162