### PR TITLE
Do not report a fix that --ignore-regex made impossible

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1100,10 +1100,8 @@ def parse_lines(
                         fixed_words.add(word)
                         changes_made.append((line_number + 1, word, fixword))
                         continue
-                    # The word was found in the --ignore-regex substituted text
-                    # but cannot be located in the original line, so no fix can
-                    # be written.  Fall through and report it as a warning
-                    # instead of claiming a fix that did not happen.
+                    # Not found in the original line (e.g. --ignore-regex split
+                    # it out of a larger word), so report it instead (GH-2056).
 
                 # otherwise warning was explicitly set by interactive mode
                 if (

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -1093,11 +1093,17 @@ def parse_lines(
                     continue
 
                 if options.write_changes and fix:
-                    changed = True
-                    lines[i] = re.sub(rf"\b{word}\b", fixword, lines[i])
-                    fixed_words.add(word)
-                    changes_made.append((line_number + 1, word, fixword))
-                    continue
+                    new_line = re.sub(rf"\b{word}\b", fixword, lines[i])
+                    if new_line != lines[i]:
+                        changed = True
+                        lines[i] = new_line
+                        fixed_words.add(word)
+                        changes_made.append((line_number + 1, word, fixword))
+                        continue
+                    # The word was found in the --ignore-regex substituted text
+                    # but cannot be located in the original line, so no fix can
+                    # be written.  Fall through and report it as a warning
+                    # instead of claiming a fix that did not happen.
 
                 # otherwise warning was explicitly set by interactive mode
                 if (

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1069,16 +1069,17 @@ def test_ignore_regex_with_write_changes(
     fname.write_text(content)
     result = cs.main("-w", "--ignore-regex=_", fname, std=True)
     assert isinstance(result, tuple)
-    code, _, stderr = result
+    code, stdout, stderr = result
     corrected = fname.read_text()
 
     # Line 1 really is rewritten.
     assert corrected == "1st\n1nd_2nd\n"
-    # Line 2 cannot be rewritten (\b1nd\b does not match "1nd_2nd"),
-    # so codespell must not claim it was fixed ...
+    # Line 2 cannot be rewritten (\b1nd\b does not match "1nd_2nd"), so it must
+    # not be listed as fixed, must be reported as a misspelling instead ...
     assert "flag.txt:2: 1nd ==> 1st" not in stderr
-    # ... and the still-present misspelling must affect the exit code.
-    assert code != 0
+    assert "flag.txt:2: 1nd ==> 1st" in stdout
+    # ... and must be counted, so that it affects the exit code.
+    assert code == 1
 
 
 def test_ignore_multiline_regex_option(

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -1054,6 +1054,33 @@ def test_ignore_regex_option(
     assert cs.main(fname, r"--ignore-regex=\bdonn\b") == 1
 
 
+def test_ignore_regex_with_write_changes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that -w never claims a fix it did not perform (gh-2056)."""
+    fname = tmp_path / "flag.txt"
+    content = "1nd\n1nd_2nd\n"
+
+    # Without -w, --ignore-regex=_ makes BOTH lines report a misspelling.
+    fname.write_text(content)
+    assert cs.main(fname, "--ignore-regex=_") == 2
+
+    fname.write_text(content)
+    result = cs.main("-w", "--ignore-regex=_", fname, std=True)
+    assert isinstance(result, tuple)
+    code, _, stderr = result
+    corrected = fname.read_text()
+
+    # Line 1 really is rewritten.
+    assert corrected == "1st\n1nd_2nd\n"
+    # Line 2 cannot be rewritten (\b1nd\b does not match "1nd_2nd"),
+    # so codespell must not claim it was fixed ...
+    assert "flag.txt:2: 1nd ==> 1st" not in stderr
+    # ... and the still-present misspelling must affect the exit code.
+    assert code != 0
+
+
 def test_ignore_multiline_regex_option(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
Fixes #2056.

### What happens

```console
$ printf '1nd\n1nd_2nd\n' > test.txt
$ codespell test.txt --ignore-regex _ --write-changes
FIXED: test.txt
  test.txt:1: 1nd ==> 1st
  test.txt:2: 1nd ==> 1st
$ echo $?
0
$ cat test.txt
1st
1nd_2nd
```

Line 2 is reported as fixed, is not fixed, and does not affect the exit code — so a CI run goes green with the misspelling still in the file, and running codespell again prints the same false `FIXED:` forever.

### Why

Detection and writing look at two different texts. Detection walks the line with `--ignore-regex` substituted out (`_ignore_word_sub` replaces the match with a space), so it sees `1nd 2nd` and finds `1nd`. `--write-changes` then substitutes on the **original** line:

```python
if options.write_changes and fix:
    changed = True
    lines[i] = re.sub(rf"\b{word}\b", fixword, lines[i])
    fixed_words.add(word)
    changes_made.append((line_number + 1, word, fixword))
    continue
```

In `1nd_2nd` there is no word boundary between `1nd` and `_`, so `re.sub` matches nothing. But `changed` is set before the result is inspected, `changes_made` records a change that never happened, and `continue` skips the warning branch that would have set the exit code.

### The change

Keep the result of the substitution, and only claim the fix when the line really changed; otherwise fall through to the normal warning. `--ignore-regex` semantics are untouched — the word is still detected, it is just reported instead of silently dropped. This is the second of the two outcomes the reporter said would be acceptable ("either fix it, or tell me it can't").

After:

```console
FIXED: test.txt
  test.txt:1: 1nd ==> 1st
test.txt:2: 1nd ==> 1st
$ echo $?
65
```

### Tests

`test_ignore_regex_with_write_changes` in `codespell_lib/tests/test_basic.py`, next to the existing `--ignore-regex` tests. It asserts all three symptoms: line 1 is rewritten, line 2 is **not** listed as fixed, and the exit code is non-zero. On `main` it fails on the middle assertion.

`pytest codespell_lib/tests/test_basic.py`: **85 passed** on `main`, **86 passed** with this change, no failures either way. `ruff check`, `ruff format --check` and `mypy` are clean (mypy reports the same two pre-existing `chardet` stub errors on an untouched tree).