### PR TITLE
README: mention MegaLinter integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -292,6 +292,12 @@ If one configures codespell using the `pyproject.toml` file instead use:
       additional_dependencies:
         - tomli
 
+Using with MegaLinter
+---------------------
+
+codespell is embedded in `MegaLinter <https://megalinter.io>`_, a linters aggregator for CI:
+see its `codespell page <https://megalinter.io/latest/descriptors/spell_codespell/>`_ for how to enable and configure it there.
+
 Dictionary format
 -----------------
 


### PR DESCRIPTION
Hi! I maintain MegaLinter (https://megalinter.io), an open-source linters aggregator for CI, and codespell has been one of its embedded linters for a while.

This adds a short note in the README (next to the pre-commit section) pointing users to the MegaLinter codespell page, so folks who want codespell in their CI alongside other linters know it's an option: https://megalinter.io/latest/descriptors/spell_codespell/

Happy to reword or move it elsewhere if you'd prefer. Thanks for the great tool!