### PR TITLE
Revert "Add rare typo `lien->line`"

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -154,8 +154,6 @@ lamdas->lambdas
 leaded->led, lead,
 leas->least, lease,
 lief->leaf, life,
-lien->line
-liens->lines
 lightening->lightning, lighting,
 loafing->loading
 lod->load, loud, lode,


### PR DESCRIPTION
Since `lien` is a word frequently used when working with the Google
Terraform Provider, it feels wrong to treat it as a typo.

Humbly suggesting to revert that change

This reverts commit 536ccb530ef9f955d17932e201a0d0f4e27bf2f9.

Fixes #3630
