### PR TITLE
Fix version typo

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -63223,6 +63223,10 @@ vesion->version
 vesioned->versioned
 vesioning->versioning
 vesions->versions
+vesrion->version
+vesrioned->versioned
+vesrioning->versioning
+vesrions->versions
 vetex->vertex
 vetexes->vertices
 vetical->vertical


### PR DESCRIPTION
The typo was found in CMake source repository tests.

See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11325 for more info