### PR TITLE
Add spelling correction for "agos".

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2800,6 +2800,7 @@ agonsticism->agnosticism
 agorithm->algorithm
 agorithmic->algorithmic
 agorithms->algorithms
+agos->ago, ages, egos, Lagos,
 agracultural->agricultural
 agrain->again
 agrandize->aggrandize


### PR DESCRIPTION
Doesn't happen that much if looking at https://grep.app/search?q=%20agos%20&words=true but found e.g. this:

> 1 week agos is invalid

and did this typo recently as well.