### PR TITLE
Add spelling correction for appliance and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5207,6 +5207,8 @@ aplhabet->alphabet
 aplhabetical->alphabetical
 aplhabetically->alphabetically
 aplhabets->alphabets
+apliance->appliance, alliance,
+apliances->appliances, alliances,
 aplicabile->applicable
 aplicability->applicability
 aplicable->applicable
@@ -5467,6 +5469,7 @@ applicaiton->application
 applicaitons->applications
 applicalbe->applicable
 applicance->appliance
+applicances->appliances
 applicapility->applicability
 applicaple->applicable
 applicatable->applicable


### PR DESCRIPTION
See e.g.
- https://grep.app/search?q=Apliance&words=true
- https://grep.app/search?q=applicance
- https://github.com/search?q=%22apliances%22&type=code (Has many unrelated hits but e.g. `apliances_path` can be seen there)