### PR TITLE
master → main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,10 @@ on:
     types: [published]
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: v4.6.0
     hooks:
       - id: no-commit-to-branch
-        args: [--branch, master]
+        args: [--branch, main]
       - id: check-yaml
         args: [--unsafe]
       - id: debug-statements

--- a/README.rst
+++ b/README.rst
@@ -364,13 +364,13 @@ In the scenario where the user prefers not to follow the development version of 
 
 .. code-block:: sh
 
-    wget https://raw.githubusercontent.com/codespell-project/codespell/master/codespell_lib/data/dictionary.txt
+    wget https://raw.githubusercontent.com/codespell-project/codespell/main/codespell_lib/data/dictionary.txt
     codespell -D dictionary.txt
 
 The above simply downloads the latest ``dictionary.txt`` file and then by utilizing the ``-D`` flag allows the user to specify the freshly downloaded ``dictionary.txt`` as the custom dictionary instead of the default one.
 
 You can also do the same thing for the other dictionaries listed here:
-    https://github.com/codespell-project/codespell/tree/master/codespell_lib/data
+    https://github.com/codespell-project/codespell/tree/main/codespell_lib/data
 
 License
 -------


### PR DESCRIPTION
Attempt to fix the recent failures of the `package` job:
https://github.com/codespell-project/codespell/blob/c3c5989def487d4376a2c2658baaedc5e1cde6aa/.github/workflows/release.yml#L18-L42

![package](https://github.com/user-attachments/assets/7dece80e-cfe6-459d-8885-3348f9eeee63)
