### PR TITLE
Revert `hep->heap, help,` in dictionary_rare.txt from #3461

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -127,7 +127,6 @@ habitants->inhabitants
 hart->heart, harm,
 heighth->height, eight, eighth,
 heighths->heights, eights, eighths,
-hep->heap, help,
 heterogenous->heterogeneous
 hided->hidden, hid,
 hims->his, hymns,


### PR DESCRIPTION
This is a follow-up from https://github.com/codespell-project/codespell/pull/3461#issuecomment-2619687778 in which @larsoner asked me to revert the dictionary_rare.txt changes from #3461, but keep the dictionary.txt changes.

(At least, this is my interpretation of what you're looking for. If I've misunderstood, you can just close this PR or tell me how to fix it. Thanks!)