### PR TITLE
Fix  "ti" as "it"

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -58939,6 +58939,7 @@ thursdey->Thursday
 thurver->further
 thw->the, thaw,
 thyat->that
+ti->it
 tich->thick, tick, titch, stitch,
 tichened->thickened
 tichness->thickness


### PR DESCRIPTION
Not sure about this one though -- since so short, might raise alarm too often in false positive cases etc.