### PR TITLE
END: add "queues" (plural from queue) as possible fix for ques

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -218,7 +218,7 @@ protestors->protesters
 provence->province
 purportive->supportive
 purvue->purview
-ques->quest,queues,
+ques->quest, queues,
 readd->re-add, read,
 readded->re-added, read,
 readding->re-adding, reading,

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -218,7 +218,7 @@ protestors->protesters
 provence->province
 purportive->supportive
 purvue->purview
-ques->quest
+ques->quest,queues
 readd->re-add, read,
 readded->re-added, read,
 readding->re-adding, reading,

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -218,7 +218,7 @@ protestors->protesters
 provence->province
 purportive->supportive
 purvue->purview
-ques->quest, queues,
+ques->quest, queues, cues,
 readd->re-add, read,
 readded->re-added, read,
 readding->re-adding, reading,

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -218,7 +218,7 @@ protestors->protesters
 provence->province
 purportive->supportive
 purvue->purview
-ques->quest,queues
+ques->quest,queues,
 readd->re-add, read,
 readded->re-added, read,
 readding->re-adding, reading,


### PR DESCRIPTION
Just ran into it, and I think it is a legit "error + typo" since prounounciation of this word to non-native speakers could indeed be that tricky