### PR TITLE
"Intensional" is a word

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -34336,7 +34336,6 @@ inteneded->intended
 intenet->internet, intent,
 intenisty->intensity
 intension->intention
-intensional->intentional
 intensionally->intentionally
 intensionaly->intentionally
 intensitive->insensitive, intensive,

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -144,6 +144,7 @@ infarction->infraction
 infarctions->infractions
 ingenuous->ingenious
 inly->only
+intensional->intentional
 irregardless->regardless
 joo->you
 knifes->knives


### PR DESCRIPTION
The spelling "intensional" is correct, and is for instance used for "intensional type theory" https://ncatlab.org/nlab/show/intensional+type+theory