### PR TITLE
Remove "fix" of "deques" - it is quite legit

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -20063,7 +20063,6 @@ depricating->deprecating
 deprication->deprecation, deprivation,
 dequed->dequeued
 dequeing->dequeuing
-deques->dequeues
 derageable->dirigible
 derailin->derailing, derail in,
 deram->dram, dream,


### PR DESCRIPTION
Kudos to @psobolewskiPhD for a sharp eye and explanation.  "deques" is a legit form of a "deque" which is a data structure ("Double-Ended Queue") which is used/accepted in many languages, Python included.  Thus we can expect to encounter it often and "fixing" it to mean "dequeues" (3rd form of "dequeue" as "remove from queue"?) is totally incorrect.

Plural form is "deques", as also described on
https://en.wiktionary.org/wiki/deques#English