### PR TITLE
PEP 735 compliance: dependency groups

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -9,6 +9,6 @@ pip install --upgrade \
     setuptools \
     setuptools_scm \
     wheel
-pip install -e '.[dev]'
+pip install -e . --group dev
 
 pre-commit install --install-hooks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           python --version  # just to check
           python -m pip install --upgrade pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
-          pip install --upgrade "setuptools!=47.2.0" docutils setuptools_scm[toml] twine
+          pip install --upgrade setuptools docutils setuptools_scm[toml] twine
           pip install -e . --group dev # install the codespell dev packages
       - run: pip install aspell-python-py3
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         shell: bash -e {0}
         run: |
           python --version  # just to check
-          python -m pip install --upgrade pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
+          python -m pip install --upgrade pip wheel
           pip install --upgrade setuptools docutils setuptools_scm[toml] twine
           pip install -e . --group dev # install the codespell dev packages
       - run: pip install aspell-python-py3
@@ -92,7 +92,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install general dependencies
-        run: pip install --upgrade pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
+        run: pip install --upgrade pip wheel
       - name: Install codespell dependencies
         run: pip install -e . --group dev
       - uses: codespell-project/sort-problem-matcher@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
           python --version  # just to check
           python -m pip install --upgrade pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
           pip install --upgrade "setuptools!=47.2.0" docutils setuptools_scm[toml] twine
-          pip install -e ".[dev]" # install the codespell dev packages
+          pip install -e . --group dev # install the codespell dev packages
       - run: pip install aspell-python-py3
         if: startsWith(matrix.os, 'ubuntu')
       - run: pip install "chardet<7"
@@ -94,6 +94,6 @@ jobs:
       - name: Install general dependencies
         run: pip install --upgrade pip wheel # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
       - name: Install codespell dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e . --group dev
       - uses: codespell-project/sort-problem-matcher@v1
       - run: make check-dictionaries

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check-dictionaries: sort-dictionaries
 	@if command -v pytest > /dev/null; then \
 		pytest codespell_lib/tests/test_dictionary.py; \
 	else \
-		echo "Test dependencies not present, install using 'pip install -e \".[dev]\"'"; \
+		echo "Test dependencies not present, install using 'pip install -e . --group dev'"; \
 		exit 1; \
 	fi
 
@@ -50,7 +50,7 @@ pytest: sort-dictionaries
 	@if command -v pytest > /dev/null; then \
 		pytest codespell_lib; \
 	else \
-		echo "Test dependencies not present, install using 'pip install -e \".[dev]\"'"; \
+		echo "Test dependencies not present, install using 'pip install -e . --group dev'"; \
 		exit 1; \
 	fi
 

--- a/README.rst
+++ b/README.rst
@@ -306,7 +306,7 @@ You can install required dependencies for development by running the following w
 
 .. code-block:: sh
 
-       pip install -e ".[dev]"
+       pip install -e . --group dev
 
 To run tests against the codebase run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,14 @@ dependencies = []
 dynamic = ["version"]
 
 [project.optional-dependencies]
+hard-encoding-detection = [
+    "chardet"
+]
+toml = [
+    "tomli; python_version < '3.11'"
+]
+
+[dependency-groups]
 dev = [
     "build",
     "chardet",
@@ -41,12 +49,6 @@ dev = [
     "ruff",
     "tomli",
     "twine"
-]
-hard-encoding-detection = [
-    "chardet"
-]
-toml = [
-    "tomli; python_version < '3.11'"
 ]
 types = [
     "chardet>=5.1.0",


### PR DESCRIPTION
Only for development and build time dependencies, not run time depdendencies that are meant to be published with the package.