### PR TITLE
Fix introduction typo

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -35258,6 +35258,8 @@ intrisics->intrinsics
 intrisinc->intrinsic
 intrisincally->intrinsically
 intrisincs->intrinsics
+introdcution->introduction
+introdcutions->introductions
 introducin->introducing
 introducted->introduced
 introducting->introducing


### PR DESCRIPTION
The typo was found in CMake tests: https://gitlab.kitware.com/cmake/cmake/-/blob/ad684ceb565ce97dc26482498188049ab8034197/Tests/CMakeTests/PolicyCheckTest.cmake.in#L1