### PR TITLE
Check hidden files named explicitly on the command line

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -640,7 +640,11 @@ def parse_options(
         "--check-hidden",
         action="store_true",
         default=False,
-        help='check hidden files and directories (those starting with ".") as well.',
+        help=(
+            'check hidden files and directories (those starting with ".") as '
+            "well. Hidden files named explicitly on the command line are always "
+            "checked."
+        ),
     )
     parser.add_argument(
         "-A",
@@ -1528,8 +1532,10 @@ def main(*args: str) -> int:
 
     bad_count = 0
     for filename in sorted(options.files):
-        # ignore hidden files
-        if is_hidden(filename, options.check_hidden):
+        # A hidden path named explicitly on the command line is checked even
+        # without --check-hidden. Directories still honor --check-hidden so that
+        # recursing into them does not pull in hidden contents unexpectedly.
+        if is_hidden(filename, options.check_hidden) and os.path.isdir(filename):
             continue
 
         if os.path.isdir(filename):

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -774,7 +774,9 @@ def test_check_hidden(
     #
     hidden_file = tmp_path / ".test.txt"
     fname.rename(hidden_file)
-    assert cs.main(hidden_file) == 0
+    # A hidden file named explicitly is checked even without --check-hidden,
+    # but the same file reached by recursing a directory is still skipped.
+    assert cs.main(hidden_file) == 1
     assert cs.main(tmp_path) == 0
     assert cs.main("--check-hidden", hidden_file) == 1
     assert cs.main("--check-hidden", tmp_path) == 1
@@ -786,7 +788,8 @@ def test_check_hidden(
     #
     typo_file = tmp_path / ".abandonned.txt"
     hidden_file.rename(typo_file)
-    assert cs.main(typo_file) == 0
+    assert cs.main(typo_file) == 1
+    assert cs.main("--check-filenames", typo_file) == 2
     assert cs.main(tmp_path) == 0
     assert cs.main("--check-hidden", typo_file) == 1
     assert cs.main("--check-hidden", tmp_path) == 1
@@ -811,6 +814,10 @@ def test_check_hidden(
     subdir = hidden / "subdir"
     subdir.mkdir()
     copyfile(typo_file, subdir / typo_file.name)
+    # An explicitly named hidden directory is still skipped without
+    # --check-hidden, since scanning its contents is a recursive scan.
+    assert cs.main(hidden) == 0
+    assert cs.main("--check-hidden", hidden) == 2
     assert cs.main(tmp_path) == 0
     assert cs.main("--check-hidden", tmp_path) == 3
     assert cs.main("--check-hidden", "--check-filenames", tmp_path) == 8


### PR DESCRIPTION
Fixes #3822.

Passing a hidden file explicitly on the command line (for example `codespell ~/.bashrc`) checked nothing, because the top-level loop skipped anything hidden unless `--check-hidden` was set. You had to already know about `--check-hidden` to check a file you had just named yourself, which is surprising.

Now a hidden file named explicitly is always checked. Directories still honor `--check-hidden`, so recursing into one (hidden or not) does not pull in hidden contents unexpectedly, which is what the issue asked for. An explicitly-named hidden directory is therefore still skipped without the flag.

I updated `test_check_hidden` to the new contract and added cases for an explicit hidden file (with and without `--check-filenames`) and for an explicit hidden directory still being skipped. I also added a note to the `--check-hidden` help text so the behavior is discoverable. Full `test_basic.py` passes, and `ruff check`, `ruff format --check`, and mypy are clean.
