### PR TITLE
Fix CI on Windows: pip upgrade pip

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash -e {0}
         run: |
           python --version  # just to check
-          pip install --upgrade pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
+          python -m pip install --upgrade pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
           pip install --upgrade "setuptools!=47.2.0" docutils setuptools_scm[toml] twine
           pip install -e ".[dev]" # install the codespell dev packages
       - run: pip install aspell-python-py3


### PR DESCRIPTION
On Windows, pip.exe cannot update pip.exe if pip.exe is already running.
Use an alternative command that avoids running the pip.exe executable.