### PR TITLE
Add `atfer`->`after` and variations

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7740,6 +7740,13 @@ atends->attends
 atention->attention
 aternies->attorneys
 aterny->attorney
+atfer->after
+atfernoon->afternoon
+atfernoons->afternoons
+atferthought->afterthought
+atferthoughts->afterthoughts
+atferward->afterward
+atferwards->afterwards
 atheistical->atheistic
 athenean->Athenian
 atheneans->Athenians
@@ -58466,6 +58473,7 @@ theread->thread, the read,
 thereaded->threaded
 thereading->threading, the reading,
 thereads->threads, the reads,
+thereatfer->thereafter
 thered->thread, the red,
 therem->there, theorem,
 thereom->theorem


### PR DESCRIPTION
Several places misspelled `after` to `atfer` and `afterwards` to `atferwards`:

- https://github.com/search?q=+atfer&type=code
- https://github.com/search?q=+atferwards&type=code

Other words with `after` such as `thereafter` and `afternoon` were misspelled on GitHub:

- https://github.com/search?q=+thereatfer&type=code
- https://github.com/search?q=+atfernoon&type=code