### PR TITLE
codespell-private.yml: Do not codespell digital signature files

### DIFF
--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -58,7 +58,7 @@ jobs:
       # tomli should not be required for the next two steps (and make sure it's not)
       - run: pip uninstall -yq tomli
         if: ${{ matrix.no-toml == 'no-toml' }}
-      - run: codespell --check-filenames --skip="./.*,./build/lib/codespell_lib/data/*,./build/lib/codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./codespell_lib/tests/test_basic.py,./example/code.c,./junit-results.xml,*.egg-info/*,*.pyc,*.sig,pyproject-codespell.precommit-toml,README.rst,"
+      - run: codespell --check-filenames --skip="./.*,./build/*,./codespell_lib/data/*,./codespell_lib/tests/test_basic.py,./example/code.c,./junit-results.xml,*.egg-info/*,*.pyc,*.sig,pyproject-codespell.precommit-toml,README.rst,"
       # this file has an error
       - run: "! codespell codespell_lib/tests/test_basic.py"
 

--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -58,7 +58,7 @@ jobs:
       # tomli should not be required for the next two steps (and make sure it's not)
       - run: pip uninstall -yq tomli
         if: ${{ matrix.no-toml == 'no-toml' }}
-      - run: codespell --check-filenames --skip="./.git/*,./.pytest_cache/*,./junit-results.xml,*.pyc,./codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./example/code.c,./build/lib/codespell_lib/tests/test_basic.py,./build/lib/codespell_lib/data/*,README.rst,*.egg-info/*,pyproject-codespell.precommit-toml,./.mypy_cache"
+      - run: codespell --check-filenames --skip="./.*,./build/lib/codespell_lib/data/*,./build/lib/codespell_lib/tests/test_basic.py,./codespell_lib/data/*,./codespell_lib/tests/test_basic.py,./example/code.c,./junit-results.xml,*.egg-info/*,*.pyc,*.sig,pyproject-codespell.precommit-toml,README.rst,"
       # this file has an error
       - run: "! codespell codespell_lib/tests/test_basic.py"
 


### PR DESCRIPTION
Ignore `*.sig`

Also:
1. Ignore all hidden (.files and .directories) in the root directory.
2. Sort the ignore elements to make it easier to spot missing entries and nearly impossible to insert duplicates.

---
Please rerun the failing GitHub Action to see if it is a fluke.