### PR TITLE
dict: poen

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -44714,7 +44714,8 @@ poduction->production
 poductions->productions
 poducts->products
 podule->module
-poenis->penis
+poen->open, pen, poem, phone,
+poenis->peonies, penis,
 poential->potential
 poentially->potentially
 poentials->potentials


### PR DESCRIPTION
Added poen, often a misspelling of open.

I also added an alternative for the next misspelling poenis.