### PR TITLE
Move `quater` to rare dictionary

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -47685,7 +47685,6 @@ quartenion->quaternion
 quartenions->quaternions
 quartically->quadratically
 quatation->quotation
-quater->quarter
 quating->quoting, squatting, equating,
 quation->equation
 quations->equations

--- a/codespell_lib/data/dictionary_rare.txt
+++ b/codespell_lib/data/dictionary_rare.txt
@@ -224,6 +224,7 @@ protestors->protesters
 provence->province
 purportive->supportive
 purvue->purview
+quater->quarter
 ques->quest, queues, cues,
 readd->re-add, read,
 readded->re-added, read,


### PR DESCRIPTION
https://www.oed.com/search/dictionary/?q=quater

bis, ter, quater, quinquies, ...:
https://github.com/pybind/pybind11/blob/1dc76208d5822e78fc8129552b4d622c78b7ce64/tests/valgrind-numpy-scipy.supp#L57