### PR TITLE
fix(dictionary_rare): remove “empress” and “empresses” words

### DIFF
--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -94,8 +94,6 @@ discus->discuss
 discuses->discusses
 disturbative->distributive, disruptive,
 doest->does, doesn't,
-empress->impress
-empresses->impresses
 fallow->follow
 fallowed->followed
 fallowing->following


### PR DESCRIPTION
### Question if the pull-request will decline

Please provide more details about the criteria for including words to the dictionary `dictionary_rare.txt`. I found solely information from `codespell --help`:

> 'rare' for rare (but valid) words that are likely to be errors

In my view, the dictionary `dictionary_rare.txt` must contain words and forms of words that used in English language in previous centuries, but almost out of use in the 21st century. Words “empress” and “empresses” doesn’t match this criterion — when now, in 2025, people speak and write about empresses, they still use the word “empress”.

Thanks.