### PR TITLE
exposere->exposure

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -27467,6 +27467,7 @@ exporing->exploring, expiring, exporting, exposing,
 expors->exports
 exportet->exported, exporter,
 exportin->exporting, export in,
+exposere->exposure
 exposin->exposing, expos in,
 exposte->expose
 exposted->exposed


### PR DESCRIPTION
Another spelling error found in OpenFlexure source code, due to my terrible typing.