### PR TITLE
Fix iterator typo

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -58843,6 +58843,8 @@ teraforming->terraforming
 teraforms->terraforms
 terain->terrain, train,
 terains->terrains, trains,
+terator->iterator
+terators->iterators
 terfform->terraform
 terfformed->terraformed
 terfforming->terraforming


### PR DESCRIPTION
This typo was found in CMake sources repository.

See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11282 for more info