### PR TITLE
Use a maintained mirrors-prettier for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,8 +62,8 @@ repos:
     hooks:
       - id: ruff-check
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.6.2
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]


### PR DESCRIPTION
https://github.com/pre-commit/mirrors-prettier was archived in April 2024 so let's use a maintained mirror such as https://github.com/rbubley/mirrors-prettier.

(This also helps https://github.com/j178/prek/issues/545 which is caused by https://github.com/pre-commit/mirrors-prettier not setting a minimum Node version for Prettier)