### PR TITLE
Add chloropleth->choropleth

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -12659,6 +12659,7 @@ chked->checked
 chlid->child
 chlidren->children
 chlids->children
+chloropleth->choropleth
 chnage->change
 chnaged->changed
 chnages->changes


### PR DESCRIPTION
This is a fairly common typo for people encountering the word _choropleth_ for the first time, since in English the prefix _chloro-_ is familiar whereas `choro-` is relatively rare.