### PR TITLE
Add spelling corrections for vulnerabilities and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -63258,9 +63258,11 @@ vulnerabililty->vulnerability
 vulnerabilites->vulnerabilities
 vulnerabiliti->vulnerability
 vulnerabilitie->vulnerability
+vulnerabilitiesy->vulnerability, vulnerabilities,
 vulnerabilitis->vulnerabilities
 vulnerabilitiy->vulnerability
 vulnerabilitu->vulnerability
+vulnerabilityies->vulnerability, vulnerabilities,
 vulnerabilitys->vulnerability, vulnerabilities,
 vulnerabiliy->vulnerability
 vulnerabillities->vulnerabilities


### PR DESCRIPTION
This can happen if some one e.g. first wants to write `vulnerability` but change it to `vulnerabilities` then wrongly.

See e.g.:
- https://github.com/search?q=vulnerabilityies&type=code
- https://github.com/search?q=%22vulnerabilitiesy%22&type=code (the "other way around" to the previous but none found so far, still adding it)