### PR TITLE
Add vacabulary (and plural) typo

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -62867,6 +62867,8 @@ vaalue->value
 vaalued->valued
 vaalues->values
 vaaluing->valuing
+vacabularies->vocabularies
+vacabulary->vocabulary
 vaccinatin->vaccinating, vaccination,
 vaccum->vacuum
 vaccume->vacuum


### PR DESCRIPTION
Frequent user, first-time contributor, thank you codespell folks!

over 2000 hits on https://github.com/search?q=vacabulary&type=code, and 117 for the plural on https://github.com/search?q=vacabularies&type=code

Also 64 repositories: https://github.com/search?q=vacabulary&type=repositories (the top hit is hilariously a spell checker):

> [**Ezharjan/SpellChecker**](https://github.com/Ezharjan/SpellChecker) 
> This is a C# based project which creates a commond line tool to check whether the spell of an English vacabulary is correct or not.

Found via a missed `vacabulary` in a ReproNim/repronim.org PR.