### PR TITLE
If `writeable` is OK, so is `overwriteable`

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           check_filenames: true
           # When using this Action in other repos, the --skip option below can be removed
-          skip: "./.git,./codespell_lib/data,./example/code.c,test_basic.py,*.pyc,README.rst,pyproject-codespell.precommit-toml"
+          skip: "./.git,./codespell_lib/data,./example/code.c,test_basic.py,./codespell_lib/tests/data,*.pyc,README.rst,pyproject-codespell.precommit-toml"

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -42354,7 +42354,6 @@ overwridden->overridden, overwritten,
 overwride->overwrite, override,
 overwrides->overwrites, overrides,
 overwriding->overwriting, overriding,
-overwriteable->overwritable
 overwrited->overwritten, overwrote,
 overwriten->overwritten
 overwritin->overwriting

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -323,6 +323,7 @@ organiser->organizer
 organisers->organizers
 organises->organizes
 organising->organizing
+overwriteable->overwritable
 parallelisation->parallelization
 parallelise->parallelize
 parallelised->parallelized
@@ -522,3 +523,4 @@ visualised->visualized
 visualiser->visualizer
 visualises->visualizes
 visualising->visualizing
+writeable->writable

--- a/codespell_lib/tests/data/en_GB-additional.wordlist
+++ b/codespell_lib/tests/data/en_GB-additional.wordlist
@@ -27,6 +27,7 @@ localisations
 normalisations
 ochreous
 ochrey
+overwriteable
 parallelisation
 parallelise
 parallelised

--- a/codespell_lib/tests/data/en_US-additional.wordlist
+++ b/codespell_lib/tests/data/en_US-additional.wordlist
@@ -22,6 +22,7 @@ localizations
 normalizations
 ocherous
 ochery
+overwritable
 parallelization
 parallelize
 parallelized


### PR DESCRIPTION
Both should probably appear in `dictionary_en-GB_to_en-US.txt` instead of the standard dictionary.