### PR TITLE
Remove ACI from dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1364,7 +1364,6 @@ achor->anchor
 achored->anchored
 achoring->anchoring
 achors->anchors
-ACI->ACPI
 acident->accident
 acidental->accidental
 acidentally->accidentally


### PR DESCRIPTION
ACI is a product of [Cisco](https://www.cisco.com/site/de/de/products/networking/cloud-networking/application-centric-infrastructure/index.html) and stands for Application Centric Infrastructure