### PR TITLE
Update pre-commit version in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,7 @@ codespell also works with `pre-commit <https://pre-commit.com/>`_, using
 .. code-block:: yaml
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.4.1
     hooks:
     - id: codespell
 
@@ -246,7 +246,7 @@ If one configures codespell using the `pyproject.toml` file instead use:
 .. code-block:: yaml
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.4.1
     hooks:
     - id: codespell
       additional_dependencies:


### PR DESCRIPTION
Closes: https://github.com/codespell-project/codespell/issues/3662- Update user documentation 

Update the version of pre-commit in the documentation from v2.2.4 to v2.4.1 to align with current standards. The previous change was 2 years ago.