### PR TITLE
Add spelling corrections for "complete" variations

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -17202,6 +17202,13 @@ copmiler->compiler
 copmilers->compilers
 copmiles->compiles
 copmiling->compiling
+copmlete->complete
+copmleted->completed
+copmletely->completely
+copmletes->completes
+copmleting->completing
+copmletion->completion
+copmletions->completions
 copmonent->component
 copmonents->components
 copmutations->computations


### PR DESCRIPTION
This will catch mismatches where "m" and "p" are swapped for several "complete" variations.