### PR TITLE
Switch tox.ini to dependency groups

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-min_version = 4.0
+min_version = 4.22
 env_list = unitest,type,dictionaries
 
 [testenv:dictionaries]
@@ -10,10 +10,10 @@ commands = make check-dictionaries
 
 [testenv:unitest]
 description = run unit tests
-extras = dev
+dependency_groups = dev
 commands = pytest --cov=codespell_lib codespell_lib
 
 [testenv:type]
 description = run type checks
-extras = types
+dependency_groups = types
 commands = mypy codespell_lib


### PR DESCRIPTION
This got forgotten during the initial dependency group work in #3877.