### PR TITLE
Add spelling correction for "priort".

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -45836,6 +45836,7 @@ priorized->prioritized
 priorizes->prioritizes
 priorizin->prioritizing
 priorizing->prioritizing
+priort->prior, priory, priors, priori,
 priorties->priorities, prior ties,
 priortisation->prioritisation
 priortisations->prioritisations


### PR DESCRIPTION
See e.g. https://grep.app/search?words=true&q=priort+ (There are a few `priorT` variables but IMHO this should be fine like this).