### PR TITLE
remove misformed->malformed

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -38192,7 +38192,6 @@ miselaneous->miscellaneous
 miselaneously->miscellaneously
 misellaneous->miscellaneous
 misellaneously->miscellaneously
-misformed->malformed
 misfourtunes->misfortunes
 misile->missile
 mising->missing


### PR DESCRIPTION
This was removed previously in https://github.com/codespell-project/codespell/pull/555, but later added back in https://github.com/codespell-project/codespell/pull/1330.

Naive(probably often) suggestion, but there will be nice to have list of corrections that was removed from dict, to prevent oscillation for adding\removing words.