### PR TITLE
Don't fix Voight

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -63766,7 +63766,6 @@ vocabularlies->vocabularies
 vocabularly->vocabulary
 voidin->voiding, void in,
 voif->void
-Voight->Voigt
 volatage->voltage
 volatages->voltages
 volatge->voltage


### PR DESCRIPTION
Fixes https://github.com/crate-ci/typos/issues/1527

`Voight` is the Americanized version  of the German `Vogt`/`Voigt` family name.