### PR TITLE
13 new dictionary entries based on findings from auditing a repository

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3416,6 +3416,7 @@ aliasas->aliases
 aliase->aliases, alias,
 aliasin->aliasing, alias in,
 aliasses->aliases
+aliassing->aliasing
 alienatin->alienating, alienation,
 alienet->alienate
 alientating->alienating
@@ -17072,6 +17073,7 @@ conviced->convinced, convicted,
 convices->convinces, convicts,
 convicing->convincing, convicting,
 convictin->convicting, convict in, conviction,
+convienance->convenience
 convienant->convenient
 convience->convince, convenience,
 conviencece->convenience
@@ -19220,6 +19222,7 @@ decalre->declare
 decalred->declared
 decalres->declares
 decalring->declaring
+decaorator->decorator
 decapsulting->decapsulating
 decathalon->decathlon
 deccelerate->decelerate
@@ -23243,6 +23246,7 @@ doller->dollar
 dollers->dollars
 dollor->dollar
 dollors->dollars
+dollys->dollies
 domait->domain
 doman->domain
 domans->domains
@@ -23874,6 +23878,7 @@ eazy->easy
 ebale->enable
 ebaled->enabled
 EBCIDC->EBCDIC
+ebeddable->embeddable
 ebedded->embedded
 eccessive->excessive
 ecclectic->eclectic
@@ -30382,6 +30387,7 @@ graphis->graphics
 grapic->graphic
 grapical->graphical
 grapics->graphics
+grasshoper->grasshopper
 grat->great
 gratefull->grateful
 gratest->greatest, grates,
@@ -35089,6 +35095,7 @@ intersecction->intersection
 interseccts->intersects
 intersecrion->intersection
 intersectin->intersecting, intersect in, intersection,
+intersectio->intersection
 intersecton->intersection
 intersectons->intersections
 intersepts->intercepts, intersteps,
@@ -36165,6 +36172,7 @@ keywork->keyword, key work,
 keyworkd->keyword
 keyworkds->keywords
 keyworks->keywords, key works,
+keyworld->keyword
 keywors->keywords
 keywprd->keyword
 keywprds->keywords
@@ -38614,6 +38622,7 @@ mininized->minimized
 mininizes->minimizes
 mininizing->minimizing
 mininum->minimum
+minior->minor
 minisation->minimisation
 miniscule->minuscule
 miniscully->minusculely
@@ -42291,6 +42300,7 @@ opportunites->opportunities
 opportunties->opportunities
 opportunty->opportunity
 opportuny->opportunity
+opposide->opposite
 opposin->opposing
 opposit->opposite
 oppositition->opposition
@@ -42983,6 +42993,7 @@ overiding->overriding
 overlaped->overlapped
 overlaping->overlapping
 overlapp->overlap
+overlappig->overlapping
 overlappin->overlapping
 overlayed->overlaid
 overlflow->overflow
@@ -59271,6 +59282,7 @@ testser->tester
 testsers->testers
 testsing->testing
 testss->tests
+testure->texture
 tesult->result
 tesulted->resulted
 tesulting->resulting
@@ -61879,6 +61891,7 @@ unios->unions
 uniqe->unique
 uniqu->unique
 uniquenes->uniqueness
+uniques->unique
 uniquness->uniqueness
 unirom->uniform
 unistall->uninstall


### PR DESCRIPTION
New dictionary entries for misspellings found while auditing a repository's documentation. These are real typos found inside the `pyvista` project that were missed by `codespell`.

- `aliassing` -> aliasing
- `convienance` -> convenience
- `decaorator` -> decorator
- `dollys` -> dollies
- `ebeddable` -> embeddable
- `grasshoper` -> grasshopper
- `intersectio` -> intersection
- `keyworld` -> keyword
- `minior` -> minor
- `opposide` -> opposite
- `overlappig` -> overlapping
- `testure` -> texture
- `uniques` -> unique