### PR TITLE
Dictionary plasic-plastic

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -44906,7 +44906,7 @@ plased->placed, pleased, phased,
 plasement->placement
 plasements->placements
 plases->places, pleases, phases,
-plasic->plastic
+plasic->plastic, plasmic,
 plasing->placing, pleasing, phasing,
 plateu->plateau
 platfarm->platform

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -44906,6 +44906,7 @@ plased->placed, pleased, phased,
 plasement->placement
 plasements->placements
 plases->places, pleases, phases,
+plasic->plastic
 plasing->placing, pleasing, phasing,
 plateu->plateau
 platfarm->platform


### PR DESCRIPTION
Correction for a typo found in the wild.