### PR TITLE
Add/update spelling corrections for vulnerability and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -63697,11 +63697,12 @@ vulnerabiliies->vulnerabilities
 vulnerabilility->vulnerability
 vulnerabililties->vulnerabilities
 vulnerabililty->vulnerability
+vulnerabilit->vulnerability, vulnerabilities,
 vulnerabilites->vulnerabilities
-vulnerabiliti->vulnerability
-vulnerabilitie->vulnerability
+vulnerabiliti->vulnerability, vulnerabilities,
+vulnerabilitie->vulnerability, vulnerabilities,
 vulnerabilitiesy->vulnerability, vulnerabilities,
-vulnerabilitis->vulnerabilities
+vulnerabilitis->vulnerabilities, vulnerability,
 vulnerabilitiy->vulnerability
 vulnerabilitu->vulnerability
 vulnerabilityies->vulnerability, vulnerabilities,


### PR DESCRIPTION
- For the new addition it seems they are not happening often but we can still see some on https://grep.app/search?words=true&q=vulnerabilit as well as a few of these from https://grep.app/search?words=true&q=vulnerabilit:
  ```
  Common Vulnerabilit Scoring System object, representing its component measures
          'name': 'QNX QCONN Remote Command Execution Vulnerabilit',
  ```
- For the updates some of them just got a few possible additional variants added i noticed while adding the previous