### PR TITLE
`licenced` is incorrect both in en_GB and en_US.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -36677,6 +36677,7 @@ lication->location
 lications->locations
 licemse->license
 licemses->licenses
+licenced->licensed
 licenceing->licencing
 licencin->licencing
 licencse->license, licenses,

--- a/codespell_lib/data/dictionary_en-GB_to_en-US.txt
+++ b/codespell_lib/data/dictionary_en-GB_to_en-US.txt
@@ -242,7 +242,6 @@ legalises->legalizes
 legalising->legalizing
 leukaemia->leukemia
 licence->license
-licenced->licensed
 licences->licenses
 licencing->licensing
 litre->liter

--- a/tools/gen_OX.sh
+++ b/tools/gen_OX.sh
@@ -25,7 +25,7 @@ EXCEPTIONS=(
 )
 PAT2="^$(one_of "${EXCEPTIONS[@]}")"
 
-# these one should be left out
+# these ones should be left out
 IGNORE=(
    'storey'
    'practise'


### PR DESCRIPTION
As the title says. (+ a typo in script comment)

**actually, no. My mistake.**