### PR TITLE
Speed up spellchecking by ignoring whitespace-only lines

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -946,7 +946,8 @@ def parse_file(
             return bad_count
 
     for i, line in enumerate(lines):
-        if line.rstrip() in exclude_lines:
+        line = line.rstrip()
+        if not line or line in exclude_lines:
             continue
 
         extra_words_to_ignore = set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,4 +173,4 @@ allow-magic-value-types = ["bytes", "int", "str",]
 max-args = 13
 max-branches = 48
 max-returns = 12
-max-statements = 119
+max-statements = 120


### PR DESCRIPTION
Whitespace only lines cannot have typos in them at all on account of not containing any words. Nevertheless, codespell did not exit early on them causing quite some overhead.

By special-casing empty and whitespace only, it is possible to reduce the runtime from ~5.4s to ~5.0s on the corpus mentioned in #3419.