### PR TITLE
Interactive mode: an answer applies to one occurrence, not the whole run

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,6 @@
 branch = True
 source = codespell_lib
 omit = */codespell_lib/tests/*
+# Some tests run the codespell entry point in a subprocess; without this their
+# coverage is invisible (pytest-cov 7 dropped its own subprocess support).
+patch = subprocess

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -588,7 +588,8 @@ def parse_options(
         help="set interactive mode when writing changes:\n"
         "- 0: no interactivity.\n"
         "- 1: ask for confirmation; 'a'/'s' answer for the rest of the file.\n"
-        "- 2: ask user to choose one fix when more than one is available.\n"
+        "- 2: ask user to choose one fix when more than one is available;"
+        " 'Na'/'s' answer for the rest of the file.\n"
         "- 3: both 1 and 2",
         metavar="MODE",
     )
@@ -872,10 +873,12 @@ def ask_for_word_fix(
         # we ask the user which word to use
 
         r = ""
+        remember = False
         opt = [w.strip() for w in misspelling.data.split(",")]
         while not r:
             print(
-                f"{cfilename}:{cline}: {line_ui} Choose an option (blank for none): ",
+                f"{cfilename}:{cline}: {line_ui} Choose an option "
+                "(blank for none, Na for whole file, s to skip): ",
                 end="",
             )
             for i, o in enumerate(opt):
@@ -886,18 +889,21 @@ def ask_for_word_fix(
             answer = sys.stdin.readline()
             if not answer:
                 return _no_more_input(misspelling)
-            n = answer.strip()
+            n = answer.strip().lower()
             if not n:
                 break
+            if n == "s":
+                return False, misspelling.data, True
 
+            remember = n.endswith("a")
             try:
-                i = int(n)
+                i = int(n[:-1] if remember else n)
                 r = opt[i]
             except (ValueError, IndexError):
                 print("Not a valid option\n")
 
         if r:
-            return True, r, False
+            return True, r, remember
 
     return misspelling.fix, misspelling.data, False
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -837,9 +837,6 @@ def ask_for_word_fix(
     cline = f"{colors.FILE}{lineno}{colors.DISABLE}"
 
     wrongword = match.group()
-    if interactivity <= 0:
-        return misspelling.fix, misspelling.data, False
-
     line_ui = (
         f"{line[: match.start()]}"
         f"{colors.WWORD}{wrongword}{colors.DISABLE}"

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -587,7 +587,7 @@ def parse_options(
         choices=range(0, 4),
         help="set interactive mode when writing changes:\n"
         "- 0: no interactivity.\n"
-        "- 1: ask for confirmation.\n"
+        "- 1: ask for confirmation; 'a'/'s' answer for the rest of the file.\n"
         "- 2: ask user to choose one fix when more than one is available.\n"
         "- 3: both 1 and 2",
         metavar="MODE",
@@ -806,6 +806,14 @@ def is_text_file(filename: str) -> bool:
     return b"\x00" not in s
 
 
+def _no_more_input(misspelling: Misspelling) -> tuple[bool, str, bool]:
+    # An unanswered prompt must not count as a "yes": stdin being at EOF means
+    # the answers ran out (or never existed), so leave the word alone and stop
+    # asking about it in this file.
+    print("\nNo answer: leaving the rest of this file alone")
+    return False, misspelling.data, True
+
+
 def ask_for_word_fix(
     line: str,
     match: Match[str],
@@ -814,16 +822,23 @@ def ask_for_word_fix(
     colors: TermColors,
     filename: str,
     lineno: int,
-) -> tuple[bool, str]:
-    # This function must not mutate `misspelling`: the object is shared by every
-    # match of the word in the run, so a per-occurrence answer would leak into
-    # every later occurrence and file (GH-62).
+) -> tuple[bool, str, bool]:
+    """Ask about one match.
+
+    Returns (fix, data, remember), where data is the replacement in dictionary
+    form, uncased, for the caller to case per match, and remember says whether
+    the answer was given for the rest of the file rather than for this match.
+
+    This function must not mutate `misspelling`: the object is shared by every
+    match of the word in the run, so an answer would leak into every later
+    match and file (GH-62).
+    """
     cfilename = f"{colors.FILE}{filename}{colors.DISABLE}"
     cline = f"{colors.FILE}{lineno}{colors.DISABLE}"
 
     wrongword = match.group()
     if interactivity <= 0:
-        return misspelling.fix, fix_case(wrongword, misspelling.data)
+        return misspelling.fix, misspelling.data, False
 
     line_ui = (
         f"{line[: match.start()]}"
@@ -836,21 +851,24 @@ def ask_for_word_fix(
         fixword = fix_case(wrongword, misspelling.data)
         while not r:
             print(
-                f"{cfilename}:{cline}: {line_ui}\t{wrongword} ==> {fixword} (Y/n) ",
+                f"{cfilename}:{cline}: {line_ui}\t{wrongword} ==> {fixword} (Y/n/a/s) ",
                 end="",
                 flush=True,
             )
-            r = sys.stdin.readline().strip().upper()
+            answer = sys.stdin.readline()
+            if not answer:
+                return _no_more_input(misspelling)
+            r = answer.strip().upper()
             if not r:
                 r = "Y"
-            if r not in ("Y", "N"):
-                print("Say 'y' or 'n'")
+            if r not in ("Y", "N", "A", "S"):
+                print(
+                    "Say 'y' or 'n' for this one, "
+                    "'a' or 's' for all of them in this file"
+                )
                 r = ""
 
-        if r == "N":
-            return False, fixword
-
-        return True, fixword
+        return r in ("Y", "A"), misspelling.data, r in ("A", "S")
 
     elif (interactivity & 2) and not misspelling.fix and not misspelling.reason:
         # if it is not disabled, i.e. it just has more than one possible fix,
@@ -868,7 +886,10 @@ def ask_for_word_fix(
                 print(f" {i}) {fixword}", end="")
             print(": ", end="", flush=True)
 
-            n = sys.stdin.readline().strip()
+            answer = sys.stdin.readline()
+            if not answer:
+                return _no_more_input(misspelling)
+            n = answer.strip()
             if not n:
                 break
 
@@ -879,9 +900,9 @@ def ask_for_word_fix(
                 print("Not a valid option\n")
 
         if r:
-            return True, fix_case(wrongword, r)
+            return True, r, False
 
-    return misspelling.fix, fix_case(wrongword, misspelling.data)
+    return misspelling.fix, misspelling.data, False
 
 
 def print_context(
@@ -981,6 +1002,7 @@ def parse_lines(
     uri_ignore_words: set[str],
     context: Optional[tuple[int, int]],
     options: argparse.Namespace,
+    asked_for: dict[str, tuple[bool, str]],
 ) -> tuple[int, bool, list[tuple[int, str, str]]]:
     bad_count = 0
     changed = False
@@ -989,11 +1011,6 @@ def parse_lines(
     _, fragment_line_number, lines = fragment
 
     next_line_ignore_words: Optional[set[str]] = None
-
-    # Memory of interactive answers for this fragment: lword -> (fix, fixword).
-    # An answer covers every later match of the word here, so each word is
-    # asked about once per file rather than once per line (GH-62).
-    asked_for: dict[str, tuple[bool, str]] = {}
 
     for i, line in enumerate(lines):
         line = line.rstrip()
@@ -1081,21 +1098,24 @@ def parse_lines(
 
                 if options.interactive:
                     if lword in asked_for:
-                        fix, fixword = asked_for[lword]
+                        fix, data = asked_for[lword]
                     else:
                         if context is not None:
                             context_shown = True
                             print_context(lines, i, context)
-                        fix, fixword = ask_for_word_fix(
+                        fix, data, remember = ask_for_word_fix(
                             lines[i],
                             match,
                             misspellings[lword],
                             options.interactive,
                             colors=colors,
                             filename=filename,
-                            lineno=i + 1,
+                            lineno=line_number + 1,
                         )
-                        asked_for[lword] = (fix, fixword)
+                        if remember:
+                            asked_for[lword] = (fix, data)
+                    # The answer is uncased: case it for this match.
+                    fixword = fix_case(word, data)
 
                 if summary and fix:
                     summary.update(lword)
@@ -1232,6 +1252,9 @@ def parse_file(
     # Parse lines.
     changed = False
     changes_made: list[tuple[int, str, str]] = []
+    # Answers given for the whole file ('a'/'s'): lword -> (fix, uncased fix).
+    # Plain y/n answers are not remembered here: they are about one match.
+    asked_for: dict[str, tuple[bool, str]] = {}
     for fragment in fragments:
         ignore, _, _ = fragment
         if ignore:
@@ -1251,6 +1274,7 @@ def parse_file(
             uri_ignore_words,
             context,
             options,
+            asked_for,
         )
         bad_count += bad_count_update
         changed = changed or changed_update

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -815,6 +815,9 @@ def ask_for_word_fix(
     filename: str,
     lineno: int,
 ) -> tuple[bool, str]:
+    # This function must not mutate `misspelling`: the object is shared by every
+    # match of the word in the run, so a per-occurrence answer would leak into
+    # every later occurrence and file (GH-62).
     cfilename = f"{colors.FILE}{filename}{colors.DISABLE}"
     cline = f"{colors.FILE}{lineno}{colors.DISABLE}"
 
@@ -845,9 +848,11 @@ def ask_for_word_fix(
                 r = ""
 
         if r == "N":
-            misspelling.fix = False
+            return False, fixword
 
-    elif (interactivity & 2) and not misspelling.reason:
+        return True, fixword
+
+    elif (interactivity & 2) and not misspelling.fix and not misspelling.reason:
         # if it is not disabled, i.e. it just has more than one possible fix,
         # we ask the user which word to use
 
@@ -874,8 +879,7 @@ def ask_for_word_fix(
                 print("Not a valid option\n")
 
         if r:
-            misspelling.fix = True
-            misspelling.data = r
+            return True, fix_case(wrongword, r)
 
     return misspelling.fix, fix_case(wrongword, misspelling.data)
 
@@ -986,6 +990,11 @@ def parse_lines(
 
     next_line_ignore_words: Optional[set[str]] = None
 
+    # Memory of interactive answers for this fragment: lword -> (fix, fixword).
+    # An answer covers every later match of the word here, so each word is
+    # asked about once per file rather than once per line (GH-62).
+    asked_for: dict[str, tuple[bool, str]] = {}
+
     for i, line in enumerate(lines):
         line = line.rstrip()
         # Apply any ignore-next-line directive carried from the previous line.
@@ -1025,7 +1034,6 @@ def parse_lines(
             extra_words_to_ignore |= pending_next_line_ignore
 
         fixed_words = set()
-        asked_for = set()
 
         # If all URI spelling errors will be ignored, erase any URI before
         # extracting words. Otherwise, apply ignores after extracting words.
@@ -1071,20 +1079,23 @@ def parse_lines(
                 fix = misspellings[lword].fix
                 fixword = fix_case(word, misspellings[lword].data)
 
-                if options.interactive and lword not in asked_for:
-                    if context is not None:
-                        context_shown = True
-                        print_context(lines, i, context)
-                    fix, fixword = ask_for_word_fix(
-                        lines[i],
-                        match,
-                        misspellings[lword],
-                        options.interactive,
-                        colors=colors,
-                        filename=filename,
-                        lineno=i + 1,
-                    )
-                    asked_for.add(lword)
+                if options.interactive:
+                    if lword in asked_for:
+                        fix, fixword = asked_for[lword]
+                    else:
+                        if context is not None:
+                            context_shown = True
+                            print_context(lines, i, context)
+                        fix, fixword = ask_for_word_fix(
+                            lines[i],
+                            match,
+                            misspellings[lword],
+                            options.interactive,
+                            colors=colors,
+                            filename=filename,
+                            lineno=i + 1,
+                        )
+                        asked_for[lword] = (fix, fixword)
 
                 if summary and fix:
                     summary.update(lword)

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1643,3 +1643,75 @@ def test_args_from_file(
     print("Testing with direct call to cs_.main()")
     r = cs_.main(*args[1:])
     print(f"{r=}")
+
+
+def run_codespell_interactive(
+    args: tuple[Any, ...],
+    answers: str,
+    cwd: Optional[Path] = None,
+) -> "subprocess.CompletedProcess[str]":
+    """Run codespell feeding interactive answers on stdin."""
+    args = tuple(str(arg) for arg in args)
+    return subprocess.run(  # noqa: S603
+        ["codespell", *args],  # noqa: S607
+        cwd=cwd,
+        input=answers,
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+def test_interactive_rejection_is_per_file(
+    tmp_path: Path,
+) -> None:
+    """Rejecting a fix answers for one file, not for the whole run (GH-62)."""
+    f1 = tmp_path / "f1.txt"
+    f2 = tmp_path / "f2.txt"
+    f1.write_text("abandonned\n")
+    f2.write_text("abandonned\n")
+    proc = run_codespell_interactive(("-w", "-i", "1", f1, f2), answers="n\ny\n")
+    assert proc.stdout.count("(Y/n)") == 2
+    assert f1.read_text() == "abandonned\n"
+    assert f2.read_text() == "abandoned\n"
+
+
+def test_interactive_same_word_asked_once_per_file(
+    tmp_path: Path,
+) -> None:
+    """Within one file the first answer is reused for later matches."""
+    f = tmp_path / "f.txt"
+    f.write_text("abandonned\nabandonned\n")
+    proc = run_codespell_interactive(("-w", "-i", "1", f), answers="n\n")
+    assert proc.stdout.count("(Y/n)") == 1
+    assert f.read_text() == "abandonned\nabandonned\n"
+
+
+def test_interactive_level_2_no_prompt_for_single_fix(
+    tmp_path: Path,
+) -> None:
+    """Level 2 prompts only when more than one fix is available (as --help says).
+
+    A word with a single candidate used to get an option list where the blank
+    "none" answer still applied the fix (GH-62).
+    """
+    f = tmp_path / "f.txt"
+    f.write_text("abandonned\n")
+    proc = run_codespell_interactive(("-w", "-i", "2", f), answers="\n")
+    assert "Choose an option" not in proc.stdout
+    assert f.read_text() == "abandoned\n"
+
+
+def test_interactive_level_3_rejection_keeps_yn_prompt(
+    tmp_path: Path,
+) -> None:
+    """A rejected word must stay a Y/n question, not degrade to an option list."""
+    f1 = tmp_path / "f1.txt"
+    f2 = tmp_path / "f2.txt"
+    f1.write_text("abandonned\n")
+    f2.write_text("abandonned\n")
+    proc = run_codespell_interactive(("-w", "-i", "3", f1, f2), answers="n\nn\n")
+    assert proc.stdout.count("(Y/n)") == 2
+    assert "Choose an option" not in proc.stdout
+    assert f1.read_text() == "abandonned\n"
+    assert f2.read_text() == "abandonned\n"

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1808,6 +1808,43 @@ def test_interactive_level_2_answer_keeps_case(
     assert f.read_text() == "cache\nCache\n"
 
 
+def test_interactive_level_2_answer_for_whole_file(
+    tmp_path: Path,
+) -> None:
+    """A number with a trailing 'a' picks that fix for the rest of the file."""
+    f = tmp_path / "f.txt"
+    f.write_text("aache\nAache\n")
+    proc = run_codespell_interactive(("-w", "-i", "2", f), answers="0a\n")
+    assert proc.stdout.count("Choose an option") == 1
+    assert f.read_text() == "cache\nCache\n"
+
+
+def test_interactive_level_2_skip_whole_file(
+    tmp_path: Path,
+) -> None:
+    """'s' leaves the word alone for the rest of the file."""
+    f1 = tmp_path / "f1.txt"
+    f2 = tmp_path / "f2.txt"
+    f1.write_text("aache\naache\n")
+    f2.write_text("aache\n")
+    proc = run_codespell_interactive(("-w", "-i", "2", f1, f2), answers="s\n0\n")
+    assert proc.stdout.count("Choose an option") == 2
+    assert f1.read_text() == "aache\naache\n"
+    assert f2.read_text() == "cache\n"
+
+
+def test_interactive_level_2_invalid_answer_asks_again(
+    tmp_path: Path,
+) -> None:
+    """A bare 'a' is not a choice: it re-asks rather than picking something."""
+    f = tmp_path / "f.txt"
+    f.write_text("aache\n")
+    proc = run_codespell_interactive(("-w", "-i", "2", f), answers="a\n9\n1\n")
+    assert proc.stdout.count("Choose an option") == 3
+    assert proc.stdout.count("Not a valid option") == 2
+    assert f.read_text() == "ache\n"
+
+
 def test_interactive_level_2_no_prompt_for_single_fix(
     tmp_path: Path,
 ) -> None:

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1645,6 +1645,9 @@ def test_args_from_file(
     print(f"{r=}")
 
 
+PROMPT = "(Y/n/a/s)"
+
+
 def run_codespell_interactive(
     args: tuple[Any, ...],
     answers: str,
@@ -1662,29 +1665,107 @@ def run_codespell_interactive(
     )
 
 
-def test_interactive_rejection_is_per_file(
+def test_interactive_rejection_is_per_match(
     tmp_path: Path,
 ) -> None:
-    """Rejecting a fix answers for one file, not for the whole run (GH-62)."""
+    """A y/n answer is about one match, not the rest of the run (GH-62)."""
     f1 = tmp_path / "f1.txt"
     f2 = tmp_path / "f2.txt"
-    f1.write_text("abandonned\n")
+    f1.write_text("abandonned\nabandonned\n")
     f2.write_text("abandonned\n")
-    proc = run_codespell_interactive(("-w", "-i", "1", f1, f2), answers="n\ny\n")
-    assert proc.stdout.count("(Y/n)") == 2
-    assert f1.read_text() == "abandonned\n"
+    proc = run_codespell_interactive(("-w", "-i", "1", f1, f2), answers="n\ny\ny\n")
+    assert proc.stdout.count(PROMPT) == 3
+    assert f1.read_text() == "abandonned\nabandoned\n"
     assert f2.read_text() == "abandoned\n"
 
 
-def test_interactive_same_word_asked_once_per_file(
+def test_interactive_answer_for_whole_file(
     tmp_path: Path,
 ) -> None:
-    """Within one file the first answer is reused for later matches."""
+    """'a' and 's' answer for the rest of the file, and stop at its end."""
+    f1 = tmp_path / "f1.txt"
+    f2 = tmp_path / "f2.txt"
+    f1.write_text("abandonned\nabandonned\n")
+    f2.write_text("abandonned\nabandonned\n")
+    proc = run_codespell_interactive(("-w", "-i", "1", f1, f2), answers="s\na\n")
+    assert proc.stdout.count(PROMPT) == 2
+    assert f1.read_text() == "abandonned\nabandonned\n"
+    assert f2.read_text() == "abandoned\nabandoned\n"
+
+
+def test_interactive_whole_file_answer_spans_fragments(
+    tmp_path: Path,
+) -> None:
+    """An ignored multiline region splits a file but must not re-ask."""
     f = tmp_path / "f.txt"
-    f.write_text("abandonned\nabandonned\n")
-    proc = run_codespell_interactive(("-w", "-i", "1", f), answers="n\n")
-    assert proc.stdout.count("(Y/n)") == 1
-    assert f.read_text() == "abandonned\nabandonned\n"
+    f.write_text("abandonned\nSKIPSTART\nfoo\nSKIPEND\nabandonned\n")
+    proc = run_codespell_interactive(
+        ("-w", "-i", "1", "--ignore-multiline-regex", r"SKIPSTART[\s\S]*?SKIPEND", f),
+        answers="s\n",
+    )
+    assert proc.stdout.count(PROMPT) == 1
+    assert f.read_text() == "abandonned\nSKIPSTART\nfoo\nSKIPEND\nabandonned\n"
+
+
+def test_interactive_answer_keeps_case(
+    tmp_path: Path,
+) -> None:
+    """An answer is cased for each match, not for the one that was asked about."""
+    f = tmp_path / "f.txt"
+    f.write_text("abandonned\nAbandonned\nABANDONNED\n")
+    proc = run_codespell_interactive(("-w", "-i", "1", f), answers="a\n")
+    assert proc.stdout.count(PROMPT) == 1
+    assert f.read_text() == "abandoned\nAbandoned\nABANDONED\n"
+
+
+def test_interactive_invalid_answer_asks_again(
+    tmp_path: Path,
+) -> None:
+    """Anything that is not y/n/a/s re-asks about the same match."""
+    f = tmp_path / "f.txt"
+    f.write_text("abandonned\n")
+    proc = run_codespell_interactive(("-w", "-i", "1", f), answers="x\ny\n")
+    assert proc.stdout.count(PROMPT) == 2
+    assert "Say 'y' or 'n'" in proc.stdout
+    assert f.read_text() == "abandoned\n"
+
+
+@pytest.mark.parametrize(
+    ("level", "text"),
+    [
+        ("1", "abandonned\nabandonned\n"),  # asked with y/n/a/s
+        ("2", "aache\naache\n"),  # asked with a list of fixes
+        ("3", "abandonned\naache\n"),  # both
+    ],
+)
+def test_interactive_no_answer_fixes_nothing(
+    tmp_path: Path,
+    level: str,
+    text: str,
+) -> None:
+    """Running out of answers must not count as accepting the rest."""
+    f = tmp_path / "f.txt"
+    f.write_text(text)
+    proc = run_codespell_interactive(("-w", "-i", level, f), answers="")
+    assert "No answer" in proc.stdout
+    assert f.read_text() == text
+
+
+def test_interactive_level_2_answer_keeps_case(
+    tmp_path: Path,
+) -> None:
+    """The same, for the answer chosen from a list of fixes.
+
+    The list is asked about once per match, and keeps every candidate: choosing
+    one used to narrow the list for every later match (GH-62).
+    """
+    f = tmp_path / "f.txt"
+    f.write_text("aache\nAache\n")
+    proc = run_codespell_interactive(("-w", "-i", "2", f), answers="0\n0\n")
+    assert proc.stdout.count("Choose an option") == 2
+    assert proc.stdout.count("1) ache") == 1
+    assert proc.stdout.count("1) Ache") == 1
+    assert f.read_text() == "cache\nCache\n"
 
 
 def test_interactive_level_2_no_prompt_for_single_fix(
@@ -1711,7 +1792,7 @@ def test_interactive_level_3_rejection_keeps_yn_prompt(
     f1.write_text("abandonned\n")
     f2.write_text("abandonned\n")
     proc = run_codespell_interactive(("-w", "-i", "3", f1, f2), answers="n\nn\n")
-    assert proc.stdout.count("(Y/n)") == 2
+    assert proc.stdout.count(PROMPT) == 2
     assert "Choose an option" not in proc.stdout
     assert f1.read_text() == "abandonned\n"
     assert f2.read_text() == "abandonned\n"

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1718,6 +1718,18 @@ def test_interactive_answer_keeps_case(
     assert f.read_text() == "abandoned\nAbandoned\nABANDONED\n"
 
 
+def test_interactive_context_is_shown_once(
+    tmp_path: Path,
+) -> None:
+    """-C prints the surrounding lines before asking, and not again after."""
+    f = tmp_path / "f.txt"
+    f.write_text("first line\nabandonned\n")
+    proc = run_codespell_interactive(("-w", "-i", "1", "-C", "1", f), answers="n\n")
+    assert proc.stdout.count(PROMPT) == 1
+    assert proc.stdout.count("first line") == 1
+    assert f.read_text() == "first line\nabandonned\n"
+
+
 def test_interactive_invalid_answer_asks_again(
     tmp_path: Path,
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     "chardet",
     "pre-commit",
     "pytest",
-    "pytest-cov",
+    "pytest-cov>=7",
     "pytest-dependency",
     "Pygments",
     "ruff",
@@ -54,7 +54,7 @@ types = [
     "chardet>=5.1.0",
     "mypy",
     "pytest",
-    "pytest-cov",
+    "pytest-cov>=7",
     "pytest-dependency",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ max-complexity = 45
 
 [tool.ruff.lint.pylint]
 allow-magic-value-types = ["bytes", "int", "str",]
-max-args = 13
+max-args = 14
 max-branches = 48
 max-returns = 12
 max-statements = 120


### PR DESCRIPTION
Fixes #62.

The root cause is that `ask_for_word_fix` answers a question about one occurrence by mutating the shared `Misspelling` object, so a single answer leaks into every later occurrence of the word in the run. Observed on current `master` (all transcripts scripted, answers fed on stdin):

- `-w -i 1`, the same word in two files, answers `n`, `y`: the second file never asks — the rejection turned the word off globally, and the queued `y` is never consumed.
- `-w -i 3`, reject a word, then meet it in the next file: the prompt degrades from `(Y/n)` to `Choose an option (blank for none): 0) ...` — the "handled as a list of available fixes" behaviour from the issue, still alive.
- `-w -i 2`, a word with a single candidate, answer blank ("blank for none"): the file is changed anyway — `FIXED: c.txt`.

Three changes:

1. `ask_for_word_fix` no longer mutates `misspelling`; it returns the answer for this occurrence.
2. The caller remembers answers per word per file (`asked_for` becomes a dict and moves out of the per-line scope, where its reset meant "asked once per file" only held because of the mutation). Accepting and rejecting now behave symmetrically: each word is asked once per file, and the answer covers the rest of that file.
3. The option-list branch now triggers only for words with more than one candidate, which is what `--help` says level 2 is for ("ask user to choose one fix when more than one is available"). Single-candidate words at `-i 2` are written without a prompt, as documented; the blank-accepts-anyway path is gone.

These are the first tests for interactive mode in the suite; they feed answers through stdin. On the unpatched tree the three bug tests fail exactly on the behaviours above, the per-file control passes; with the fix all four pass. Full `test_basic.py`: 86 passed, 3 failed — the same three failures (chardet import) as on a clean tree. `ruff check`, `ruff format --check` clean; mypy reports the same two pre-existing errors as on a clean tree.

AI-assisted (LLM used for drafting); the runs above are mine.
