### PR TITLE
Add spelling correction for calid->valid and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -10817,6 +10817,15 @@ calibraitons->calibrations
 calibratin->calibrating, calibration,
 calibrte->calibrate
 calibrtion->calibration
+calid->valid, canid,
+calidate->validate
+calidated->validated
+calidates->validates
+calidating->validating
+calidation->validation
+calidations->validations
+calidator->validator
+calidators->validators
 caligraphy->calligraphy
 calilng->calling
 caliming->claiming


### PR DESCRIPTION
See e.g.:
- https://grep.app/search?words=true&q=calidate
- https://grep.app/search?words=true&q=calidation
- https://grep.app/search?words=true&q=calidated

Notes:
- Sees this happen because the `v` is usually next to the `c`
- I have left out https://www.collinsdictionary.com/dictionary/english/calidity for now as this seems to be some kind of valid (but obsolete) word