### PR TITLE
Add spelling correction for revert and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -48456,9 +48456,12 @@ referrrer->referrer
 referrrers->referrers
 referrring->referring
 referrs->refers
+refert->revert, refer, refers,
+referted->reverted, referred, refereed,
 refertence->reference
 refertenced->referenced
 refertences->references
+referting->reverting, referring,
 refesh->refresh
 refeshed->refreshed
 refeshes->refreshes


### PR DESCRIPTION
See e.g.:
- https://github.com/search?q=referted&type=code
- https://grep.app/search?q=referted
- https://github.com/search?q=referting&type=code
- https://grep.app/search?q=refert&words=true&filter[lang][0]=Python (Only Python included as the other findings seems to include mostly "dummy" text like e.g. `Refert tamen, quo modo`)