### PR TITLE
Add symmectric and similar typos

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7686,6 +7686,16 @@ asymetricaly->asymmetrically
 asymetries->asymmetries
 asymetriy->asymmetry
 asymetry->asymmetry
+asymmectric->asymmetric
+asymmectric->asymmetric
+asymmectrical->asymmetrical
+asymmectrical->asymmetrical
+asymmectrically->asymmetrically
+asymmectrically->asymmetrically
+asymmectries->asymmetries
+asymmectries->asymmetries
+asymmectry->asymmetry
+asymmectry->asymmetry
 asymmeric->asymmetric
 asymmerical->asymmetrical
 asymmerically->asymmetrically
@@ -8883,6 +8893,8 @@ awsome->awesome
 awya->away
 axises->axes
 axissymmetric->axisymmetric
+axisymmectric->axisymmetric
+axisymmectric->axisymmetric
 axix->axis
 axixsymmetric->axisymmetric
 axpressed->expressed
@@ -22586,6 +22598,12 @@ disssociate->dissociate
 disssociated->dissociated
 disssociates->dissociates
 disssociating->dissociating
+dissymmectric->dissymmetric
+dissymmectric->dissymmetric
+dissymmectrical->dissymmetrical
+dissymmectrical->dissymmetrical
+dissymmectry->dissymmetry
+dissymmectry->dissymmetry
 distace->distance, distaste,
 distaced->distanced
 distaces->distances, distastes,
@@ -57719,6 +57737,18 @@ symetriy->symmetry
 symetry->symmetry
 symettric->symmetric
 symlinc->symlink
+symmectric->symmetric
+symmectric->symmetric
+symmectrical->symmetrical
+symmectrical->symmetrical
+symmectrically->symmetrically
+symmectrically->symmetrically
+symmectries->symmetries
+symmectries->symmetries
+symmectrized->symmetrized
+symmectrized->symmetrized
+symmectry->symmetry
+symmectry->symmetry
 symmeterized->symmetrized
 symmetetric->symmetric
 symmetic->symmetric

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7687,14 +7687,9 @@ asymetries->asymmetries
 asymetriy->asymmetry
 asymetry->asymmetry
 asymmectric->asymmetric
-asymmectric->asymmetric
-asymmectrical->asymmetrical
 asymmectrical->asymmetrical
 asymmectrically->asymmetrically
-asymmectrically->asymmetrically
 asymmectries->asymmetries
-asymmectries->asymmetries
-asymmectry->asymmetry
 asymmectry->asymmetry
 asymmeric->asymmetric
 asymmerical->asymmetrical
@@ -8893,7 +8888,6 @@ awsome->awesome
 awya->away
 axises->axes
 axissymmetric->axisymmetric
-axisymmectric->axisymmetric
 axisymmectric->axisymmetric
 axix->axis
 axixsymmetric->axisymmetric
@@ -22599,10 +22593,7 @@ disssociated->dissociated
 disssociates->dissociates
 disssociating->dissociating
 dissymmectric->dissymmetric
-dissymmectric->dissymmetric
 dissymmectrical->dissymmetrical
-dissymmectrical->dissymmetrical
-dissymmectry->dissymmetry
 dissymmectry->dissymmetry
 distace->distance, distaste,
 distaced->distanced
@@ -57738,16 +57729,10 @@ symetry->symmetry
 symettric->symmetric
 symlinc->symlink
 symmectric->symmetric
-symmectric->symmetric
-symmectrical->symmetrical
 symmectrical->symmetrical
 symmectrically->symmetrically
-symmectrically->symmetrically
-symmectries->symmetries
 symmectries->symmetries
 symmectrized->symmetrized
-symmectrized->symmetrized
-symmectry->symmetry
 symmectry->symmetry
 symmeterized->symmetrized
 symmetetric->symmetric


### PR DESCRIPTION
Context: https://github.com/python/typeshed/pull/13877

I added a line for each correct word containing `symmet` in `codespell_lib/data/dictionary.txt`.