### PR TITLE
Do not allow for a word to start with punctuation symbols

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -53,7 +53,7 @@ from ._version import (  # type: ignore[import-not-found]
     __version__ as VERSION,  # noqa: N812
 )
 
-word_regex_def = r"[\w\-'’]+"  # noqa: RUF001
+word_regex_def = r"\w[\w\-'’]*"  # noqa: RUF001
 # While we want to treat characters like ( or " as okay for a starting break,
 # these may occur unescaped in URIs, and so we are more restrictive on the
 # endpoint.  Emails are more restrictive, so the endpoint remains flexible.

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -51,6 +51,7 @@ class MainWrapper:
         capsys = frame.f_locals["capsys"]
         stdout, stderr = capsys.readouterr()
         assert code in (EX_OK, EX_USAGE, EX_DATAERR, EX_CONFIG)
+        # print(f"stderr: {stderr}")
         if code == EX_DATAERR:  # have some misspellings
             code = int(stderr.split("\n")[-2])
         elif code == EX_OK and count:
@@ -117,7 +118,7 @@ def test_basic(
     assert cs.main("--builtin", "clear,rare,names,informal", fname) == 4
     with fname.open("w") as f:  # overwrite the file
         f.write("var = 'nwe must check codespell likes escapes nin strings'\n")
-    assert cs.main(fname) == 1, "checking our string escape test word is bad"
+    assert cs.main(fname) == 2, "checking our string escape test word is bad"
     # the first one is missed because the apostrophe means its not currently
     # treated as a word on its own
     with fname.open("w") as f:  # overwrite the file


### PR DESCRIPTION
The inspired for me to look use case
- https://github.com/INTERSECT-SDK/python-sdk/pull/19/files/33da9ff31d6162caa0dfc1a1155f321e6d68b1cc#diff-10380fd6e5ecb84c1ae11e135982739946c5aff1a50499378db397cf5034f54e

And then I found the issue this
- Close #3305

Although may be I am missing the use-cases/problems @DimitriPapadopoulos and @mdeweerd discussed back then