### PR TITLE
feat: add typo for override and overridden

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -42284,6 +42284,8 @@ overriddes->overrides
 overridding->overriding
 overrideable->overridable
 overrided->overrode, overridden,
+overridee->override
+overrideen->overridden
 overriden->overridden
 overrident->overridden
 overridiing->overriding


### PR DESCRIPTION
Adds additional misspelling of the words"override" and "overridden" to the dictionary for correction.