### PR TITLE
Fix three problems with --ignore-multiline-regex

### DIFF
--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -994,6 +994,25 @@ def test_ignore_multiline_regex_option(
     )
     assert fname.read_text() == "This\nThis"
 
+    fname.write_text(text)
+    cs.main(
+        fname,
+        "-w",
+        "--ignore-multiline-regex",
+        "codespell:ignore-begin.*codespell:ignore-end",
+    )
+    fixed_text = """
+    Please see http://example.com/abandoned for info
+    # codespell:ignore-begin
+    '''
+    abandonned
+    abandonned
+    '''
+    # codespell:ignore-end
+    abandoned
+    """
+    assert fname.read_text() == fixed_text
+
 
 def test_uri_regex_option(
     tmp_path: Path,


### PR DESCRIPTION
This series consists of four patches.

Patches 1, 2 and 4 each fix a problem with `--ignore-multiline-regex` (described in the commit messages), and add a corresponding unit test.

Patch 3 is a refactoring patch, making patch 4 smaller.

Patch 2 fixes [this issue](https://github.com/codespell-project/codespell/issues/3642) .

Closes #3642