### PR TITLE
Run pytest GitHub Action on an ARM processor

### DIFF
--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -14,7 +14,7 @@ jobs:
       REQUIRE_ASPELL: true
       RUFF_OUTPUT_FORMAT: github
     # Make sure we're using the latest aspell dictionary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     strategy:
       fail-fast: false


### PR DESCRIPTION
Speed up a long running GitHub Action by running it on an ARM processor.
[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `os: ubuntu-24.04-arm`

Compare with other runtimes…
https://github.com/codespell-project/codespell/actions/workflows/codespell-private.yml