### PR TITLE
DRAFT: Add free threaded Python 3.14t to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,8 @@ jobs:
       - run: codespell --help
       - run: codespell --version
       - run: make check
+        env:
+          PYTHON_GIL: 0
         if: startsWith(matrix.os, 'ubuntu')
       - run: pytest codespell_lib
         if: startsWith(matrix.os, 'windows')


### PR DESCRIPTION
* #3778
```
___________ ERROR collecting codespell_lib/tests/test_dictionary.py ____________
codespell_lib/tests/test_dictionary.py:22: in <module>
    import aspell  # type: ignore[import]
    ^^^^^^^^^^^^^
E   RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'aspell', which
    has not declared that it can run safely without the GIL. To override this behavior and keep the
    GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
```
https://pypi.org/project/aspell-python-py3