### PR TITLE
"ane" could have been "one"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -4426,7 +4426,7 @@ androis->androids
 andthe->and the
 andtoid->android
 andtoids->androids
-ane->and
+ane->and, one,
 anecdatal->anecdotal
 anecdatally->anecdotally
 anecdate->anecdote


### PR DESCRIPTION
Ran into within https://github.com/napari/docs/pull/587
