### PR TITLE
Add exposte->expose and variations

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27431,6 +27431,10 @@ expors->exports
 exportet->exported, exporter,
 exportin->exporting, export in,
 exposin->exposing, expos in,
+exposte->expose
+exposted->exposed
+expostes->exposes
+exposting->exposing
 expport->export
 exppressed->expressed
 expration->expiration


### PR DESCRIPTION
"exposte" was not found in publicly-available resources but its variations were.

"exposted" was found in https://github.com/tianocore/edk2/blob/a1b509c1a453815acbc6c8b0fc5882fd03a6f2c0/MdeModulePkg/Include/Library/CapsuleLib.h#L64

"expostes" was found in https://github.com/dlsc-software-consulting-gmbh/GemsFX/blob/19f6cadadc02798a096c86005d292a9bb19673ca/docs/com.dlsc.gemsfx/com/dlsc/gemsfx/FilterView.FilterGroup.html#L109

"exposting" was found in https://github.com/moodle/moodle/blob/9addea9f0ace94e228329a93df80afaa76fee3e0/mod/lti/classes/local/ltiopenid/jwks_helper.php#L67 and https://github.com/akka/akka-management/blob/4b884424a52817caee10256675b437e0e08da693/management/src/main/resources/reference.conf#L75