### PR TITLE
Avoid deprecated license specification format

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Useful links
 Requirements
 ------------
 
-Python 3.8 or above.
+Python 3.9 or above.
 
 Installation
 ------------

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -25,13 +25,11 @@ import os
 import re
 import sys
 import textwrap
+from collections.abc import Iterable, Sequence
+from re import Match, Pattern
 from typing import (
     Any,
-    Iterable,
-    Match,
     Optional,
-    Pattern,
-    Sequence,
     TextIO,
 )
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -27,16 +27,12 @@ import sys
 import textwrap
 from typing import (
     Any,
-    Dict,
     Iterable,
-    List,
     Match,
     Optional,
     Pattern,
     Sequence,
-    Set,
     TextIO,
-    Tuple,
 )
 
 if sys.platform == "win32":
@@ -161,8 +157,8 @@ class QuietLevels:
 
 
 class GlobMatch:
-    def __init__(self, pattern: List[str]) -> None:
-        self.pattern_list: List[str] = pattern
+    def __init__(self, pattern: list[str]) -> None:
+        self.pattern_list: list[str] = pattern
 
     def match(self, filename: str) -> bool:
         return any(fnmatch.fnmatch(filename, p) for p in self.pattern_list)
@@ -184,7 +180,7 @@ class TermColors:
 
 class Summary:
     def __init__(self) -> None:
-        self.summary: Dict[str, int] = {}
+        self.summary: dict[str, int] = {}
 
     def update(self, wrongword: str) -> None:
         if wrongword in self.summary:
@@ -227,12 +223,12 @@ class FileOpener:
 
         self.encdetector = UniversalDetector()
 
-    def open(self, filename: str) -> Tuple[List[str], str]:
+    def open(self, filename: str) -> tuple[list[str], str]:
         if self.use_chardet:
             return self.open_with_chardet(filename)
         return self.open_with_internal(filename)
 
-    def open_with_chardet(self, filename: str) -> Tuple[List[str], str]:
+    def open_with_chardet(self, filename: str) -> tuple[list[str], str]:
         self.encdetector.reset()
         with open(filename, "rb") as fb:
             for line in fb:
@@ -259,7 +255,7 @@ class FileOpener:
 
         return lines, f.encoding
 
-    def open_with_internal(self, filename: str) -> Tuple[List[str], str]:
+    def open_with_internal(self, filename: str) -> tuple[list[str], str]:
         encoding = None
         first_try = True
         for encoding in ("utf-8", "iso-8859-1"):
@@ -286,7 +282,7 @@ class FileOpener:
 
         return lines, encoding
 
-    def get_lines(self, f: TextIO) -> List[str]:
+    def get_lines(self, f: TextIO) -> list[str]:
         if self.ignore_multiline_regex:
             text = f.read()
             pos = 0
@@ -313,7 +309,7 @@ class FileOpener:
 class NewlineHelpFormatter(argparse.HelpFormatter):
     """Help formatter that preserves newlines and deals with lists."""
 
-    def _split_lines(self, text: str, width: int) -> List[str]:
+    def _split_lines(self, text: str, width: int) -> list[str]:
         parts = text.split("\n")
         out = []
         for part in parts:
@@ -330,7 +326,7 @@ class NewlineHelpFormatter(argparse.HelpFormatter):
         return out
 
 
-def _toml_to_parseconfig(toml_dict: Dict[str, Any]) -> Dict[str, Any]:
+def _toml_to_parseconfig(toml_dict: dict[str, Any]) -> dict[str, Any]:
     """Convert a dict read from a TOML file to the parseconfig.read_dict() format."""
     return {
         k: "" if v is True else ",".join(v) if isinstance(v, list) else v
@@ -373,7 +369,7 @@ def _supports_ansi_colors() -> bool:
 
 def parse_options(
     args: Sequence[str],
-) -> Tuple[argparse.Namespace, argparse.ArgumentParser, List[str]]:
+) -> tuple[argparse.Namespace, argparse.ArgumentParser, list[str]]:
     parser = argparse.ArgumentParser(formatter_class=NewlineHelpFormatter)
 
     parser.set_defaults(colors=_supports_ansi_colors())
@@ -697,7 +693,7 @@ def parse_options(
 
 
 def process_ignore_words(
-    words: Iterable[str], ignore_words: Set[str], ignore_words_cased: Set[str]
+    words: Iterable[str], ignore_words: set[str], ignore_words_cased: set[str]
 ) -> None:
     for word in words:
         word = word.strip()
@@ -708,10 +704,10 @@ def process_ignore_words(
 
 
 def parse_ignore_words_option(
-    ignore_words_option: List[str],
-) -> Tuple[Set[str], Set[str]]:
-    ignore_words: Set[str] = set()
-    ignore_words_cased: Set[str] = set()
+    ignore_words_option: list[str],
+) -> tuple[set[str], set[str]]:
+    ignore_words: set[str] = set()
+    ignore_words_cased: set[str] = set()
     if ignore_words_option:
         for comma_separated_words in ignore_words_option:
             process_ignore_words(
@@ -722,13 +718,13 @@ def parse_ignore_words_option(
     return (ignore_words, ignore_words_cased)
 
 
-def build_exclude_hashes(filename: str, exclude_lines: Set[str]) -> None:
+def build_exclude_hashes(filename: str, exclude_lines: set[str]) -> None:
     with open(filename, encoding="utf-8") as f:
         exclude_lines.update(line.rstrip() for line in f)
 
 
 def build_ignore_words(
-    filename: str, ignore_words: Set[str], ignore_words_cased: Set[str]
+    filename: str, ignore_words: set[str], ignore_words_cased: set[str]
 ) -> None:
     with open(filename, encoding="utf-8") as f:
         process_ignore_words(
@@ -756,7 +752,7 @@ def ask_for_word_fix(
     misspelling: Misspelling,
     interactivity: int,
     colors: TermColors,
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     wrongword = match.group()
     if interactivity <= 0:
         return misspelling.fix, fix_case(wrongword, misspelling.data)
@@ -813,9 +809,9 @@ def ask_for_word_fix(
 
 
 def print_context(
-    lines: List[str],
+    lines: list[str],
     index: int,
-    context: Tuple[int, int],
+    context: tuple[int, int],
 ) -> None:
     # context = (context_before, context_after)
     for i in range(index - context[0], index + context[1] + 1):
@@ -836,7 +832,7 @@ def extract_words(
     text: str,
     word_regex: Pattern[str],
     ignore_word_regex: Optional[Pattern[str]],
-) -> List[str]:
+) -> list[str]:
     return word_regex.findall(_ignore_word_sub(text, ignore_word_regex))
 
 
@@ -844,18 +840,18 @@ def extract_words_iter(
     text: str,
     word_regex: Pattern[str],
     ignore_word_regex: Optional[Pattern[str]],
-) -> List[Match[str]]:
+) -> list[Match[str]]:
     return list(word_regex.finditer(_ignore_word_sub(text, ignore_word_regex)))
 
 
 def apply_uri_ignore_words(
-    check_matches: List[Match[str]],
+    check_matches: list[Match[str]],
     line: str,
     word_regex: Pattern[str],
     ignore_word_regex: Optional[Pattern[str]],
     uri_regex: Pattern[str],
-    uri_ignore_words: Set[str],
-) -> List[Match[str]]:
+    uri_ignore_words: set[str],
+) -> list[Match[str]]:
     if not uri_ignore_words:
         return check_matches
     for uri in uri_regex.findall(line):
@@ -873,15 +869,15 @@ def parse_file(
     filename: str,
     colors: TermColors,
     summary: Optional[Summary],
-    misspellings: Dict[str, Misspelling],
-    ignore_words_cased: Set[str],
-    exclude_lines: Set[str],
+    misspellings: dict[str, Misspelling],
+    ignore_words_cased: set[str],
+    exclude_lines: set[str],
     file_opener: FileOpener,
     word_regex: Pattern[str],
     ignore_word_regex: Optional[Pattern[str]],
     uri_regex: Pattern[str],
-    uri_ignore_words: Set[str],
-    context: Optional[Tuple[int, int]],
+    uri_ignore_words: set[str],
+    context: Optional[tuple[int, int]],
     options: argparse.Namespace,
 ) -> int:
     bad_count = 0
@@ -1085,7 +1081,7 @@ def parse_file(
 
 def flatten_clean_comma_separated_arguments(
     arguments: Iterable[str],
-) -> List[str]:
+) -> list[str]:
     """
     >>> flatten_clean_comma_separated_arguments(["a, b ,\n c, d,", "e"])
     ['a', 'b', 'c', 'd', 'e']
@@ -1227,7 +1223,7 @@ def main(*args: str) -> int:
                     f"ERROR: cannot find dictionary file: {dictionary}",
                 )
             use_dictionaries.append(dictionary)
-    misspellings: Dict[str, Misspelling] = {}
+    misspellings: dict[str, Misspelling] = {}
     for dictionary in use_dictionaries:
         build_dict(dictionary, misspellings, ignore_words)
     colors = TermColors()
@@ -1255,7 +1251,7 @@ def main(*args: str) -> int:
             context_after = max(0, options.after_context)
         context = (context_before, context_after)
 
-    exclude_lines: Set[str] = set()
+    exclude_lines: set[str] = set()
     if options.exclude_file:
         exclude_files = flatten_clean_comma_separated_arguments(options.exclude_file)
         for exclude_file in exclude_files:

--- a/codespell_lib/_spellchecker.py
+++ b/codespell_lib/_spellchecker.py
@@ -16,11 +16,6 @@ Copyright (C) 2010-2011  Lucas De Marchi <lucas.de.marchi@gmail.com>
 Copyright (C) 2011  ProFUSION embedded systems
 """
 
-from typing import (
-    Dict,
-    Set,
-)
-
 # Pass all misspellings through this translation table to generate
 # alternative misspellings and fixes.
 alt_chars = (("'", "’"),)  # noqa: RUF001
@@ -36,7 +31,7 @@ class Misspelling:
 def add_misspelling(
     key: str,
     data: str,
-    misspellings: Dict[str, Misspelling],
+    misspellings: dict[str, Misspelling],
 ) -> None:
     data = data.strip()
 
@@ -53,8 +48,8 @@ def add_misspelling(
 
 def build_dict(
     filename: str,
-    misspellings: Dict[str, Misspelling],
-    ignore_words: Set[str],
+    misspellings: dict[str, Misspelling],
+    ignore_words: set[str],
 ) -> None:
     with open(filename, encoding="utf-8") as f:
         translate_tables = [(x, str.maketrans(x, y)) for x, y in alt_chars]

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -8,7 +8,7 @@ import sys
 from io import StringIO
 from pathlib import Path
 from shutil import copyfile
-from typing import Any, Generator, Optional, Tuple, Union
+from typing import Any, Generator, Optional, Union
 from unittest import mock
 
 import pytest
@@ -39,7 +39,7 @@ class MainWrapper:
         *args: Any,
         count: bool = True,
         std: bool = False,
-    ) -> Union[int, Tuple[int, str, str]]:
+    ) -> Union[int, tuple[int, str, str]]:
         args = tuple(str(arg) for arg in args)
         if count:
             args = ("--count", *args)
@@ -65,7 +65,7 @@ cs = MainWrapper()
 
 
 def run_codespell(
-    args: Tuple[Any, ...] = (),
+    args: tuple[Any, ...] = (),
     cwd: Optional[Path] = None,
 ) -> int:
     """Run codespell."""
@@ -1373,7 +1373,7 @@ def FakeStdin(text: str) -> Generator[None, None, None]:
 
 def run_codespell_stdin(
     text: str,
-    args: Tuple[Any, ...],
+    args: tuple[Any, ...],
     cwd: Optional[Path] = None,
 ) -> int:
     """Run codespell in stdin mode and return number of lines in output."""
@@ -1397,7 +1397,7 @@ def test_stdin(tmp_path: Path) -> None:
     for _ in range(input_file_lines):
         text += "abandonned\n"
     for single_line_per_error in (True, False):
-        args: Tuple[str, ...] = ()
+        args: tuple[str, ...] = ()
         if single_line_per_error:
             args = ("--stdin-single-line",)
         # we expect 'input_file_lines' number of lines with

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -5,10 +5,11 @@ import os.path as op
 import re
 import subprocess
 import sys
+from collections.abc import Generator
 from io import StringIO
 from pathlib import Path
 from shutil import copyfile
-from typing import Any, Generator, Optional, Union
+from typing import Any, Optional, Union
 from unittest import mock
 
 import pytest

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -3,7 +3,7 @@ import os
 import os.path as op
 import pathlib
 import re
-from typing import Any, Dict, Iterable, Optional, Set, Tuple
+from typing import Any, Iterable, Optional
 
 import pytest
 
@@ -37,8 +37,8 @@ except ImportError as e:
         )
         raise RuntimeError(msg) from e
 
-global_err_dicts: Dict[str, Dict[str, Any]] = {}
-global_pairs: Set[Tuple[str, str]] = set()
+global_err_dicts: dict[str, dict[str, Any]] = {}
+global_pairs: set[tuple[str, str]] = set()
 
 # Filename, should be seen as errors in aspell or not
 _data_dir = op.join(op.dirname(__file__), "..", "data")
@@ -61,8 +61,8 @@ def test_dictionaries_exist() -> None:
 @fname_params
 def test_dictionary_formatting(
     fname: str,
-    in_aspell: Tuple[bool, bool],
-    in_dictionary: Tuple[Iterable[str], Iterable[str]],
+    in_aspell: tuple[bool, bool],
+    in_dictionary: tuple[Iterable[str], Iterable[str]],
 ) -> None:
     """Test that all dictionary entries are valid."""
     errors = []
@@ -137,9 +137,9 @@ single_comma = re.compile(r"^[^,]*,\s*$")
 def _check_err_rep(
     err: str,
     rep: str,
-    in_aspell: Tuple[Optional[bool], Optional[bool]],
+    in_aspell: tuple[Optional[bool], Optional[bool]],
     fname: str,
-    languages: Tuple[Iterable[str], Iterable[str]],
+    languages: tuple[Iterable[str], Iterable[str]],
 ) -> None:
     assert whitespace.search(err) is None, f"error {err!r} has whitespace"
     assert "," not in err, f"error {err!r} has a comma"
@@ -296,8 +296,8 @@ allowed_dups = {
 @pytest.mark.dependency(name="dictionary loop")
 def test_dictionary_looping(
     fname: str,
-    in_aspell: Tuple[bool, bool],
-    in_dictionary: Tuple[bool, bool],
+    in_aspell: tuple[bool, bool],
+    in_dictionary: tuple[bool, bool],
 ) -> None:
     """Test that all dictionary entries are valid."""
     this_err_dict = {}

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -3,7 +3,8 @@ import os
 import os.path as op
 import pathlib
 import re
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,13 @@
 name = "codespell"
 description = "Fix common misspellings in text files"
 readme = { file = "README.rst", content-type = "text/x-rst" }
-requires-python = ">=3.8"
-license = {text = "GPL-2.0-only"}
+requires-python = ">=3.9"
+license = "GPL-2.0-only"
 authors = [
     {name = "Lucas De Marchi", email = "lucas.de.marchi@gmail.com"},
 ]
 classifiers = [
     "Intended Audience :: Developers",
-    "License :: OSI Approved",
     "Programming Language :: Python",
     "Topic :: Software Development",
     "Operating System :: Microsoft :: Windows",
@@ -21,7 +20,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -67,7 +65,7 @@ repository = "https://github.com/codespell-project/codespell"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2, != 8.0.0"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=6.2, != 8.0.0"]
 
 [tool.setuptools_scm]
 write_to = "codespell_lib/_version.py"


### PR DESCRIPTION
Fix this pip warning:

	********************************************************************************
	Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

	By 2026-Feb-18, you need to update your project and remove deprecated calls
	or your builds will no longer be supported.

	See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
	********************************************************************************

[PEP 639](https://peps.python.org/pep-0639/) support requires setuptools [77](https://setuptools.pypa.io/en/stable/history.html#v77-0-0) which requires Python 3.9.