### PR TITLE
Leaner dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,6 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "pytest-dependency",
-    "Pygments",
     "ruff",
     "tomli",
     "twine"
@@ -53,7 +51,6 @@ types = [
     "mypy",
     "pytest",
     "pytest-cov",
-    "pytest-dependency",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Remove dependencies that seem “nice to have” but are not explicitly used by the build process or CI.

Fixes #3749.