### PR TITLE
Fix --write-changes silently not fixing a trailing-apostrophe typo

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1094,7 +1094,12 @@ def parse_lines(
 
                 if options.write_changes and fix:
                     changed = True
-                    lines[i] = re.sub(rf"\b{word}\b", fixword, lines[i])
+                    # Not \b: the word regex admits a trailing apostrophe, and a
+                    # \b after one can never hold, so the substitution silently
+                    # matched nothing.
+                    lines[i] = re.sub(
+                        rf"(?<!\w){re.escape(word)}(?!\w)", fixword, lines[i]
+                    )
                     fixed_words.add(word)
                     changes_made.append((line_number + 1, word, fixword))
                     continue

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -216,6 +216,22 @@ def test_default_word_parsing(
     assert cs.main(fname) == 1, "misspelling containing typographic apostrophe U+2019"
 
 
+def test_write_changes_trailing_apostrophe(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A misspelling ending in an apostrophe must actually be written out."""
+    fname = tmp_path / "trailing_apostrophe"
+
+    fname.write_text("dont' go\n", encoding="utf-8")  # U+0027
+    cs.main("-w", fname, count=False)
+    assert fname.read_text(encoding="utf-8") == "don't go\n"
+
+    fname.write_text("dont’ go\n", encoding="utf-8")  # U+2019  # noqa: RUF001
+    cs.main("-w", fname, count=False)
+    assert fname.read_text(encoding="utf-8") == "don’t go\n"  # noqa: RUF001
+
+
 def test_bad_glob(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Problem

`codespell -w` reports `FIXED` and exits 0 for a misspelling that ends in an apostrophe, but the file is unchanged — the typo survives silently.

```console
$ printf "dont' go there\n" > t.txt
$ codespell --write-changes t.txt
FIXED: t.txt
  t.txt:1: dont' ==> don't
$ echo $?
0
$ cat t.txt
dont' go there
```

It's also non-idempotent: running `codespell -w` three times reports `FIXED` all three times and the file never changes. Since the exit code is 0 for both a real fix and a phantom one, nothing downstream can tell them apart — a CI that runs `codespell -w` and then `codespell` stays red with no tool-side remedy.

## Cause

`_codespell.py:1097` builds the substitution pattern with `\b` anchors:

```python
lines[i] = re.sub(rf"\b{word}\b", fixword, lines[i])
```

The word regex (`_codespell.py:51`) is `[\w\-'’]+`, so it admits a trailing apostrophe and `word` can end in one. A trailing `\b` then needs a word→non-word transition, but the preceding character is already non-word, so the assertion can never hold:

```python
re.sub(r"\bdont'\b", "don't", "dont' go there")  # -> "dont' go there"  (no match)
re.sub(r"\bteh\b",   "the",   "teh cat")         # -> "the cat"
```

Detection uses the plain word regex and is unaffected, which is why the misspelling is still reported — only the write-back is lost.

This affects **23 keys in the shipped dictionaries** (`dont'`, `cant'`, `isnt'`, `wasnt'`, `wouldnt'`, `thats'`, `aircrafts'`, …). `build_dict` also auto-generates a U+2019 variant of each via `alt_chars`, and `’` is non-word too, so the typographic form fails identically.

Mid-word apostrophes are fine (`woudn't` → `wouldn't` writes correctly) because the trailing `\b` there follows a word character.

## Fix

```python
lines[i] = re.sub(rf"(?<!\w){re.escape(word)}(?!\w)", fixword, lines[i])
```

Lookarounds express the intended boundary without depending on the previous character's class. Verified equivalent on the boundary-sensitive cases:

| word | line | before | after |
|---|---|---|---|
| `dont'` | `dont' go there` | `dont' go there` ❌ | `don't go there` ✅ |
| `dont’` | `dont’ go` | `dont’ go` ❌ | `don’t go` ✅ |
| `teh` | `teh cat teh` | `the cat the` | `the cat the` ✅ |
| `teh` | `theteh x` | no match | no match ✅ |
| `teh` | `_teh x` | no match | no match ✅ |
| `teh` | `teh's` | `the's` | `the's` ✅ |

The `re.escape` isn't fixing a live bug — no dictionary key currently contains a regex metacharacter (I checked) — but the interpolation was only safe by accident, and escaping is free here.

## Testing

Added `test_write_changes_trailing_apostrophe`, next to the existing `test_apostrophe`. The existing test only asserts *detection* (`cs.main(fname) == 1`) and uses `woudn't` — a mid-word apostrophe — so it never exercised the broken path; none of the `-w` tests use an apostrophe-terminated word either.

Verified it fails first (`assert "dont' go\n" == "don't go\n"`) and passes after.

Full `codespell_lib/tests/` — 124 passed, 16 skipped. The 3 failures (`test_command`, `test_stdin`, `test_args_from_file`) are identical before and after my change; they're `FileNotFoundError` from my sandbox not having the CLI on PATH, unrelated to this. `ruff check` and `ruff format --check` clean.

---

This change was AI-assisted (Claude). I reproduced the phantom fix and the non-idempotence myself with the real CLI before writing anything, confirmed the regex mechanism directly in a REPL, counted the affected dictionary keys, and ran the tests and baseline comparison above myself.
