### PR TITLE
Add typos of `hypocenter` to the dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -31371,10 +31371,10 @@ Hyperldger->Hyperledger
 hypervior->hypervisor
 hyphenatin->hyphenating, hyphenation,
 hypocencter->hypocenter
-hypocengter->hypocenter
-hypocnter->hypocenter
 hypocenctre->hypocentre
+hypocengter->hypocenter
 hypocengtre->hypocentre
+hypocnter->hypocenter
 hypocntre->hypocentre
 hypocracy->hypocrisy
 hypocrasy->hypocrisy


### PR DESCRIPTION
I'm mainly concerned with `hypocnter->hypocenter` but the other two I got from looking at corrections for plain `center`