### PR TITLE
feat: add --ignore-sic to skip misspellings marked with [sic]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,6 +172,23 @@ Words should be separated by a comma.
        def wrod(wrods):
            pass
 
+Ignoring misspellings marked with "[sic]"
+-----------------------------------------
+
+The ``--ignore-sic`` option tells codespell to skip a misspelling that is
+followed by the editorial ``[sic]`` marker (case-insensitive). Only the single
+occurrence preceding the marker is ignored, so other misspellings on the same
+line are still reported. A closing quote may sit between the word and the
+marker, which is the common case when documenting a corrected typo (for example
+in a changelog):
+
+.. code-block:: text
+
+    correct the "wrod" [sic] typo in a changelog entry
+
+Unlike ``codespell:ignore``, the marker is part of the prose itself and does not
+require naming the word in a tooling comment.
+
 Using a config file
 -------------------
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -63,6 +63,9 @@ inline_ignore_regex = re.compile(
 ignore_next_line_regex = re.compile(
     rf"[^\w\s]\s*{codespell_ignore_next_line_tag}\b(\s+(?P<words>[\w,]*))?"
 )
+# Editorial "[sic]" marker following a word, allowing an intervening closing
+# quote so a quoted misspelling like `"..." [sic]` is matched.
+sic_regex = re.compile(r"[\"'’”)\s]*\[sic\]", re.IGNORECASE)  # noqa: RUF001
 USAGE = """
 \t%prog [OPTIONS] [file1 file2 ... fileN]
 """
@@ -660,6 +663,13 @@ def parse_options(
         help="print LINES of surrounding context",
     )
     parser.add_argument(
+        "--ignore-sic",
+        action="store_true",
+        default=False,
+        help='ignore a misspelling immediately followed by the editorial "[sic]" '
+        "marker (optionally preceded by a closing quote).",
+    )
+    parser.add_argument(
         "--stdin-single-line",
         action="store_true",
         help="output just a single line for each misspelling in stdin mode",
@@ -1048,6 +1058,11 @@ def parse_lines(
                     and word.startswith(("a", "b", "f", "n", "r", "t", "v"))
                     and lword[1:] not in misspellings
                 ):
+                    continue
+
+                # An "[sic]" marker right after the word flags it as an
+                # intentional/quoted spelling, so leave it alone.
+                if options.ignore_sic and sic_regex.match(line, match.end()):
                     continue
 
                 context_shown = False

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -502,6 +502,46 @@ def test_inline_ignores(
 @pytest.mark.parametrize(
     ("content", "expected_error_count"),
     [
+        # marker right after the word (optional whitespace) excuses it
+        ("they wrod [sic] it\n", 0),
+        ("they wrod[sic] it\n", 0),
+        ("they wrod  [sic] it\n", 0),
+        # case-insensitive marker
+        ("they wrod [SIC] it\n", 0),
+        # quoted typo followed by the marker (changelog use case)
+        ('correct "wrod" [sic] typo\n', 0),
+        ('correct "wrod"[sic] typo\n', 0),
+        # only the immediately preceding occurrence is excused
+        ("wrod wrod [sic]\n", 1),
+        # a marker elsewhere on the line does not excuse the word
+        ("wrod it [sic] anyway abilty\n", 2),
+        # an intervening word breaks the association
+        ('wrod" abilty [sic]\n', 1),
+        # without a marker the misspelling is still reported
+        ("they wrod it\n", 1),
+        # not a real marker
+        ("they wrod (sic) it\n", 1),
+        ("they wrod [sick] it\n", 1),
+    ],
+)
+def test_ignore_sic(
+    tmpdir: pytest.TempPathFactory,
+    capsys: pytest.CaptureFixture[str],
+    content: str,
+    expected_error_count: int,
+) -> None:
+    d = str(tmpdir)
+    with open(op.join(d, "bad.txt"), "w", encoding="utf-8") as f:
+        f.write(content)
+    # off by default
+    assert cs.main(d) == content.count("wrod") + content.count("abilty")
+    # opt-in
+    assert cs.main("--ignore-sic", d) == expected_error_count
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_error_count"),
+    [
         # wildcard form: ignore all misspellings on the next line
         ("# codespell:ignore-next-line\nabandonned abondon abilty\n", 0),
         ("// codespell:ignore-next-line\nabandonned abondon abilty\n", 0),


### PR DESCRIPTION
Closes #3764.

## Summary

Adds an opt-in `--ignore-sic` flag that skips a misspelling immediately followed by the editorial `[sic]` marker.

- Only the **single occurrence** preceding the marker is ignored; other misspellings on the same line are still reported.
- A closing quote may sit between the word and the marker, which is the common case when documenting a corrected typo in a changelog, e.g. `correct the "wrod" [sic] typo`.
- Case-insensitive (`[sic]`/`[SIC]`), with optional whitespace before the marker.

## Motivation

The existing inline mechanisms are all annotations aimed at the tool: `codespell:ignore` (whole line), `codespell:ignore <word>` (by spelling, not position — it can't target a single occurrence and requires naming the typo in a comment), and `codespell:ignore-next-line`. None of these fit prose where an intentional/quoted misspelling appears, such as a changelog entry announcing a typo fix.

`[sic]` is a long-standing editorial convention that already belongs in the text on its own merits, so reusing it costs the document nothing and needs no tooling comment. Because it changes default behavior only when explicitly requested, it is gated behind a flag rather than folded into `codespell:ignore`.

## Implementation

- New `sic_regex` and an `--ignore-sic` argument (default off).
- The check sits beside the existing backslash-escape false-alarm lookbehind in the match loop, using a positional `re.match(line, match.end())` anchor.

## Test plan

- [x] New parametrized `test_ignore_sic`: bare/quoted/whitespace/case variants, the changelog quoted form, single-occurrence scoping, and negative cases (`(sic)`, `[sick]`, intervening word). Asserts off-by-default behavior too.
- [x] `ruff check`, `ruff format --check`, `mypy --strict` clean.
- [x] codespell self-check passes (examples reuse the already-allowlisted `wrod`, so no new ignore-words entry).
- [x] Full `test_basic.py` suite: 82 passed, 1 skipped.