### PR TITLE
fix(packaging): prevent unwanted files and tests from being installed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,11 @@
-exclude *.yml *.yaml
+exclude *.yml
 exclude .coveragerc
 exclude .git-blame-ignore-revs
-exclude example example/* snap snap/*
-exclude Makefile
+prune example
+prune snap
+prune .devcontainer
+prune .github
+exclude .gitignore
+exclude .mailmap
 exclude codespell.1.include
 exclude pyproject-codespell.precommit-toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,17 @@ requires = ["setuptools>=77", "setuptools_scm[toml]>=6.2, != 8.0.0"]
 [tool.setuptools_scm]
 write_to = "codespell_lib/_version.py"
 
+[tool.setuptools]
+include-package-data = false
+
 [tool.setuptools.packages.find]
+include = ["codespell_lib", "codespell_lib.*"]
 exclude = [
     "dist",
     "snap",
+    "tools",
+    "example",
+    "codespell_lib.tests*",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Disable implicit namespace discovery and exclude those dirs so dev-only paths like `tools/gen_OX.sh` are not installed as top-level packages.