### PR TITLE
Add spelling correction for flwa/flwas.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -28645,6 +28645,8 @@ flushin->flushing, flush in,
 flushs->flushes
 flusing->flushing
 flutterin->fluttering, flutter in,
+flwa->flaw, flea,
+flwas->flaws, fleas,
 flyes->flies, flyers,
 fnction->function
 fnctions->functions


### PR DESCRIPTION
See e.g.:
- https://grep.app/search?words=true&q=flwas
- https://github.com/search?q=%22flwas+%22&type=code (Includes more then the previous)
- https://grep.app/search?words=true&q=flwa (Seems to include a low of unrelated strings but still have included the singular for now)