### PR TITLE
Add spelling correction for followinig->following

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -28646,6 +28646,7 @@ followign->following
 followiing->following
 followin->following
 followind->following
+followinig->following
 followins->following, followings,
 followint->following
 followng->following


### PR DESCRIPTION
See e.g. (second has more hits):
- https://grep.app/search?q=followinig
- https://github.com/search?q=followinig&type=code