### PR TITLE
remove disjointness->disjointedness

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -22301,7 +22301,6 @@ disired->desired
 disires->desires
 disiring->desiring
 disitributions->distributions
-disjointness->disjointedness
 diskrete->discrete
 diskretion->discretion
 diskretization->discretization

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -92,6 +92,7 @@ discontentment->discontent
 discreet->discrete
 discus->discuss
 discuses->discusses
+disjointness->disjointedness
 disturbative->distributive, disruptive,
 doest->does, doesn't,
 empress->impress


### PR DESCRIPTION
While `disjointness` is missing from the [OED](https://www.oed.com/search/dictionary/?q=disjointness) and other mainstream dictionaries, as well as [SCOWL (And Friends)](http://app.aspell.net/lookup?dict=en_US-large;words=disjointness), it is commonly used to describe disjoint sets in the context of mathematics.

Move it to the _rare_ dictionary?