### PR TITLE
Add spelling corrections for simpe and variants.

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -54560,6 +54560,8 @@ simmetry->symmetry
 simmilar->similar
 simmilarity->similarity
 simmilarly->similarly
+simpe->simple, simper,
+simpest->simplest
 simpicity->simplicity
 simpification->simplification
 simpifications->simplifications


### PR DESCRIPTION
See e.g.:
- https://grep.app/search?words=true&q=simpest
- https://grep.app/search?words=true&q=simpe

Note: `simper` might be a typo of `simpler` but is also a valid word so i have left that out.