### PR TITLE
Add spelling correction for leadin.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -35931,6 +35931,7 @@ lcuase->clause
 leaast->least
 leace->leave
 leack->leak
+leadin->leading, lead in,
 leagacy->legacy
 leagal->legal
 leagalise->legalise


### PR DESCRIPTION
- See e.g. https://grep.app/search?q=leadin&words=true (a few are variables like `leadIn` but that IMHO shouldn't matter)
- There is already the `misleadin->misleading, mislead in,` in the dictionary