### PR TITLE
Add variations for correction: reurn->return

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -51090,7 +51090,10 @@ reuqirement->requirement
 reuqirements->requirements
 reuqires->requires
 reuqiring->requiring
-reurn->return
+reurn->return, rerun,
+reurned->returned, reran,
+reurning->returning, rerunning,
+reurns->returns, reruns,
 reursively->recursively
 reuseable->reusable
 reusin->reusing, resin,


### PR DESCRIPTION
Found the misspelling "reurns" in a personal project, as in: "It reurns false ..."

The mistake could also be a typo for "rerun", so include that as a potential fix too.
