### PR TITLE
Add generaml->general spelling correction.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -29422,6 +29422,7 @@ generallly->generally
 generaly->generally
 generalyl->generally
 generalyse->generalise
+generaml->general
 generaor->generator
 generaors->generators
 generare->generate


### PR DESCRIPTION
Found only a single occurrence via https://github.com/search?q=Generaml&type=code:

https://github.com/materials-data-facility/nucapt/blob/91d4c0aefce04ada6e8c56ae0b0ca4660c806b2c/nucapt/manager.py#L149

but i made such a typo on my own recently so it might happen and thus submitting it here.