### PR TITLE
Add spelling correction for accorss/accors.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1011,6 +1011,8 @@ accoridngly->accordingly
 accoring->according, occurring,
 accoringly->accordingly
 accorndingly->accordingly
+accors->accord, across,
+accorss->accords, across,
 accort->accord
 accortance->accordance
 accorted->accorded


### PR DESCRIPTION
See e.g.:
- https://grep.app/search?q=accorss
- https://grep.app/search?words=true&q=accors