### PR TITLE
relus->rules

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -50081,6 +50081,7 @@ relpaces->replaces
 relpacing->replacing
 relpy->reply
 reltive->relative
+relus->rules, relu,
 relvance->relevance
 relvancy->relevancy
 relvant->relevant


### PR DESCRIPTION
~relu -> rule is invalid because [ReLU](https://en.wikipedia.org/wiki/Rectified_linear_unit) is a thing~